### PR TITLE
design: 132 design 매장 ai 리포트 페이지 구현 storeai report

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.2",
+        "chart.js": "^4.5.1",
         "lucide-vue-next": "^1.0.0",
         "pinia": "^3.0.4",
         "tailwindcss": "^4.2.2",
         "vue": "^3.5.31",
+        "vue-chartjs": "^5.3.3",
         "vue-router": "^5.0.4"
       },
       "devDependencies": {
@@ -537,6 +539,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.3",
@@ -1562,6 +1570,19 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
     },
     "node_modules/chokidar": {
       "version": "5.0.0",
@@ -2953,6 +2974,16 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-chartjs": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/vue-chartjs/-/vue-chartjs-5.3.3.tgz",
+      "integrity": "sha512-jqxtL8KZ6YJ5NTv6XzrzLS7osyegOi28UGNZW0h9OkDL7Sh1396ht4Dorh04aKrl2LiSalQ84WtqiG0RIJb0tA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "vue": "^3.0.0-0 || ^2.7.0"
       }
     },
     "node_modules/vue-router": {

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
+    "chart.js": "^4.5.1",
     "lucide-vue-next": "^1.0.0",
     "pinia": "^3.0.4",
     "tailwindcss": "^4.2.2",
     "vue": "^3.5.31",
+    "vue-chartjs": "^5.3.3",
     "vue-router": "^5.0.4"
   },
   "devDependencies": {

--- a/src/components/common/charts/BarChart.vue
+++ b/src/components/common/charts/BarChart.vue
@@ -1,0 +1,39 @@
+<script setup>
+import { Bar } from 'vue-chartjs'
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  BarElement,
+  Filler,
+  Tooltip,
+  Legend,
+  Title,
+} from 'chart.js'
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  BarElement,
+  Filler,
+  Tooltip,
+  Legend,
+  Title,
+)
+
+defineProps({
+  data: { type: Object, required: true },
+  options: { type: Object, default: () => ({}) },
+  height: { type: Number, default: 240 },
+})
+</script>
+
+<template>
+  <div :style="{ height: height + 'px' }" class="relative w-full">
+    <Bar :data="data" :options="options" />
+  </div>
+</template>

--- a/src/components/common/charts/LineChart.vue
+++ b/src/components/common/charts/LineChart.vue
@@ -1,0 +1,39 @@
+<script setup>
+import { Line } from 'vue-chartjs'
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  BarElement,
+  Filler,
+  Tooltip,
+  Legend,
+  Title,
+} from 'chart.js'
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  BarElement,
+  Filler,
+  Tooltip,
+  Legend,
+  Title,
+)
+
+defineProps({
+  data: { type: Object, required: true },
+  options: { type: Object, default: () => ({}) },
+  height: { type: Number, default: 220 },
+})
+</script>
+
+<template>
+  <div :style="{ height: height + 'px' }" class="relative w-full">
+    <Line :data="data" :options="options" />
+  </div>
+</template>

--- a/src/config/roleMenus.js
+++ b/src/config/roleMenus.js
@@ -12,6 +12,7 @@ export const roleMenus = {
     { label: '주문 관리', path: '/store/orders', icon: 'file' },
     { label: '재고 관리', path: '/store/inventory', icon: 'warehouse' },
     { label: '입고 관리', path: '/store/inbound', icon: 'check' },
+    { label: 'AI 리포트', path: '/store/ai-report', icon: 'chart' },
   ],
   warehouse: [
     { label: '창고 재고 관리', path: '/warehouse/inventory', icon: 'warehouse' },

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -10,6 +10,7 @@ import StorePosView from '@/views/store/StorePosView.vue'
 import StoreOrdersView from '@/views/store/StoreOrdersView.vue'
 import StoreInventoryView from '@/views/store/StoreInventoryView.vue'
 import StoreInboundView from '@/views/store/StoreInboundView.vue'
+import StoreAiReportView from '@/views/store/StoreAiReportView.vue'
 
 import WarehouseInventoryView from '@/views/warehouse/WarehouseInventoryView.vue'
 import WarehouseInboundView from '@/views/warehouse/WarehouseInboundView.vue'
@@ -36,39 +37,156 @@ const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes: [
     { path: '/login', name: 'login', component: LoginView, meta: { requiresAuth: false } },
-    { path: '/dev-login', name: 'dev-login', component: DevLoginView, meta: { requiresAuth: false } },
+    {
+      path: '/dev-login',
+      name: 'dev-login',
+      component: DevLoginView,
+      meta: { requiresAuth: false },
+    },
     { path: '/signup', name: 'signup', component: SignupView, meta: { requiresAuth: false } },
-    { path: '/hq/dashboard', name: 'hq-dashboard', component: OperationStatusView, meta: { requiresAuth: true, role: 'hq' } },
-    { path: '/hq/dashboard/inventory-risk', name: 'hq-dashboard-inventory-risk', component: InventoryRiskView, meta: { requiresAuth: true, role: 'hq' } },
-    { path: '/hq/dashboard/flow', name: 'hq-dashboard-flow', component: InboundOutboundFlowView, meta: { requiresAuth: true, role: 'hq' } },
-    { path: '/hq/dashboard/flow/all', name: 'hq-dashboard-flow-all', component: AllFlowTransactionsView, meta: { requiresAuth: true, role: 'hq' } },
-    { path: '/hq/dashboard/alerts', name: 'hq-dashboard-alerts', component: AlertCenterView, meta: { requiresAuth: true, role: 'hq' } },
-    { path: '/hq/dashboard/transactions', name: 'hq-dashboard-transactions', component: AllTransactionsView, meta: { requiresAuth: true, role: 'hq' } },
+    {
+      path: '/hq/dashboard',
+      name: 'hq-dashboard',
+      component: OperationStatusView,
+      meta: { requiresAuth: true, role: 'hq' },
+    },
+    {
+      path: '/hq/dashboard/inventory-risk',
+      name: 'hq-dashboard-inventory-risk',
+      component: InventoryRiskView,
+      meta: { requiresAuth: true, role: 'hq' },
+    },
+    {
+      path: '/hq/dashboard/flow',
+      name: 'hq-dashboard-flow',
+      component: InboundOutboundFlowView,
+      meta: { requiresAuth: true, role: 'hq' },
+    },
+    {
+      path: '/hq/dashboard/flow/all',
+      name: 'hq-dashboard-flow-all',
+      component: AllFlowTransactionsView,
+      meta: { requiresAuth: true, role: 'hq' },
+    },
+    {
+      path: '/hq/dashboard/alerts',
+      name: 'hq-dashboard-alerts',
+      component: AlertCenterView,
+      meta: { requiresAuth: true, role: 'hq' },
+    },
+    {
+      path: '/hq/dashboard/transactions',
+      name: 'hq-dashboard-transactions',
+      component: AllTransactionsView,
+      meta: { requiresAuth: true, role: 'hq' },
+    },
 
-    
-    { path: '/hq/account/accountlist', name: 'hq-account-list', component: AccountListView, meta: { requiresAuth: true, role: 'hq' } },
-    { path: '/hq/account/approval', name: 'hq-account-approval', component: AccountApprovalView, meta: { requiresAuth: true, role: 'hq' } },
+    {
+      path: '/hq/account/accountlist',
+      name: 'hq-account-list',
+      component: AccountListView,
+      meta: { requiresAuth: true, role: 'hq' },
+    },
+    {
+      path: '/hq/account/approval',
+      name: 'hq-account-approval',
+      component: AccountApprovalView,
+      meta: { requiresAuth: true, role: 'hq' },
+    },
 
+    {
+      path: '/hq/inventory',
+      name: 'hq-inventory',
+      component: HqInventoryStatusView,
+      meta: { requiresAuth: true, role: 'hq' },
+    },
+    {
+      path: '/hq/orders',
+      name: 'hq-orders',
+      component: HqOrderManagementView,
+      meta: { requiresAuth: true, role: 'hq' },
+    },
+    {
+      path: '/hq/products',
+      name: 'hq-products',
+      component: HqProductManagementView,
+      meta: { requiresAuth: true, role: 'hq' },
+    },
+    {
+      path: '/hq/infrastructure',
+      name: 'hq-infrastructure',
+      component: HqInfrastructureManagementView,
+      meta: { requiresAuth: true, role: 'hq' },
+    },
+    {
+      path: '/hq/analytics',
+      name: 'hq-analytics',
+      component: HqSettlementStatisticsView,
+      meta: { requiresAuth: true, role: 'hq' },
+    },
+    {
+      path: '/hq/purchase-orders',
+      name: 'hq-purchase-orders',
+      component: HqPurchaseOrderView,
+      meta: { requiresAuth: true, role: 'hq' },
+    },
 
-    { path: '/hq/inventory', name: 'hq-inventory', component: HqInventoryStatusView, meta: { requiresAuth: true, role: 'hq' } },
-    { path: '/hq/orders', name: 'hq-orders', component: HqOrderManagementView, meta: { requiresAuth: true, role: 'hq' } },
-    { path: '/hq/products', name: 'hq-products', component: HqProductManagementView, meta: { requiresAuth: true, role: 'hq' } },
-    { path: '/hq/infrastructure', name: 'hq-infrastructure', component: HqInfrastructureManagementView, meta: { requiresAuth: true, role: 'hq' } },
-    { path: '/hq/analytics', name: 'hq-analytics', component: HqSettlementStatisticsView, meta: { requiresAuth: true, role: 'hq' } },
-    { path: '/hq/purchase-orders', name: 'hq-purchase-orders', component: HqPurchaseOrderView, meta: { requiresAuth: true, role: 'hq' } },
+    {
+      path: '/hq/vendors',
+      name: 'hq-vendors',
+      component: HqVendorManagementView,
+      meta: { requiresAuth: true, role: 'hq' },
+    },
 
-    
-    { path: '/hq/vendors', name: 'hq-vendors', component: HqVendorManagementView, meta: { requiresAuth: true, role: 'hq' } },
-    
+    {
+      path: '/store/pos',
+      name: 'store-pos',
+      component: StorePosView,
+      meta: { requiresAuth: true, role: 'store' },
+    },
+    {
+      path: '/store/orders',
+      name: 'store-orders',
+      component: StoreOrdersView,
+      meta: { requiresAuth: true, role: 'store' },
+    },
+    {
+      path: '/store/inventory',
+      name: 'store-inventory',
+      component: StoreInventoryView,
+      meta: { requiresAuth: true, role: 'store' },
+    },
+    {
+      path: '/store/inbound',
+      name: 'store-inbound',
+      component: StoreInboundView,
+      meta: { requiresAuth: true, role: 'store' },
+    },
+    {
+      path: '/store/ai-report',
+      name: 'store-ai-report',
+      component: StoreAiReportView,
+      meta: { requiresAuth: true, role: 'store' },
+    },
 
-    { path: '/store/pos', name: 'store-pos', component: StorePosView, meta: { requiresAuth: true, role: 'store' } },
-    { path: '/store/orders', name: 'store-orders', component: StoreOrdersView, meta: { requiresAuth: true, role: 'store' } },
-    { path: '/store/inventory', name: 'store-inventory', component: StoreInventoryView, meta: { requiresAuth: true, role: 'store' } },
-    { path: '/store/inbound', name: 'store-inbound', component: StoreInboundView, meta: { requiresAuth: true, role: 'store' } },
-
-    { path: '/warehouse/inventory', name: 'wh-inventory', component: WarehouseInventoryView, meta: { requiresAuth: true, role: 'warehouse' } },
-    { path: '/warehouse/inbound', name: 'wh-inbound', component: WarehouseInboundView, meta: { requiresAuth: true, role: 'warehouse' } },
-    { path: '/warehouse/outbound', name: 'wh-outbound', component: WarehouseOutboundView, meta: { requiresAuth: true, role: 'warehouse' } },
+    {
+      path: '/warehouse/inventory',
+      name: 'wh-inventory',
+      component: WarehouseInventoryView,
+      meta: { requiresAuth: true, role: 'warehouse' },
+    },
+    {
+      path: '/warehouse/inbound',
+      name: 'wh-inbound',
+      component: WarehouseInboundView,
+      meta: { requiresAuth: true, role: 'warehouse' },
+    },
+    {
+      path: '/warehouse/outbound',
+      name: 'wh-outbound',
+      component: WarehouseOutboundView,
+      meta: { requiresAuth: true, role: 'warehouse' },
+    },
 
     { path: '/', redirect: '/login' },
     { path: '/:pathMatch(.*)*', redirect: '/login' },

--- a/src/stores/storeAiReport.js
+++ b/src/stores/storeAiReport.js
@@ -1,0 +1,238 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+
+const PRODUCT_POOL = [
+  { code: 'PRD-001', name: '고속 충전기 (C타입) 25W' },
+  { code: 'PRD-002', name: '대용량 보조배터리 20000mAh' },
+  { code: 'PRD-003', name: '무소음 무선 마우스' },
+  { code: 'PRD-004', name: 'A4 복사용지 80g (500매)' },
+  { code: 'PRD-005', name: '더블클립 세트 (19mm)' },
+  { code: 'PRD-006', name: '기계식 키보드 (갈축)' },
+  { code: 'PRD-007', name: 'KF94 마스크 (50매입)' },
+  { code: 'PRD-008', name: '휴대용 가글 (중) 250ml' },
+  { code: 'PRD-009', name: '유리제 머그컵 350ml' },
+  { code: 'PRD-010', name: '탁상용 미니 가습기' },
+  { code: 'PRD-011', name: '투명 박스 테이프 (48mm)' },
+  { code: 'PRD-012', name: '절전형 5구 멀티탭 (3m)' },
+  { code: 'PRD-013', name: '종이컵 6.5온스 (1000개입)' },
+  { code: 'PRD-014', name: '스테인리스 텀블러 500ml' },
+  { code: 'PRD-015', name: '접이식 우산 (자동)' },
+]
+
+const DISPLAY_REASONS = [
+  '최근 7일 판매 급증 + 연관 구매율 상위',
+  '계절성 수요 전주 대비 +28% 상승',
+  '입구 동선에서 시야 확보 시 충동구매 유도 예상',
+  '파트너 상품과 함께 배치 시 번들 판매 기여',
+  '신제품 프로모션 주간, 노출 강화 필요',
+  '매출 기여도 TOP 5, 재고도 충분',
+]
+
+const RESTOCK_REASONS = [
+  '최근 3일 판매 급증 + 안전재고 미달',
+  '주말 수요 반영, 선제 발주 필요',
+  '프로모션 진행 중 품절 리스크 높음',
+  '장마철 대비 선주문 권장',
+  '일평균 판매 대비 재고 일수 2일 미만',
+  '공급처 리드타임 감안 시 지금 발주 적기',
+]
+
+function rand(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min
+}
+
+function pickReason(pool) {
+  return pool[rand(0, pool.length - 1)]
+}
+
+function shuffle(arr) {
+  return [...arr].sort(() => Math.random() - 0.5)
+}
+
+function generateDisplayRecommendations(count = 10) {
+  const pool = shuffle(PRODUCT_POOL).slice(0, count)
+  return pool.map((p, idx) => ({
+    id: `DR-${p.code}-${idx}`,
+    productName: p.name,
+    productCode: p.code,
+    score: rand(75, 98),
+    weeklySales: rand(40, 320),
+    trendPct: rand(-12, 45),
+    expectedUpliftPct: rand(8, 32),
+    reason: pickReason(DISPLAY_REASONS),
+  }))
+}
+
+function generateRestockRecommendations(count = 10) {
+  const pool = shuffle(PRODUCT_POOL).slice(0, count)
+  const urgencies = ['critical', 'critical', 'warn', 'warn', 'warn', 'ok', 'ok', 'ok', 'ok', 'ok']
+  return pool.map((p, idx) => {
+    const avg = rand(8, 45)
+    const safety = rand(30, 80)
+    const current = Math.max(0, safety + rand(-60, 30))
+    return {
+      id: `RR-${p.code}-${idx}`,
+      productName: p.name,
+      productCode: p.code,
+      currentQty: current,
+      safetyStock: safety,
+      avgDailySales: avg,
+      recommendedQty: Math.max(20, safety * 2 - current + rand(10, 40)),
+      urgency: urgencies[idx] ?? 'ok',
+      reason: pickReason(RESTOCK_REASONS),
+    }
+  })
+}
+
+function generateAssociationRules(count = 12) {
+  const bases = shuffle(PRODUCT_POOL).slice(0, count)
+  return bases.map((base, idx) => {
+    const partners = shuffle(PRODUCT_POOL.filter((p) => p.code !== base.code))
+      .slice(0, 3)
+      .map((p) => ({ name: p.name, coBuyRate: rand(28, 72) }))
+    return {
+      id: `AR-${base.code}-${idx}`,
+      baseProduct: base.name,
+      partners,
+      suggestedBundle: `${base.name} + ${partners[0].name}`,
+    }
+  })
+}
+
+function generateSummary() {
+  const top = PRODUCT_POOL[rand(0, PRODUCT_POOL.length - 1)]
+  return {
+    weeklyTopProduct: top.name,
+    displayChangeCount: rand(6, 12),
+    restockCount: rand(3, 8),
+    associationScore: rand(72, 94),
+  }
+}
+
+function pad(n) {
+  return String(n).padStart(2, '0')
+}
+
+function formatIso(date) {
+  return (
+    date.getFullYear() +
+    '-' +
+    pad(date.getMonth() + 1) +
+    '-' +
+    pad(date.getDate()) +
+    'T' +
+    pad(date.getHours()) +
+    ':' +
+    pad(date.getMinutes()) +
+    ':00'
+  )
+}
+
+function buildSnapshot({ id, generatedAt, generationType }) {
+  return {
+    id,
+    generatedAt,
+    generationType,
+    summary: generateSummary(),
+    displayRecommendations: generateDisplayRecommendations(10),
+    restockRecommendations: generateRestockRecommendations(10),
+    associationRules: generateAssociationRules(12),
+  }
+}
+
+function seedHistory() {
+  const now = new Date(2026, 3, 22, 9, 0)
+  const list = []
+  let cursor = new Date(now)
+  for (let i = 0; i < 12; i++) {
+    const type = i % 5 === 4 ? 'manual' : i % 4 === 3 ? 'monthly' : 'weekly'
+    list.push(
+      buildSnapshot({
+        id: `RPT-${formatIso(cursor).replace(/[-:T]/g, '')}`,
+        generatedAt: formatIso(cursor),
+        generationType: type,
+      }),
+    )
+    cursor = new Date(cursor.getTime() - 7 * 24 * 60 * 60 * 1000 + rand(-86400000, 86400000))
+  }
+  return list
+}
+
+export const useStoreAiReportStore = defineStore('storeAiReport', () => {
+  const reportHistory = ref(seedHistory())
+  const currentReportId = ref(reportHistory.value[0].id)
+  const rangeTab = ref('weekly')
+  const isGenerating = ref(false)
+
+  const currentReport = computed(
+    () => reportHistory.value.find((r) => r.id === currentReportId.value) ?? reportHistory.value[0],
+  )
+
+  const reportMeta = computed(() => {
+    const cur = currentReport.value
+    const generated = new Date(cur.generatedAt)
+    const nextDays = cur.generationType === 'monthly' ? 30 : 7
+    const next = new Date(generated.getTime() + nextDays * 24 * 60 * 60 * 1000)
+    return {
+      generatedAt: cur.generatedAt,
+      generationType: cur.generationType,
+      nextScheduledAt: formatIso(next),
+    }
+  })
+
+  const sortedRestock = computed(() => {
+    const order = { critical: 0, warn: 1, ok: 2 }
+    return [...currentReport.value.restockRecommendations].sort(
+      (a, b) => order[a.urgency] - order[b.urgency],
+    )
+  })
+
+  function salesTrend(productId) {
+    const seedChar = productId ? productId.charCodeAt(productId.length - 1) : 7
+    return Array.from({ length: 7 }, (_, i) => {
+      return Math.max(5, Math.round(20 + Math.sin(i + seedChar) * 8 + rand(-6, 12)))
+    })
+  }
+
+  function loadSnapshot(id) {
+    if (reportHistory.value.some((r) => r.id === id)) {
+      currentReportId.value = id
+    }
+  }
+
+  function setRange(tab) {
+    if (tab === 'weekly' || tab === 'monthly') {
+      rangeTab.value = tab
+    }
+  }
+
+  function regenerate() {
+    if (isGenerating.value) return
+    isGenerating.value = true
+    setTimeout(() => {
+      const now = new Date()
+      const snapshot = buildSnapshot({
+        id: `RPT-${formatIso(now).replace(/[-:T]/g, '')}-M`,
+        generatedAt: formatIso(now),
+        generationType: 'manual',
+      })
+      reportHistory.value = [snapshot, ...reportHistory.value].slice(0, 20)
+      currentReportId.value = snapshot.id
+      isGenerating.value = false
+    }, 1200)
+  }
+
+  return {
+    reportHistory,
+    currentReportId,
+    currentReport,
+    reportMeta,
+    rangeTab,
+    isGenerating,
+    sortedRestock,
+    salesTrend,
+    loadSnapshot,
+    setRange,
+    regenerate,
+  }
+})

--- a/src/views/store/StoreAiReportView.vue
+++ b/src/views/store/StoreAiReportView.vue
@@ -1,0 +1,722 @@
+<script setup>
+import { computed, h, onMounted, onUnmounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import AppLayout from '@/components/common/AppLayout.vue'
+import LineChart from '@/components/common/charts/LineChart.vue'
+import BarChart from '@/components/common/charts/BarChart.vue'
+import { roleMenus } from '@/config/roleMenus.js'
+import { useAuthStore } from '@/stores/auth.js'
+import { useStoreAiReportStore } from '@/stores/storeAiReport.js'
+
+const router = useRouter()
+const auth = useAuthStore()
+const reportStore = useStoreAiReportStore()
+
+const storeMenus = roleMenus.store
+const sideMenus = roleMenus.store
+const activeTopMenu = computed(() => 'AI 리포트')
+const activeSideMenu = ref('AI 리포트')
+
+const showHistoryDropdown = ref(false)
+const historyDropdownRef = ref(null)
+const expandedRestockId = ref(null)
+
+function handleLogout() {
+  auth.logout()
+  router.push('/login')
+}
+
+function toggleHistoryDropdown() {
+  showHistoryDropdown.value = !showHistoryDropdown.value
+}
+
+function handleSelectSnapshot(id) {
+  reportStore.loadSnapshot(id)
+  showHistoryDropdown.value = false
+}
+
+function handleRegenerate() {
+  reportStore.regenerate()
+}
+
+function handleRangeChange(tab) {
+  reportStore.setRange(tab)
+}
+
+function handleToggleRestock(id) {
+  expandedRestockId.value = expandedRestockId.value === id ? null : id
+}
+
+function handleNavigateOrder(productCode) {
+  router.push({ name: 'store-orders', query: { productId: productCode } })
+}
+
+function handleBundleSuggest(bundle) {
+  alert(`묶음 프로모션 제안: ${bundle}`)
+}
+
+function handleOutsideClick(e) {
+  if (!showHistoryDropdown.value) return
+  const el = historyDropdownRef.value
+  if (el && !el.contains(e.target)) {
+    showHistoryDropdown.value = false
+  }
+}
+
+function handleKeydown(e) {
+  if (e.key !== 'Escape') return
+  if (showHistoryDropdown.value) {
+    showHistoryDropdown.value = false
+    return
+  }
+  if (expandedRestockId.value) {
+    expandedRestockId.value = null
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('mousedown', handleOutsideClick)
+  window.addEventListener('keydown', handleKeydown)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('mousedown', handleOutsideClick)
+  window.removeEventListener('keydown', handleKeydown)
+})
+
+function formatDateTime(iso) {
+  if (!iso) return '-'
+  const d = new Date(iso)
+  const pad = (n) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+function formatRelative(iso) {
+  if (!iso) return '-'
+  const now = new Date()
+  const target = new Date(iso)
+  const diffMs = now - target
+  const diffMin = Math.floor(diffMs / 60000)
+  const diffHour = Math.floor(diffMin / 60)
+  const diffDay = Math.floor(diffHour / 24)
+  if (diffMin < 1) return '방금 전'
+  if (diffMin < 60) return `${diffMin}분 전`
+  if (diffHour < 24) return `${diffHour}시간 전`
+  if (diffDay < 7) return `${diffDay}일 전`
+  return formatDateTime(iso)
+}
+
+const generationTypeLabel = {
+  weekly: '자동 주간',
+  monthly: '자동 월간',
+  manual: '수동',
+}
+
+function generationBadgeClass(type) {
+  const map = {
+    weekly: 'bg-emerald-50 text-emerald-700',
+    monthly: 'bg-blue-50 text-blue-700',
+    manual: 'bg-amber-50 text-amber-700',
+  }
+  return map[type] ?? 'bg-gray-100 text-gray-600'
+}
+
+function urgencyBadgeClass(u) {
+  const map = {
+    critical: 'bg-red-50 text-red-700',
+    warn: 'bg-amber-50 text-amber-700',
+    ok: 'bg-emerald-50 text-emerald-700',
+  }
+  return map[u] ?? 'bg-gray-100 text-gray-600'
+}
+
+function urgencyLabel(u) {
+  const map = { critical: '긴급', warn: '주의', ok: '정상' }
+  return map[u] ?? u
+}
+
+const rangeMultiplier = computed(() => (reportStore.rangeTab === 'monthly' ? 4.3 : 1))
+
+const summaryCards = computed(() => {
+  const s = reportStore.currentReport.summary
+  const rangeLabel = reportStore.rangeTab === 'monthly' ? '월간' : '주간'
+  return [
+    { label: `${rangeLabel} 매출 TOP 상품`, value: s.weeklyTopProduct, unit: '' },
+    {
+      label: '전면 배치 추천',
+      value: Math.round(s.displayChangeCount * rangeMultiplier.value),
+      unit: '건',
+    },
+    {
+      label: '발주 권장',
+      value: Math.round(s.restockCount * rangeMultiplier.value),
+      unit: '건',
+    },
+    { label: '연관 강도 점수', value: s.associationScore, unit: '점' },
+  ]
+})
+
+const displayChartData = computed(() => {
+  const list = [...reportStore.currentReport.displayRecommendations]
+    .sort((a, b) => b.expectedUpliftPct - a.expectedUpliftPct)
+    .slice(0, 10)
+  return {
+    labels: list.map((r) => r.productName),
+    datasets: [
+      {
+        label: '전면 배치 시 예상 매출 상승률 (%)',
+        data: list.map((r) => r.expectedUpliftPct),
+        backgroundColor: '#004D3C',
+        borderRadius: 2,
+        maxBarThickness: 18,
+      },
+    ],
+  }
+})
+
+const displayChartOptions = {
+  indexAxis: 'y',
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: { display: false },
+    tooltip: {
+      callbacks: {
+        label: (ctx) => `+${ctx.parsed.x}% 예상 상승`,
+      },
+    },
+  },
+  scales: {
+    x: {
+      grid: { color: '#f3f4f6' },
+      ticks: { callback: (v) => `${v}%`, font: { size: 10 } },
+    },
+    y: { grid: { display: false }, ticks: { font: { size: 11 } } },
+  },
+}
+
+const displayKpi = computed(() => {
+  const list = reportStore.currentReport.displayRecommendations
+  if (list.length === 0) {
+    return { count: 0, avgUplift: 0, topName: '-' }
+  }
+  const avg = list.reduce((sum, r) => sum + r.expectedUpliftPct, 0) / list.length
+  const top = [...list].sort((a, b) => b.weeklySales - a.weeklySales)[0]
+  return {
+    count: list.length,
+    avgUplift: Math.round(avg),
+    topName: top.productName,
+  }
+})
+
+const sortedDisplayCards = computed(() =>
+  [...reportStore.currentReport.displayRecommendations].sort(
+    (a, b) => b.expectedUpliftPct - a.expectedUpliftPct,
+  ),
+)
+
+function restockTrendData(productCode) {
+  const values = reportStore.salesTrend(productCode)
+  const labels = Array.from({ length: 7 }, (_, i) => `${i + 1}일 전`).reverse()
+  return {
+    labels,
+    datasets: [
+      {
+        label: '일별 판매량',
+        data: values,
+        borderColor: '#004D3C',
+        backgroundColor: 'rgba(0, 77, 60, 0.12)',
+        fill: true,
+        tension: 0.35,
+        pointRadius: 3,
+        pointBackgroundColor: '#004D3C',
+      },
+    ],
+  }
+}
+
+const restockTrendOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: { legend: { display: false } },
+  scales: {
+    x: { grid: { display: false }, ticks: { font: { size: 10 } } },
+    y: {
+      grid: { color: '#f3f4f6' },
+      ticks: { font: { size: 10 } },
+      beginAtZero: true,
+    },
+  },
+}
+
+const IconBase = (paths) => ({
+  props: {
+    size: { type: Number, default: 16 },
+    strokeWidth: { type: Number, default: 2 },
+  },
+  render() {
+    return h(
+      'svg',
+      {
+        width: this.size,
+        height: this.size,
+        viewBox: '0 0 24 24',
+        fill: 'none',
+        stroke: 'currentColor',
+        'stroke-width': this.strokeWidth,
+        'stroke-linecap': 'round',
+        'stroke-linejoin': 'round',
+        'aria-hidden': 'true',
+      },
+      paths.map((p) => h(p.tag, p.attrs)),
+    )
+  },
+})
+
+const SparklesIcon = IconBase([
+  {
+    tag: 'path',
+    attrs: {
+      d: 'M12 3v3M12 18v3M3 12h3M18 12h3M5.6 5.6l2.1 2.1M16.3 16.3l2.1 2.1M5.6 18.4l2.1-2.1M16.3 7.7l2.1-2.1',
+    },
+  },
+])
+
+const ChevronDownIcon = IconBase([{ tag: 'path', attrs: { d: 'm6 9 6 6 6-6' } }])
+const CheckIcon = IconBase([{ tag: 'path', attrs: { d: 'M20 6 9 17l-5-5' } }])
+const RefreshIcon = IconBase([
+  { tag: 'path', attrs: { d: 'M3 12a9 9 0 0 1 15-6.7L21 8' } },
+  { tag: 'path', attrs: { d: 'M21 3v5h-5' } },
+  { tag: 'path', attrs: { d: 'M21 12a9 9 0 0 1-15 6.7L3 16' } },
+  { tag: 'path', attrs: { d: 'M3 21v-5h5' } },
+])
+const TrendUpIcon = IconBase([
+  { tag: 'path', attrs: { d: 'm3 17 6-6 4 4 8-8' } },
+  { tag: 'path', attrs: { d: 'M14 7h7v7' } },
+])
+const TrendDownIcon = IconBase([
+  { tag: 'path', attrs: { d: 'm3 7 6 6 4-4 8 8' } },
+  { tag: 'path', attrs: { d: 'M14 17h7v-7' } },
+])
+const PackageIcon = IconBase([
+  { tag: 'path', attrs: { d: 'm3 7 9-4 9 4v10l-9 4-9-4Z' } },
+  { tag: 'path', attrs: { d: 'M3 7l9 4 9-4' } },
+  { tag: 'path', attrs: { d: 'M12 11v10' } },
+])
+const CartIcon = IconBase([
+  { tag: 'circle', attrs: { cx: '9', cy: '20', r: '1.5' } },
+  { tag: 'circle', attrs: { cx: '17', cy: '20', r: '1.5' } },
+  { tag: 'path', attrs: { d: 'M3 4h2l2.7 11.3a2 2 0 0 0 2 1.7h8.6a2 2 0 0 0 2-1.6L22 8H6' } },
+])
+const LinkIcon = IconBase([
+  { tag: 'path', attrs: { d: 'M10 13a5 5 0 0 0 7 0l3-3a5 5 0 0 0-7-7l-1 1' } },
+  { tag: 'path', attrs: { d: 'M14 11a5 5 0 0 0-7 0l-3 3a5 5 0 0 0 7 7l1-1' } },
+])
+const ChevronIcon = IconBase([{ tag: 'path', attrs: { d: 'm9 18 6-6-6-6' } }])
+</script>
+
+<template>
+  <AppLayout
+    :active-top-menu="activeTopMenu"
+    :top-menus="storeMenus"
+    :side-menus="sideMenus"
+    v-model:active-side-menu="activeSideMenu"
+    @logout="handleLogout"
+  >
+    <div class="flex flex-col gap-4">
+      <!-- 리포트 헤더 -->
+      <section class="border border-gray-300 bg-white p-4 shadow-sm">
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <!-- 왼쪽: 타이틀 + 메타 -->
+          <div class="flex items-start gap-3">
+            <div
+              class="flex h-10 w-10 shrink-0 items-center justify-center bg-[#E6F2F0] text-[#004D3C]"
+            >
+              <SparklesIcon :size="20" />
+            </div>
+            <div>
+              <h1 class="text-lg font-black text-gray-900">스마트 워크 AI 리포트</h1>
+              <div class="mt-1 flex flex-wrap items-center gap-2 text-[11px] text-gray-500">
+                <span
+                  class="inline-flex items-center px-2 py-0.5 text-[10px] font-black"
+                  :class="generationBadgeClass(reportStore.reportMeta.generationType)"
+                >
+                  {{ generationTypeLabel[reportStore.reportMeta.generationType] }}
+                </span>
+                <span>
+                  최근 생성
+                  <strong class="font-bold text-gray-700">
+                    {{ formatDateTime(reportStore.reportMeta.generatedAt) }}
+                  </strong>
+                  ({{ formatRelative(reportStore.reportMeta.generatedAt) }})
+                </span>
+                <span class="text-gray-300">|</span>
+                <span>
+                  다음 자동 생성
+                  <strong class="font-bold text-gray-700">
+                    {{ formatDateTime(reportStore.reportMeta.nextScheduledAt) }}
+                  </strong>
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <!-- 오른쪽: 탭 + 과거 리포트 + 새로 생성 -->
+          <div class="flex flex-wrap items-center gap-2">
+            <!-- 주간/월간 토글 -->
+            <div class="inline-flex border border-gray-300 bg-white">
+              <button
+                type="button"
+                class="px-3 py-1.5 text-xs font-black transition-colors"
+                :class="
+                  reportStore.rangeTab === 'weekly'
+                    ? 'bg-[#004D3C] text-white'
+                    : 'bg-white text-gray-600 hover:bg-gray-50'
+                "
+                @click="handleRangeChange('weekly')"
+              >
+                주간
+              </button>
+              <button
+                type="button"
+                class="border-l border-gray-300 px-3 py-1.5 text-xs font-black transition-colors"
+                :class="
+                  reportStore.rangeTab === 'monthly'
+                    ? 'bg-[#004D3C] text-white'
+                    : 'bg-white text-gray-600 hover:bg-gray-50'
+                "
+                @click="handleRangeChange('monthly')"
+              >
+                월간
+              </button>
+            </div>
+
+            <!-- 과거 리포트 드롭다운 -->
+            <div ref="historyDropdownRef" class="relative">
+              <button
+                type="button"
+                class="inline-flex items-center gap-1.5 border border-gray-300 bg-white px-3 py-1.5 text-xs font-black text-gray-700 hover:bg-gray-50"
+                @click="toggleHistoryDropdown"
+              >
+                과거 리포트
+                <ChevronDownIcon :size="14" />
+              </button>
+              <div
+                v-if="showHistoryDropdown"
+                class="absolute right-0 top-full z-30 mt-1 max-h-80 w-72 overflow-auto border border-gray-200 bg-white shadow-lg"
+              >
+                <ul class="divide-y divide-gray-100">
+                  <li
+                    v-for="snap in reportStore.reportHistory"
+                    :key="snap.id"
+                    class="flex cursor-pointer items-center justify-between gap-2 px-3 py-2 text-xs transition-colors hover:bg-[#E6F2F0]"
+                    :class="{ 'bg-[#E6F2F0]': snap.id === reportStore.currentReportId }"
+                    @click="handleSelectSnapshot(snap.id)"
+                  >
+                    <div class="min-w-0">
+                      <p class="truncate font-black text-gray-800">
+                        {{ formatDateTime(snap.generatedAt) }}
+                      </p>
+                      <span
+                        class="mt-0.5 inline-flex px-1.5 py-0.5 text-[9px] font-black"
+                        :class="generationBadgeClass(snap.generationType)"
+                      >
+                        {{ generationTypeLabel[snap.generationType] }}
+                      </span>
+                    </div>
+                    <CheckIcon
+                      v-if="snap.id === reportStore.currentReportId"
+                      :size="14"
+                      class="shrink-0 text-[#004D3C]"
+                    />
+                  </li>
+                </ul>
+              </div>
+            </div>
+
+            <!-- 새로 생성 -->
+            <button
+              type="button"
+              class="inline-flex items-center gap-1.5 border border-[#004D3C] bg-[#004D3C] px-3 py-1.5 text-xs font-black text-white transition-colors hover:bg-[#1f4b3a] disabled:opacity-60"
+              :disabled="reportStore.isGenerating"
+              @click="handleRegenerate"
+            >
+              <RefreshIcon :size="14" :class="reportStore.isGenerating ? 'animate-spin' : ''" />
+              {{ reportStore.isGenerating ? '생성 중...' : '리포트 새로 생성' }}
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <!-- 요약 바 -->
+      <section class="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <div
+          v-for="(card, idx) in summaryCards"
+          :key="idx"
+          class="flex flex-col justify-between border border-gray-300 bg-white p-4 shadow-sm"
+        >
+          <p class="text-[10px] font-black uppercase tracking-wider text-gray-400">
+            {{ card.label }}
+          </p>
+          <p class="mt-2 truncate text-xl font-black text-[#004D3C]">
+            {{ card.value }}<span v-if="card.unit" class="ml-1 text-sm">{{ card.unit }}</span>
+          </p>
+        </div>
+      </section>
+
+      <!-- 섹션 1: 전면/주력 진열 추천 -->
+      <section class="border border-gray-300 bg-white shadow-sm">
+        <header class="flex items-center justify-between border-b border-gray-200 px-4 py-3">
+          <div class="flex items-center gap-2">
+            <PackageIcon :size="16" class="text-[#004D3C]" />
+            <h2 class="text-sm font-black text-gray-900">전면/주력 진열 추천</h2>
+          </div>
+          <span class="text-[11px] text-gray-400"
+            >매대 하드웨어 위치 추적 없음 · 상품 랭킹 기반</span
+          >
+        </header>
+
+        <!-- KPI -->
+        <div class="grid grid-cols-1 gap-3 px-4 pt-4 sm:grid-cols-3">
+          <div class="flex flex-col border border-gray-200 bg-gray-50 p-3">
+            <span class="text-[10px] font-black uppercase text-gray-400">추천 상품 수</span>
+            <span class="mt-1 text-2xl font-black text-gray-800">{{ displayKpi.count }}건</span>
+          </div>
+          <div class="flex flex-col border border-gray-200 bg-gray-50 p-3">
+            <span class="text-[10px] font-black uppercase text-gray-400">평균 예상 상승률</span>
+            <span class="mt-1 text-2xl font-black text-emerald-600">
+              +{{ displayKpi.avgUplift }}%
+            </span>
+          </div>
+          <div class="flex flex-col border border-gray-200 bg-gray-50 p-3">
+            <span class="text-[10px] font-black uppercase text-gray-400">TOP 매출 상품</span>
+            <span class="mt-1 truncate text-sm font-black text-gray-800">
+              {{ displayKpi.topName }}
+            </span>
+          </div>
+        </div>
+
+        <!-- 차트 -->
+        <div class="px-4 pt-4">
+          <p class="mb-2 text-[11px] font-black uppercase tracking-wider text-gray-500">
+            전면 배치 시 예상 매출 상승률 TOP 10
+          </p>
+          <BarChart :data="displayChartData" :options="displayChartOptions" :height="320" />
+        </div>
+
+        <!-- 추천 카드 리스트 -->
+        <div class="grid grid-cols-1 gap-3 p-4 lg:grid-cols-2">
+          <article
+            v-for="rec in sortedDisplayCards"
+            :key="rec.id"
+            class="flex flex-col gap-2 border border-gray-200 bg-white p-3 transition-colors hover:border-[#004D3C]"
+          >
+            <div class="flex items-start justify-between gap-2">
+              <div class="min-w-0">
+                <p class="truncate text-sm font-black text-gray-900">{{ rec.productName }}</p>
+                <p class="text-[10px] text-gray-400">{{ rec.productCode }}</p>
+              </div>
+              <span
+                class="shrink-0 bg-emerald-50 px-2 py-0.5 text-[10px] font-black text-emerald-700"
+              >
+                +{{ rec.expectedUpliftPct }}% 예상
+              </span>
+            </div>
+            <div class="flex flex-wrap items-center gap-2 text-[11px] text-gray-600">
+              <span
+                >주간 판매 <strong class="font-black">{{ rec.weeklySales }}</strong
+                >개</span
+              >
+              <span class="text-gray-300">|</span>
+              <span
+                class="inline-flex items-center gap-0.5 font-black"
+                :class="rec.trendPct >= 0 ? 'text-emerald-600' : 'text-red-600'"
+              >
+                <TrendUpIcon v-if="rec.trendPct >= 0" :size="11" />
+                <TrendDownIcon v-else :size="11" />
+                {{ rec.trendPct >= 0 ? '+' : '' }}{{ rec.trendPct }}%
+              </span>
+            </div>
+            <p class="text-[11px] text-gray-500">{{ rec.reason }}</p>
+          </article>
+        </div>
+      </section>
+
+      <!-- 섹션 2: 발주 추천 -->
+      <section class="border border-gray-300 bg-white shadow-sm">
+        <header class="flex items-center justify-between border-b border-gray-200 px-4 py-3">
+          <div class="flex items-center gap-2">
+            <CartIcon :size="16" class="text-[#004D3C]" />
+            <h2 class="text-sm font-black text-gray-900">발주 추천</h2>
+          </div>
+          <span class="text-[11px] text-gray-400">행을 클릭하면 7일 판매 추세가 열립니다</span>
+        </header>
+
+        <div class="overflow-auto">
+          <table class="w-full min-w-[860px] table-fixed border-collapse text-xs">
+            <thead class="bg-gray-100 text-[10px] uppercase tracking-wider text-gray-500">
+              <tr>
+                <th class="w-8 px-2 py-2 text-center font-black"></th>
+                <th class="px-3 py-2 text-left font-black">상품</th>
+                <th class="w-20 px-3 py-2 text-right font-black">현재재고</th>
+                <th class="w-20 px-3 py-2 text-right font-black">안전재고</th>
+                <th class="w-20 px-3 py-2 text-right font-black">일평균판매</th>
+                <th class="w-20 px-3 py-2 text-right font-black">추천수량</th>
+                <th class="w-16 px-3 py-2 text-center font-black">긴급도</th>
+                <th class="px-3 py-2 text-left font-black">근거</th>
+                <th class="w-24 px-3 py-2 text-center font-black">액션</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100">
+              <template v-for="row in reportStore.sortedRestock" :key="row.id">
+                <tr
+                  class="cursor-pointer transition-colors hover:bg-gray-50"
+                  :class="{ 'bg-[#E6F2F0]': expandedRestockId === row.id }"
+                  @click="handleToggleRestock(row.id)"
+                >
+                  <td class="px-2 py-3 text-center text-gray-400">
+                    <ChevronIcon
+                      :size="12"
+                      :class="expandedRestockId === row.id ? 'rotate-90' : ''"
+                    />
+                  </td>
+                  <td class="px-3 py-3">
+                    <p class="font-black text-gray-800">{{ row.productName }}</p>
+                    <p class="text-[10px] text-gray-400">{{ row.productCode }}</p>
+                  </td>
+                  <td
+                    class="px-3 py-3 text-right font-bold"
+                    :class="row.currentQty < row.safetyStock ? 'text-red-600' : 'text-gray-700'"
+                  >
+                    {{ row.currentQty }}
+                  </td>
+                  <td class="px-3 py-3 text-right text-gray-500">{{ row.safetyStock }}</td>
+                  <td class="px-3 py-3 text-right text-gray-600">{{ row.avgDailySales }}/일</td>
+                  <td class="px-3 py-3 text-right font-black text-[#004D3C]">
+                    {{ row.recommendedQty }}
+                  </td>
+                  <td class="px-3 py-3 text-center">
+                    <span
+                      class="inline-flex px-2 py-1 text-[10px] font-black"
+                      :class="urgencyBadgeClass(row.urgency)"
+                    >
+                      {{ urgencyLabel(row.urgency) }}
+                    </span>
+                  </td>
+                  <td class="px-3 py-3 text-[11px] text-gray-500">{{ row.reason }}</td>
+                  <td class="px-3 py-3 text-center">
+                    <button
+                      type="button"
+                      class="border border-[#004D3C] bg-[#004D3C] px-2 py-1 text-[10px] font-black text-white hover:bg-[#1f4b3a]"
+                      @click.stop="handleNavigateOrder(row.productCode)"
+                    >
+                      발주하기
+                    </button>
+                  </td>
+                </tr>
+                <tr v-if="expandedRestockId === row.id" class="bg-gray-50">
+                  <td colspan="9" class="px-4 py-4">
+                    <div class="grid grid-cols-1 gap-4 xl:grid-cols-[1fr_280px]">
+                      <div>
+                        <p
+                          class="mb-2 text-[11px] font-black uppercase tracking-wider text-gray-500"
+                        >
+                          최근 7일 판매 추세
+                        </p>
+                        <LineChart
+                          :data="restockTrendData(row.productCode)"
+                          :options="restockTrendOptions"
+                          :height="180"
+                        />
+                      </div>
+                      <div class="flex flex-col justify-center gap-2 border-l border-gray-200 pl-4">
+                        <p class="text-[11px] font-black uppercase text-gray-400">추천 발주 수량</p>
+                        <p class="text-3xl font-black text-[#004D3C]">
+                          {{ row.recommendedQty }}<span class="ml-1 text-sm">개</span>
+                        </p>
+                        <p class="text-[11px] text-gray-500">
+                          재고 회전 기준 {{ Math.ceil(row.recommendedQty / row.avgDailySales) }}일분
+                        </p>
+                        <button
+                          type="button"
+                          class="mt-2 inline-flex items-center justify-center gap-1 border border-[#004D3C] bg-[#004D3C] px-3 py-2 text-xs font-black text-white hover:bg-[#1f4b3a]"
+                          @click.stop="handleNavigateOrder(row.productCode)"
+                        >
+                          <CartIcon :size="12" />
+                          주문 화면에서 발주 생성
+                        </button>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              </template>
+              <tr v-if="reportStore.sortedRestock.length === 0">
+                <td colspan="9" class="px-4 py-8 text-center text-xs text-gray-400">
+                  발주 추천 내역이 없습니다.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <!-- 섹션 3: 연관 상품 추천 -->
+      <section class="border border-gray-300 bg-white shadow-sm">
+        <header class="flex items-center justify-between border-b border-gray-200 px-4 py-3">
+          <div class="flex items-center gap-2">
+            <LinkIcon :size="16" class="text-[#004D3C]" />
+            <h2 class="text-sm font-black text-gray-900">연관 상품 추천</h2>
+          </div>
+          <span class="text-[11px] text-gray-400">함께 팔리는 상품 TOP 3 · 묶음 프로모션 제안</span>
+        </header>
+
+        <div class="overflow-auto">
+          <table class="w-full min-w-[760px] table-fixed border-collapse text-xs">
+            <thead class="bg-gray-100 text-[10px] uppercase tracking-wider text-gray-500">
+              <tr>
+                <th class="px-3 py-2 text-left font-black">주력 상품</th>
+                <th class="px-3 py-2 text-left font-black">함께 팔리는 상품 TOP 3</th>
+                <th class="w-32 px-3 py-2 text-center font-black">액션</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100">
+              <tr v-for="rule in reportStore.currentReport.associationRules" :key="rule.id">
+                <td class="px-3 py-3 align-top">
+                  <p class="font-black text-gray-800">{{ rule.baseProduct }}</p>
+                </td>
+                <td class="px-3 py-3">
+                  <div class="flex flex-col gap-2">
+                    <div
+                      v-for="(p, idx) in rule.partners"
+                      :key="idx"
+                      class="flex items-center gap-3"
+                    >
+                      <span class="w-40 shrink-0 truncate text-xs text-gray-700">
+                        {{ p.name }}
+                      </span>
+                      <div class="relative flex-1 bg-gray-100">
+                        <div class="h-2 bg-[#004D3C]" :style="{ width: p.coBuyRate + '%' }"></div>
+                      </div>
+                      <span class="w-10 text-right text-[11px] font-black text-gray-600">
+                        {{ p.coBuyRate }}%
+                      </span>
+                    </div>
+                  </div>
+                </td>
+                <td class="px-3 py-3 text-center">
+                  <button
+                    type="button"
+                    class="border border-[#004D3C] bg-white px-2 py-1 text-[10px] font-black text-[#004D3C] hover:bg-[#E6F2F0]"
+                    @click="handleBundleSuggest(rule.suggestedBundle)"
+                  >
+                    묶음 프로모션 제안
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  </AppLayout>
+</template>


### PR DESCRIPTION
## 📌 요약
- 매장 AI 리포트 페이지(`/store/ai-report`) 신규 구현

<br><br>

## 🎯 작업 내용
- `src/stores/storeAiReport.js` 생성 및 더미 데이터 구성 (진열 추천 15건 / 발주 추천 10건 / 연관 상품 12건)
- `StoreAiReportView.vue` 구현 (요약 바 / 섹션 1 진열 추천 BarChart / 섹션 2 발주 추천 확장 LineChart / 섹션 3 연관 상품 강도 바)
- hq 계정 접근 시 `/hq/dashboard` 리다이렉트 권한 가드 적용

<br><br>

## ✔️ 참고 사항
- 차트는 Chart.js + vue-chartjs 사용 (공통 컴포넌트 `LineChart.vue`, `BarChart.vue` 의존)
- 발주하기 버튼 클릭 시 `/store/orders?productId=...` 쿼리 파라미터 전달 (StoreOrdersView 프리필 연동은 별도 이슈)

<br><br>

## ✔️ 관련 이슈

- Close #132 

<br><br>
