### PR TITLE
design: 중앙관리자 제품 마스터 조회, 수정, 삭제, 등록 페이지 구현

### DIFF
--- a/src/config/roleMenus.js
+++ b/src/config/roleMenus.js
@@ -41,8 +41,8 @@ export const roleMenus = {
       path: '/hq/products',
       icon: 'file',
       children: [
-        { label: '카테고리 관리' },
-        { label: '제품 마스터' },
+        { label: '카테고리 관리', path: '/hq/products?tab=categories' },
+        { label: '제품 마스터', path: '/hq/products?tab=products' },
       ],
     },
     {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -53,6 +53,12 @@ const router = createRouter({
     { path: '/hq/orders', name: 'hq-orders', component: HqOrderManagementView, meta: { requiresAuth: true, role: 'hq' } },
     { path: '/hq/products', name: 'hq-products', component: HqProductManagementView, meta: { requiresAuth: true, role: 'hq' } },
     { path: '/hq/products/categories/add', name: 'hq-category-add', component: HqCategoryAddView, meta: { requiresAuth: true, role: 'hq' } },
+    {
+      path: '/hq/products/new',
+      name: 'hq-product-new',
+      component: () => import('@/views/hq/HqProductCreateView.vue'),
+      meta: { requiresAuth: true, role: 'hq' },
+    },
     { path: '/hq/infrastructure', name: 'hq-infrastructure', component: HqInfrastructureManagementView, meta: { requiresAuth: true, role: 'hq' } },
     { path: '/hq/analytics', name: 'hq-analytics', component: HqSettlementStatisticsView, meta: { requiresAuth: true, role: 'hq' } },
     { path: '/hq/purchase-orders', name: 'hq-purchase-orders', component: HqPurchaseOrderView, meta: { requiresAuth: true, role: 'hq' } },

--- a/src/views/hq/HqCategoryAddView.vue
+++ b/src/views/hq/HqCategoryAddView.vue
@@ -19,8 +19,8 @@ const activeTopMenu = computed(() => '상품 관리')
 const activeSideMenu = ref('카테고리 관리')
 
 const productSideMenus = [
-  { label: '카테고리 관리', icon: 'tags', id: 'SO-006' },
-  { label: '제품 마스터', icon: 'package', id: 'SO-011' },
+  { label: '카테고리 관리', icon: 'tags', id: 'SO-006', path: '/hq/products' },
+  { label: '제품 마스터', icon: 'package', id: 'SO-011', path: '/hq/products' },
 ]
 
 const parentCategories = [

--- a/src/views/hq/HqProductCreateView.vue
+++ b/src/views/hq/HqProductCreateView.vue
@@ -1,0 +1,334 @@
+<script setup>
+import { computed, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import { ArrowLeft, ChevronRight, Package } from 'lucide-vue-next'
+import AppLayout from '@/components/common/AppLayout.vue'
+import { roleMenus } from '@/config/roleMenus.js'
+import { useAuthStore } from '@/stores/auth.js'
+
+const router = useRouter()
+const auth = useAuthStore()
+const hqMenus = roleMenus.hq
+
+function handleLogout() {
+  auth.logout()
+  router.push('/login')
+}
+
+const activeTopMenu = computed(() => '상품 관리')
+const activeSideMenu = ref('제품 마스터')
+
+const productSideMenus = [
+  { label: '카테고리 관리', icon: 'tags', id: 'SO-006', path: '/hq/products' },
+  { label: '제품 마스터', icon: 'package', id: 'SO-011', path: '/hq/products' },
+]
+
+const categoryMap = {
+  상의: ['반팔', '긴팔', '셔츠', '니트', '후드티'],
+  바지: ['청바지', '반바지', '긴바지', '츄리닝'],
+  치마: ['미니 스커트', '롱스커트'],
+  아우터: ['패딩', '후드집업', '자켓', '가디건'],
+}
+const COLOR_OPTIONS = ['검정', '흰색', '그레이', '아이보리']
+const SIZE_OPTIONS = ['XS', 'S', 'M', 'L', 'XL']
+
+const productName = ref('')
+const parentCategory = ref('상의')
+const childCategory = ref('반팔')
+const price = ref('')
+const status = ref('활성')
+const vendorName = ref('')
+const regDate = ref(new Date().toISOString().slice(0, 10).replaceAll('-', '.'))
+const selectedColors = ref([])
+const selectedSizes = ref([])
+
+const childCategoryOptions = computed(() => categoryMap[parentCategory.value] ?? [])
+
+watch(parentCategory, () => {
+  if (!childCategoryOptions.value.includes(childCategory.value)) {
+    childCategory.value = childCategoryOptions.value[0] ?? ''
+  }
+})
+
+const isVariantValid = computed(() => selectedColors.value.length > 0 && selectedSizes.value.length > 0)
+
+const variantSummaryText = computed(() => {
+  if (!selectedColors.value.length || !selectedSizes.value.length) return '-'
+  return `색상(${selectedColors.value.join(', ')}) / 사이즈(${selectedSizes.value.join(', ')})`
+})
+
+const requiredProgress = computed(() => {
+  const requiredSteps = [
+    Boolean(productName.value.trim()),
+    Boolean(parentCategory.value),
+    Boolean(childCategory.value),
+    Number(price.value) > 0,
+    Boolean(vendorName.value.trim()),
+    isVariantValid.value,
+  ]
+  return requiredSteps.filter(Boolean).length
+})
+
+const canSubmit = computed(() =>
+  productName.value.trim() &&
+  parentCategory.value &&
+  childCategory.value &&
+  Number(price.value) > 0 &&
+  vendorName.value.trim() &&
+  isVariantValid.value,
+)
+
+function toggleColor(color) {
+  const next = new Set(selectedColors.value)
+  if (next.has(color)) next.delete(color)
+  else next.add(color)
+  selectedColors.value = Array.from(next)
+}
+
+function toggleSize(size) {
+  const next = new Set(selectedSizes.value)
+  if (next.has(size)) next.delete(size)
+  else next.add(size)
+  selectedSizes.value = Array.from(next)
+}
+
+function handleSubmit() {
+  if (!canSubmit.value) return
+  router.push('/hq/products')
+}
+
+function handleCancel() {
+  router.push('/hq/products')
+}
+</script>
+
+<template>
+  <AppLayout
+    :active-top-menu="activeTopMenu"
+    :top-menus="hqMenus"
+    :side-menus="productSideMenus"
+    v-model:active-side-menu="activeSideMenu"
+    show-system-card
+    @logout="handleLogout"
+  >
+    <div class="flex flex-col gap-4">
+      <section class="border border-gray-200 bg-white p-4 shadow-sm">
+        <div class="flex items-center gap-2 text-[11px] font-bold text-gray-400">
+          <button type="button" class="hover:text-[#004D3C]" @click="handleCancel">상품 관리</button>
+          <ChevronRight :size="12" />
+          <button type="button" class="hover:text-[#004D3C]" @click="handleCancel">제품 마스터</button>
+          <ChevronRight :size="12" />
+          <span class="text-gray-700">신규 제품 등록</span>
+        </div>
+        <div class="mt-3 flex items-center gap-3">
+          <button
+            type="button"
+            class="inline-flex h-8 w-8 items-center justify-center border border-gray-200 text-gray-500 hover:border-[#004D3C] hover:text-[#004D3C]"
+            @click="handleCancel"
+          >
+            <ArrowLeft :size="15" />
+          </button>
+          <div>
+            <h1 class="text-xl font-black text-gray-950">신규 제품 등록</h1>
+            <p class="mt-0.5 text-xs font-bold text-gray-400">제품 기본 정보를 입력하고 신규 제품을 등록합니다.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="grid gap-4 xl:grid-cols-[minmax(0,2fr)_minmax(280px,1fr)] xl:items-start">
+        <div class="border border-gray-200 bg-white shadow-sm">
+          <div class="flex items-center gap-2 border-b border-gray-100 px-5 py-3">
+            <Package :size="15" class="text-[#004D3C]" />
+            <h2 class="text-sm font-black text-gray-900">제품 정보 입력</h2>
+          </div>
+
+          <div class="border-b border-gray-100 bg-[#F7FBFA] px-5 py-3">
+            <div class="flex items-center justify-between gap-2">
+              <p class="text-[11px] font-black uppercase tracking-wide text-gray-500">입력 진행 안내</p>
+              <span class="text-[11px] font-black text-[#004D3C]">{{ requiredProgress }}/6 완료</span>
+            </div>
+            <div class="mt-2 h-1.5 overflow-hidden bg-[#DCEDE8]">
+              <div class="h-full bg-[#0E7A60] transition-all" :style="{ width: `${(requiredProgress / 6) * 100}%` }" />
+            </div>
+          </div>
+
+          <form class="space-y-6 p-5" @submit.prevent="handleSubmit">
+            <div>
+              <label class="mb-1.5 block text-[11px] font-black uppercase tracking-wide text-gray-500">
+                제품명 <span class="text-red-500">*</span>
+              </label>
+              <input
+                v-model="productName"
+                type="text"
+                placeholder="제품명을 입력하세요"
+                class="w-full border border-gray-300 bg-white px-3 py-2.5 text-sm outline-none focus:border-[#004D3C]"
+              />
+            </div>
+
+            <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <label class="block text-[11px] font-black uppercase tracking-wide text-gray-500">
+                대분류 <span class="text-red-500">*</span>
+                <select
+                  v-model="parentCategory"
+                  class="mt-1.5 w-full border border-gray-300 bg-white px-3 py-2.5 text-sm text-gray-800 outline-none focus:border-[#004D3C]"
+                >
+                  <option v-for="parent in Object.keys(categoryMap)" :key="parent" :value="parent">{{ parent }}</option>
+                </select>
+              </label>
+              <label class="block text-[11px] font-black uppercase tracking-wide text-gray-500">
+                소분류 <span class="text-red-500">*</span>
+                <select
+                  v-model="childCategory"
+                  class="mt-1.5 w-full border border-gray-300 bg-white px-3 py-2.5 text-sm text-gray-800 outline-none focus:border-[#004D3C]"
+                >
+                  <option v-for="child in childCategoryOptions" :key="child" :value="child">{{ child }}</option>
+                </select>
+              </label>
+            </div>
+
+            <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <label class="block text-[11px] font-black uppercase tracking-wide text-gray-500">
+                단가 <span class="text-red-500">*</span>
+                <input
+                  v-model.number="price"
+                  type="number"
+                  min="0"
+                  placeholder="숫자로 입력"
+                  class="mt-1.5 w-full border border-gray-300 bg-white px-3 py-2.5 text-sm outline-none focus:border-[#004D3C]"
+                />
+              </label>
+              <label class="block text-[11px] font-black uppercase tracking-wide text-gray-500">
+                상태
+                <select
+                  v-model="status"
+                  class="mt-1.5 w-full border border-gray-300 bg-white px-3 py-2.5 text-sm text-gray-800 outline-none focus:border-[#004D3C]"
+                >
+                  <option value="활성">활성</option>
+                  <option value="점검중">점검중</option>
+                  <option value="비활성">비활성</option>
+                </select>
+              </label>
+            </div>
+
+            <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <label class="block text-[11px] font-black uppercase tracking-wide text-gray-500">
+                메인 거래처 <span class="text-red-500">*</span>
+                <input
+                  v-model="vendorName"
+                  type="text"
+                  placeholder="거래처명을 입력하세요"
+                  class="mt-1.5 w-full border border-gray-300 bg-white px-3 py-2.5 text-sm outline-none focus:border-[#004D3C]"
+                />
+              </label>
+              <label class="block text-[11px] font-black uppercase tracking-wide text-gray-500">
+                등록일
+                <input
+                  v-model="regDate"
+                  type="text"
+                  class="mt-1.5 w-full border border-gray-300 bg-white px-3 py-2.5 text-sm outline-none focus:border-[#004D3C]"
+                />
+              </label>
+            </div>
+
+            <div class="mt-6 space-y-3 rounded-md border border-gray-300 bg-white p-5">
+              <p class="text-[11px] font-black uppercase tracking-wide text-gray-500">옵션 구성 <span class="text-red-500">*</span></p>
+              <div class="flex flex-wrap gap-2">
+                <button
+                  v-for="color in COLOR_OPTIONS"
+                  :key="color"
+                  type="button"
+                  class="border px-3 py-1.5 text-xs font-black transition"
+                  :class="selectedColors.includes(color)
+                    ? 'border-[#004D3C] bg-[#004D3C] text-white'
+                    : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-100'"
+                  @click="toggleColor(color)"
+                >
+                  {{ color }}
+                </button>
+              </div>
+
+              <div class="mt-5 pt-2">
+                <p class="mb-2 text-[11px] font-black text-gray-500">공통 사이즈 선택</p>
+                <div class="flex flex-wrap gap-2">
+                <button
+                  v-for="size in SIZE_OPTIONS"
+                  :key="size"
+                  type="button"
+                  class="border px-2.5 py-1 text-xs font-black transition"
+                  :class="selectedSizes.includes(size)
+                    ? 'border-[#0E7A60] bg-[#EBF5F5] text-[#0E7A60]'
+                    : 'border-gray-300 bg-white text-gray-600 hover:bg-gray-100'"
+                  @click="toggleSize(size)"
+                >
+                  {{ size }}
+                </button>
+                </div>
+              </div>
+            </div>
+
+            <div class="-mx-5 border-t border-gray-100 bg-white px-5 pt-4">
+              <div class="flex gap-2">
+                <button
+                  type="button"
+                  class="flex-1 border border-gray-300 bg-white py-2.5 text-sm font-black text-gray-700 hover:bg-gray-50"
+                  @click="handleCancel"
+                >
+                  취소
+                </button>
+                <button
+                  type="submit"
+                  class="flex-1 border border-[#004D3C] bg-[#004D3C] py-2.5 text-sm font-black text-white hover:bg-[#003d30] disabled:cursor-not-allowed disabled:opacity-40"
+                  :disabled="!canSubmit"
+                >
+                  신규 제품 등록
+                </button>
+              </div>
+            </div>
+          </form>
+        </div>
+
+        <aside class="space-y-4 xl:sticky xl:top-16">
+          <section class="border border-gray-200 bg-white p-4 shadow-sm">
+            <h3 class="text-xs font-black uppercase tracking-wide text-gray-500">현재 입력 요약</h3>
+            <div class="mt-3 space-y-2 text-xs">
+              <div class="flex items-center justify-between border border-gray-100 bg-gray-50 px-3 py-2">
+                <span class="font-black text-gray-500">제품명</span>
+                <span class="font-black text-gray-800">{{ productName || '-' }}</span>
+              </div>
+              <div class="flex items-center justify-between border border-gray-100 bg-gray-50 px-3 py-2">
+                <span class="font-black text-gray-500">카테고리</span>
+                <span class="font-black text-gray-800">{{ parentCategory }} &gt; {{ childCategory }}</span>
+              </div>
+              <div class="flex items-center justify-between border border-gray-100 bg-gray-50 px-3 py-2">
+                <span class="font-black text-gray-500">단가</span>
+                <span class="font-black text-gray-800">{{ Number(price) > 0 ? `₩${Number(price).toLocaleString()}` : '-' }}</span>
+              </div>
+              <div class="flex items-center justify-between border border-gray-100 bg-gray-50 px-3 py-2">
+                <span class="font-black text-gray-500">메인 거래처</span>
+                <span class="font-black text-gray-800">{{ vendorName || '-' }}</span>
+              </div>
+              <div class="flex items-center justify-between border border-gray-100 bg-gray-50 px-3 py-2">
+                <span class="font-black text-gray-500">상태</span>
+                <span class="font-black text-gray-800">{{ status }}</span>
+              </div>
+              <div class="flex items-center justify-between gap-3 border border-gray-100 bg-gray-50 px-3 py-2">
+                <span class="font-black text-gray-500">옵션</span>
+                <span class="text-right font-black text-gray-800">{{ variantSummaryText }}</span>
+              </div>
+            </div>
+          </section>
+
+          <section class="border border-gray-200 bg-white p-4 shadow-sm">
+            <h3 class="text-xs font-black uppercase tracking-wide text-gray-500">작성 가이드</h3>
+            <div class="mt-3 space-y-2 text-[12px] font-bold text-gray-600">
+              <p>제품명은 거래처/매장 공통으로 식별 가능한 명칭으로 입력하세요.</p>
+              <p>카테고리는 대분류와 소분류를 함께 선택해야 저장할 수 있습니다.</p>
+              <p>단가는 원 단위 숫자만 입력하고, 메인 거래처는 필수입니다.</p>
+              <p>옵션은 최소 1개 색상과 1개 사이즈를 선택하며, 선택한 사이즈는 모든 선택 색상에 공통 적용됩니다.</p>
+            </div>
+          </section>
+        </aside>
+      </section>
+    </div>
+  </AppLayout>
+</template>

--- a/src/views/hq/HqProductManagementView.vue
+++ b/src/views/hq/HqProductManagementView.vue
@@ -1,11 +1,12 @@
 <script setup>
-import { computed, h, ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { computed, h, ref, watch } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
 import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
 
 const router = useRouter()
+const route = useRoute()
 const auth = useAuthStore()
 const hqMenus = roleMenus.hq
 
@@ -14,8 +15,13 @@ function handleLogout() {
   router.push('/login')
 }
 
+const tabLabelMap = { categories: '카테고리 관리', products: '제품 마스터' }
 const activeTopMenu = computed(() => '상품 관리')
-const activeSideMenu = ref('카테고리 관리')
+const activeSideMenu = ref(tabLabelMap[route.query.tab] ?? '카테고리 관리')
+
+watch(() => route.query.tab, (tab) => {
+  activeSideMenu.value = tabLabelMap[tab] ?? '카테고리 관리'
+})
 const selectedProduct = ref(null)
 const selectedCategory = ref(null)
 
@@ -25,16 +31,21 @@ const productSideMenus = [
 ]
 
 const productMasterData = [
-  { id: 'PD-E001', name: '고속 충전기 (C타입) 25W', spec: '25W / White', cat: '상의 > 반팔', unit: 'EA', price: 15000, leadTime: '3일', vendor: '(주)전자에셋', status: '활성', regDate: '2024.01.12' },
-  { id: 'PD-E002', name: '무소음 무선 마우스 (블랙)', spec: 'Bluetooth 5.0', cat: '상의 > 긴팔', unit: 'EA', price: 28000, leadTime: '5일', vendor: '로지잡화', status: '활성', regDate: '2024.01.15' },
-  { id: 'PD-S001', name: 'A4 복사용지 80g (500매)', cat: '바지 > 청바지', spec: '80g / White', unit: 'Box', price: 24500, leadTime: '2일', vendor: '(주)한지제지', status: '활성', regDate: '2023.12.20' },
-  { id: 'PD-H001', name: '휴대용 가글 (중) 250ml', cat: '아우터 > 패딩', spec: '250ml / 민트', unit: 'EA', price: 3500, leadTime: '7일', vendor: '클린헬스', status: '비활성', regDate: '2024.02.05' },
-  { id: 'PD-K001', name: '유리제 머그컵 350ml', cat: '치마 > 롱스커트', spec: 'Heat-resistant', unit: 'EA', price: 8900, leadTime: '10일', vendor: '키친웨어', status: '활성', regDate: '2024.03.11' },
-  { id: 'PD-S002', name: '리무버블 데코 스티커 세트', cat: '상의 > 셔츠', spec: '10 Sheets', unit: 'Set', price: 4200, leadTime: '3일', vendor: '디자인웍스', status: '활성', regDate: '2024.03.15' },
-  { id: 'PD-S003', name: '스테이플러 심 (10호)', cat: '아우터 > 자켓', spec: '1000pcs', unit: 'Small Box', price: 800, leadTime: '2일', vendor: '(주)한지제지', status: '활성', regDate: '2024.01.10' },
-  { id: 'PD-E003', name: '기계식 키보드 (청축)', cat: '상의 > 후드티', spec: 'RGB / Wired', unit: 'EA', price: 125000, leadTime: '14일', vendor: '(주)전자에셋', status: '활성', regDate: '2024.04.01' },
-  { id: 'PD-H002', name: '손세정제 리필 500ml', cat: '바지 > 반바지', spec: '500ml / 레몬', unit: 'EA', price: 5400, leadTime: '3일', vendor: '클린헬스', status: '활성', regDate: '2024.02.10' },
-  { id: 'PD-K002', name: '니트릴 고무장갑 (M)', cat: '치마 > 미니 스커트', spec: 'Blue / 100pcs', unit: 'Box', price: 12000, leadTime: '4일', vendor: '키친웨어', status: '점검중', regDate: '2024.02.15' },
+  { id: 'PD-T001', name: '코튼 베이직 반팔 티셔츠', parentCategory: '상의', childCategory: '반팔', price: 12900, leadTime: '3일', vendor: '스타일텍스', status: '활성', regDate: '2024.01.12' },
+  { id: 'PD-T002', name: '슬림핏 긴팔 티셔츠', parentCategory: '상의', childCategory: '긴팔', price: 16900, leadTime: '4일', vendor: '스타일텍스', status: '활성', regDate: '2024.01.26' },
+  { id: 'PD-T003', name: '오버핏 옥스포드 셔츠', parentCategory: '상의', childCategory: '셔츠', price: 35900, leadTime: '5일', vendor: '어반클로스', status: '활성', regDate: '2024.02.14' },
+  { id: 'PD-T004', name: '라운드넥 소프트 니트', parentCategory: '상의', childCategory: '니트', price: 39900, leadTime: '6일', vendor: '니트랩', status: '점검중', regDate: '2024.03.02' },
+  { id: 'PD-T005', name: '헤비웨이트 로고 후드티', parentCategory: '상의', childCategory: '후드티', price: 45900, leadTime: '7일', vendor: '어반클로스', status: '활성', regDate: '2024.03.15' },
+  { id: 'PD-B001', name: '스트레이트 워싱 데님', parentCategory: '바지', childCategory: '청바지', price: 42900, leadTime: '5일', vendor: '데님하우스', status: '활성', regDate: '2024.01.19' },
+  { id: 'PD-B002', name: '라이트 코튼 쇼츠', parentCategory: '바지', childCategory: '반바지', price: 29900, leadTime: '4일', vendor: '데님하우스', status: '활성', regDate: '2024.02.08' },
+  { id: 'PD-B003', name: '와이드 밴딩 팬츠', parentCategory: '바지', childCategory: '긴바지', price: 37900, leadTime: '4일', vendor: '모션웨어', status: '활성', regDate: '2024.02.27' },
+  { id: 'PD-B004', name: '데일리 조거 트레이닝 팬츠', parentCategory: '바지', childCategory: '츄리닝', price: 33900, leadTime: '3일', vendor: '모션웨어', status: '비활성', regDate: '2024.03.11' },
+  { id: 'PD-S001', name: 'A라인 데님 미니스커트', parentCategory: '치마', childCategory: '미니 스커트', price: 31900, leadTime: '5일', vendor: '스커트스튜디오', status: '활성', regDate: '2024.01.30' },
+  { id: 'PD-S002', name: '플리츠 롱스커트', parentCategory: '치마', childCategory: '롱스커트', price: 38900, leadTime: '6일', vendor: '스커트스튜디오', status: '활성', regDate: '2024.03.05' },
+  { id: 'PD-O001', name: '라이트 숏 패딩', parentCategory: '아우터', childCategory: '패딩', price: 79900, leadTime: '8일', vendor: '윈터픽', status: '활성', regDate: '2024.02.21' },
+  { id: 'PD-O002', name: '스웨트 후드 집업', parentCategory: '아우터', childCategory: '후드집업', price: 54900, leadTime: '6일', vendor: '윈터픽', status: '점검중', regDate: '2024.03.09' },
+  { id: 'PD-O003', name: '싱글 브레스트 자켓', parentCategory: '아우터', childCategory: '자켓', price: 72900, leadTime: '9일', vendor: '테일러드원', status: '활성', regDate: '2024.03.18' },
+  { id: 'PD-O004', name: '브이넥 니트 가디건', parentCategory: '아우터', childCategory: '가디건', price: 48900, leadTime: '7일', vendor: '니트랩', status: '활성', regDate: '2024.03.25' },
 ]
 
 const categories = ref([
@@ -96,6 +107,36 @@ const expandedCategories = ref(new Set(['CAT-100']))
 const totalCategoryCount = computed(() =>
   categories.value.reduce((acc, cat) => acc + 1 + cat.children.length, 0),
 )
+const productKeyword = ref('')
+const selectedParentFilter = ref('all')
+const selectedChildFilter = ref('all')
+const parentCategoryOptions = computed(() => categories.value.map((cat) => cat.name))
+const childCategoryOptions = computed(() => {
+  if (selectedParentFilter.value === 'all') {
+    return categories.value.flatMap((cat) => cat.children.map((child) => child.name))
+  }
+  const target = categories.value.find((cat) => cat.name === selectedParentFilter.value)
+  return target ? target.children.map((child) => child.name) : []
+})
+const filteredProductMasterData = computed(() => {
+  const keyword = productKeyword.value.trim().toLowerCase()
+  return productMasterData.filter((prod) => {
+    const matchParent = selectedParentFilter.value === 'all' || prod.parentCategory === selectedParentFilter.value
+    const matchChild = selectedChildFilter.value === 'all' || prod.childCategory === selectedChildFilter.value
+    const matchKeyword =
+      !keyword ||
+      [prod.id, prod.name, prod.vendor, prod.parentCategory, prod.childCategory]
+        .join(' ')
+        .toLowerCase()
+        .includes(keyword)
+    return matchParent && matchChild && matchKeyword
+  })
+})
+
+function handleParentFilterChange(event) {
+  selectedParentFilter.value = event.target.value
+  selectedChildFilter.value = 'all'
+}
 
 const toggleExpand = (id, event) => {
   event.stopPropagation()
@@ -107,6 +148,50 @@ const toggleExpand = (id, event) => {
 
 const closeDetail = () => { selectedProduct.value = null }
 const closeCategoryDetail = () => { selectedCategory.value = null }
+const productEditForm = ref(null)
+
+const syncProductEditForm = (product) => {
+  if (!product) {
+    productEditForm.value = null
+    return
+  }
+  productEditForm.value = {
+    name: product.name,
+    parentCategory: product.parentCategory,
+    childCategory: product.childCategory,
+    price: product.price,
+    vendor: product.vendor,
+    status: product.status,
+    regDate: product.regDate,
+  }
+}
+
+watch(selectedProduct, (product) => {
+  syncProductEditForm(product)
+})
+
+const detailChildCategoryOptions = computed(() => {
+  if (!productEditForm.value?.parentCategory) return []
+  const target = categories.value.find((cat) => cat.name === productEditForm.value.parentCategory)
+  return target ? target.children.map((child) => child.name) : []
+})
+
+function handleDetailParentChange(event) {
+  if (!productEditForm.value) return
+  const nextParent = event.target.value
+  productEditForm.value.parentCategory = nextParent
+  const target = categories.value.find((cat) => cat.name === nextParent)
+  productEditForm.value.childCategory = target?.children?.[0]?.name ?? ''
+}
+
+function saveProductDetail() {
+  if (!selectedProduct.value || !productEditForm.value) return
+  Object.assign(selectedProduct.value, productEditForm.value)
+}
+
+function resetProductDetail() {
+  syncProductEditForm(selectedProduct.value)
+}
 
 const IconBase = (paths) => ({
   props: {
@@ -152,11 +237,6 @@ const InfoIcon = IconBase([
   { tag: 'path', attrs: { d: 'M12 10v6' } },
   { tag: 'path', attrs: { d: 'M12 7h.01' } },
 ])
-const DownloadIcon = IconBase([
-  { tag: 'path', attrs: { d: 'M12 3v12' } },
-  { tag: 'path', attrs: { d: 'm7 10 5 5 5-5' } },
-  { tag: 'path', attrs: { d: 'M5 21h14' } },
-])
 const PlusCircleIcon = IconBase([
   { tag: 'circle', attrs: { cx: '12', cy: '12', r: '9' } },
   { tag: 'path', attrs: { d: 'M12 8v8' } },
@@ -190,6 +270,7 @@ const iconMap = {
           <label class="relative block">
             <SearchIcon :size="14" class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
             <input
+              v-model="productKeyword"
               type="text"
               :placeholder="activeSideMenu === '카테고리 관리' ? '카테고리명 또는 코드 검색...' : '제품명, 제품 코드, 거래처명 검색...'"
               class="w-72 border border-gray-300 bg-gray-50 py-1.5 pl-8 pr-3 text-xs outline-none focus:border-[#004D3C] focus:bg-white"
@@ -197,26 +278,34 @@ const iconMap = {
           </label>
 
           <label v-if="activeSideMenu !== '카테고리 관리'" class="flex items-center gap-2 text-[11px] font-black uppercase text-gray-400">
-            카테고리
-            <select class="border border-gray-300 bg-gray-50 px-3 py-1.5 text-xs font-bold text-gray-700 outline-none focus:border-[#004D3C] focus:bg-white">
-              <option>전체 카테고리</option>
-              <option>상의</option>
-              <option>바지</option>
-              <option>치마</option>
-              <option>아우터</option>
+            대분류
+            <select
+              :value="selectedParentFilter"
+              class="border border-gray-300 bg-gray-50 px-3 py-1.5 text-xs font-bold text-gray-700 outline-none focus:border-[#004D3C] focus:bg-white"
+              @change="handleParentFilterChange"
+            >
+              <option value="all">전체</option>
+              <option v-for="parent in parentCategoryOptions" :key="parent" :value="parent">{{ parent }}</option>
+            </select>
+          </label>
+
+          <label v-if="activeSideMenu !== '카테고리 관리'" class="flex items-center gap-2 text-[11px] font-black uppercase text-gray-400">
+            소분류
+            <select
+              v-model="selectedChildFilter"
+              class="border border-gray-300 bg-gray-50 px-3 py-1.5 text-xs font-bold text-gray-700 outline-none focus:border-[#004D3C] focus:bg-white"
+            >
+              <option value="all">전체</option>
+              <option v-for="child in childCategoryOptions" :key="child" :value="child">{{ child }}</option>
             </select>
           </label>
         </div>
 
         <div class="flex flex-wrap items-center gap-2">
-          <button v-if="activeSideMenu !== '카테고리 관리'" type="button" class="inline-flex items-center gap-1.5 border border-gray-300 bg-white px-3 py-2 text-xs font-bold text-gray-700 hover:bg-gray-50">
-            <DownloadIcon :size="14" />
-            일괄 업로드 (CSV)
-          </button>
           <button
             type="button"
             class="inline-flex items-center gap-1.5 border border-[#004D3C] bg-[#004D3C] px-3 py-2 text-xs font-black text-white hover:bg-[#003d30]"
-            @click="activeSideMenu === '카테고리 관리' ? router.push('/hq/products/categories/add') : undefined"
+            @click="activeSideMenu === '카테고리 관리' ? router.push('/hq/products/categories/add') : router.push('/hq/products/new')"
           >
             <PlusCircleIcon :size="14" />
             {{ activeSideMenu === '카테고리 관리' ? '카테고리 추가' : '신규 제품 등록' }}
@@ -379,19 +468,21 @@ const iconMap = {
       <section v-else class="flex min-h-0 flex-col gap-4 xl:flex-row">
         <div class="flex min-w-0 flex-1 flex-col overflow-hidden border border-gray-300 bg-white shadow-sm">
           <div class="border-b border-gray-200 bg-gray-50/70 px-4 py-3">
-            <h3 class="inline-flex items-center gap-2 text-xs font-black uppercase tracking-wider text-gray-800">
-              <PackageIcon :size="14" />
-              {{ activeSideMenu }}
-            </h3>
+            <div class="flex items-center justify-between gap-2">
+              <h3 class="inline-flex items-center gap-2 text-xs font-black uppercase tracking-wider text-gray-800">
+                <PackageIcon :size="14" />
+                {{ activeSideMenu }}
+              </h3>
+              <span class="text-[10px] font-bold text-gray-400">총 {{ filteredProductMasterData.length }}개</span>
+            </div>
           </div>
           <div class="overflow-auto">
-            <table class="w-full min-w-[980px] text-xs">
+            <table class="w-full min-w-[860px] text-xs">
               <thead class="bg-gray-100 text-[10px] uppercase tracking-wider text-gray-500">
                 <tr>
                   <th class="w-24 px-3 py-2 text-center font-black">제품 코드</th>
                   <th class="px-3 py-2 text-left font-black">제품명</th>
-                  <th class="w-32 px-3 py-2 text-left font-black">카테고리</th>
-                  <th class="w-32 px-3 py-2 text-left font-black">규격/단위</th>
+                  <th class="w-44 px-3 py-2 text-left font-black">카테고리</th>
                   <th class="w-28 px-3 py-2 text-right font-black">표준 단가</th>
                   <th class="w-32 px-3 py-2 text-left font-black">메인 거래처</th>
                   <th class="w-24 px-3 py-2 text-center font-black">상태</th>
@@ -400,7 +491,7 @@ const iconMap = {
               </thead>
               <tbody class="divide-y divide-gray-100">
                 <tr
-                  v-for="prod in productMasterData"
+                  v-for="prod in filteredProductMasterData"
                   :key="prod.id"
                   class="cursor-pointer hover:bg-gray-50"
                   :class="selectedProduct?.id === prod.id ? 'bg-[#E6F2F0]' : ''"
@@ -408,8 +499,7 @@ const iconMap = {
                 >
                   <td class="px-3 py-3 text-center font-bold text-gray-400">{{ prod.id }}</td>
                   <td class="px-3 py-3 font-black text-gray-800">{{ prod.name }}</td>
-                  <td class="px-3 py-3 text-gray-600">{{ prod.cat }}</td>
-                  <td class="px-3 py-3 font-bold uppercase text-gray-500">{{ prod.spec }} ({{ prod.unit }})</td>
+                  <td class="px-3 py-3 text-gray-600">{{ prod.parentCategory }} &gt; {{ prod.childCategory }}</td>
                   <td class="px-3 py-3 text-right font-black text-gray-800">₩{{ prod.price.toLocaleString() }}</td>
                   <td class="px-3 py-3 text-gray-600">{{ prod.vendor }}</td>
                   <td class="px-3 py-3 text-center"><span class="bg-emerald-50 px-2 py-1 text-[10px] font-black text-emerald-700">{{ prod.status }}</span></td>
@@ -420,36 +510,117 @@ const iconMap = {
           </div>
         </div>
 
-        <aside v-if="selectedProduct" class="w-full shrink-0 border border-gray-300 bg-white shadow-sm xl:w-80">
+        <aside v-if="selectedProduct && productEditForm" class="w-full shrink-0 border border-gray-300 bg-white shadow-sm xl:w-80">
           <div class="flex items-center justify-between bg-[#004D3C] px-4 py-3 text-white">
             <h3 class="inline-flex items-center gap-2 text-[11px] font-black uppercase"><InfoIcon :size="14" /> 제품 상세</h3>
             <button type="button" class="p-1 hover:bg-white/10" @click="closeDetail"><XIcon :size="16" /></button>
           </div>
-          <div class="space-y-4 p-4">
+          <div class="space-y-6 p-5">
             <div>
               <p class="text-[10px] font-bold uppercase text-gray-400">마스터 ID: {{ selectedProduct.id }}</p>
-              <h4 class="mt-1 text-base font-black leading-snug text-gray-900">{{ selectedProduct.name }}</h4>
-              <div class="mt-2 flex flex-wrap gap-2">
-                <span class="border border-gray-200 bg-gray-100 px-2 py-1 text-[10px] font-bold text-gray-600">{{ selectedProduct.cat }}</span>
-                <span class="border border-emerald-200 bg-emerald-50 px-2 py-1 text-[10px] font-bold text-emerald-700">{{ selectedProduct.status }}</span>
+              <h4 class="mt-2 text-base font-black leading-snug text-gray-900">제품 정보 수정</h4>
+              <div class="mt-3 flex flex-wrap gap-2">
+                <span class="border border-gray-200 bg-gray-100 px-2 py-1 text-[10px] font-bold text-gray-600">{{ productEditForm.parentCategory }} &gt; {{ productEditForm.childCategory }}</span>
+                <span class="border border-emerald-200 bg-emerald-50 px-2 py-1 text-[10px] font-bold text-emerald-700">{{ productEditForm.status }}</span>
               </div>
             </div>
-            <div class="grid grid-cols-2 gap-2">
-              <div class="border border-gray-200 bg-gray-50 p-3"><p class="text-[10px] font-bold uppercase text-gray-400">단위</p><p class="mt-1 font-black text-gray-900">{{ selectedProduct.unit }}</p></div>
-              <div class="border border-gray-200 bg-gray-50 p-3"><p class="text-[10px] font-bold uppercase text-gray-400">단가</p><p class="mt-1 font-black text-gray-900">₩{{ selectedProduct.price.toLocaleString() }}</p></div>
-              <div class="border border-gray-200 bg-gray-50 p-3"><p class="text-[10px] font-bold uppercase text-gray-400">규격</p><p class="mt-1 font-black text-gray-900">{{ selectedProduct.spec }}</p></div>
-              <div class="border border-gray-200 bg-gray-50 p-3"><p class="text-[10px] font-bold uppercase text-gray-400">리드타임</p><p class="mt-1 font-black text-gray-900">{{ selectedProduct.leadTime }}</p></div>
+            <div class="space-y-4">
+              <label class="block text-[10px] font-bold uppercase text-gray-400">
+                제품명
+                <input
+                  v-model="productEditForm.name"
+                  type="text"
+                  class="mt-1.5 w-full border border-gray-300 bg-gray-50 px-3 py-2.5 text-xs font-bold text-gray-800 outline-none focus:border-[#004D3C]"
+                />
+              </label>
+              <div class="grid grid-cols-2 gap-3">
+                <label class="block text-[10px] font-bold uppercase text-gray-400">
+                  대분류
+                  <select
+                    :value="productEditForm.parentCategory"
+                    class="mt-1.5 w-full border border-gray-300 bg-gray-50 px-2 py-2.5 text-xs font-bold text-gray-800 outline-none focus:border-[#004D3C]"
+                    @change="handleDetailParentChange"
+                  >
+                    <option v-for="parent in parentCategoryOptions" :key="parent" :value="parent">{{ parent }}</option>
+                  </select>
+                </label>
+                <label class="block text-[10px] font-bold uppercase text-gray-400">
+                  소분류
+                  <select
+                    v-model="productEditForm.childCategory"
+                    class="mt-1.5 w-full border border-gray-300 bg-gray-50 px-2 py-2.5 text-xs font-bold text-gray-800 outline-none focus:border-[#004D3C]"
+                  >
+                    <option v-for="child in detailChildCategoryOptions" :key="child" :value="child">{{ child }}</option>
+                  </select>
+                </label>
+              </div>
+              <div class="grid grid-cols-2 gap-3">
+                <label class="block text-[10px] font-bold uppercase text-gray-400">
+                  단가
+                  <input
+                    v-model.number="productEditForm.price"
+                    type="number"
+                    min="0"
+                    class="mt-1.5 w-full border border-gray-300 bg-gray-50 px-3 py-2.5 text-xs font-bold text-gray-800 outline-none focus:border-[#004D3C]"
+                  />
+                </label>
+                <label class="block text-[10px] font-bold uppercase text-gray-400">
+                  상태
+                  <select
+                    v-model="productEditForm.status"
+                    class="mt-1.5 w-full border border-gray-300 bg-gray-50 px-2 py-2.5 text-xs font-bold text-gray-800 outline-none focus:border-[#004D3C]"
+                  >
+                    <option value="활성">활성</option>
+                    <option value="점검중">점검중</option>
+                    <option value="비활성">비활성</option>
+                  </select>
+                </label>
+              </div>
+              <div class="grid grid-cols-2 gap-3">
+                <label class="block text-[10px] font-bold uppercase text-gray-400">
+                  메인 거래처
+                  <input
+                    v-model="productEditForm.vendor"
+                    type="text"
+                    class="mt-1.5 w-full border border-gray-300 bg-gray-50 px-3 py-2.5 text-xs font-bold text-gray-800 outline-none focus:border-[#004D3C]"
+                  />
+                </label>
+                <label class="block text-[10px] font-bold uppercase text-gray-400">
+                  등록일
+                  <input
+                    v-model="productEditForm.regDate"
+                    type="text"
+                    class="mt-1.5 w-full border border-gray-300 bg-gray-50 px-3 py-2.5 text-xs font-bold text-gray-800 outline-none focus:border-[#004D3C]"
+                  />
+                </label>
+              </div>
             </div>
-            <div class="border border-gray-200 bg-gray-50 p-3">
+            <div class="border border-gray-200 bg-gray-50 p-4">
               <p class="text-[10px] font-bold uppercase text-gray-400">메인 계약처</p>
-              <div class="mt-2 flex items-center justify-between gap-2 text-xs font-bold text-gray-700">
-                <span>{{ selectedProduct.vendor }}</span>
+              <div class="mt-3 flex items-center justify-between gap-2 text-xs font-bold text-gray-700">
+                <span>{{ productEditForm.vendor }}</span>
                 <span class="bg-[#E6F2F0] px-2 py-1 text-[#004D3C]">메인 계약처</span>
               </div>
-              <div class="mt-2 flex justify-between text-xs">
+              <div class="mt-3 flex justify-between text-xs">
                 <span class="text-gray-500">계약가</span>
-                <strong class="text-[#004D3C]">₩{{ Math.round(selectedProduct.price * 0.95).toLocaleString() }}</strong>
+                <strong class="text-[#004D3C]">₩{{ Math.round(productEditForm.price * 0.95).toLocaleString() }}</strong>
               </div>
+            </div>
+            <div class="flex gap-2 pt-2">
+              <button
+                type="button"
+                class="flex-1 border border-[#004D3C] bg-[#004D3C] py-2 text-xs font-black text-white hover:bg-[#003d30]"
+                @click="saveProductDetail"
+              >
+                저장
+              </button>
+              <button
+                type="button"
+                class="flex-1 border border-gray-300 bg-white py-2 text-xs font-black text-gray-700 hover:bg-gray-50"
+                @click="resetProductDetail"
+              >
+                되돌리기
+              </button>
             </div>
           </div>
         </aside>


### PR DESCRIPTION
## 📌 요약
- 중앙관리자 상품 관리 영역에서 제품 마스터 조회/수정/등록 화면 UX를 개선하고, 관련 라우팅 및 페이지 이동 흐름을 정리했습니다.
- 제품 등록/상세 편집 UI를 의류 도메인(카테고리 2단계, 색상/사이즈 옵션) 기준으로 재구성했습니다.

<br><br>

## 🎯 작업 내용
- 제품 마스터 조회 화면 개선
- 카테고리 2단계(대분류/소분류) 필터 적용
- 더미데이터를 의류 도메인으로 교체
- 테이블 컬럼 정리(규격/단위 제거)
- 상단 `일괄 업로드` 버튼 제거
- 상세 패널 개선(수정 가능 폼 전환)
- 제품 상세에서 수정 가능한 입력 폼 제공
  (제품명, 대/소분류, 단가, 상태, 메인 거래처, 등록일)
- 저장/되돌리기 동작 추가
- 상세 내 리드타임 표시 제거
- 신규 제품 등록 페이지 신설 및 연동
- `/hq/products/new` 라우트 추가 및 `신규 제품 등록` 버튼 연결
- 등록 폼/요약 패널/가이드 섹션 구성
- 색상/사이즈 옵션 입력 UX 추가 및 단순화
  (선택 색상 공통 사이즈 적용 방식)
- 카테고리 추가/신규 제품 등록 하위 페이지에서
  좌측 사이드바 상품관리 메뉴 라우팅 복구 (`/hq/products`)
- 신규 등록 화면의 회색 중첩/겹침 이슈 UI 보정
  (섹션 분리, 여백/배경/경계 톤 정리)

<br><br>

## ✔️ 참고 사항
- 이번 작업은 프론트 UI/UX 및 화면 내 상태 처리 중심이며, 백엔드 API 연동/영속 저장은 범위에서 제외했습니다.

<br><br>

## ✔️ 관련 이슈

- Close #193 
