### PR TITLE
design: 본사 발주 목록에 거래처/기간/정렬 필터와 총 발주 요약 추가

### DIFF
--- a/src/stores/purchaseOrder.js
+++ b/src/stores/purchaseOrder.js
@@ -310,6 +310,10 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
   const selectedOrderId = ref(null)
   const activeStatusTab = ref('전체')
   const searchKeyword = ref('')
+  const vendorFilter = ref('')
+  const dateFrom = ref('')
+  const dateTo = ref('')
+  const sortBy = ref('latest') // 'latest' | 'oldest' | 'priceAsc' | 'priceDesc'
 
   // --- 게터(getters) ---
   const selectedOrder = computed(
@@ -332,8 +336,35 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
       )
     }
 
-    // 최신순 정렬
-    return [...list].sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
+    // 거래처 필터
+    if (vendorFilter.value) {
+      list = list.filter((o) => o.vendorId === vendorFilter.value)
+    }
+
+    // 기간 필터 (createdAt 의 YYYY-MM-DD 부분만 비교)
+    if (dateFrom.value) {
+      list = list.filter((o) => o.createdAt.slice(0, 10) >= dateFrom.value)
+    }
+    if (dateTo.value) {
+      list = list.filter((o) => o.createdAt.slice(0, 10) <= dateTo.value)
+    }
+
+    // 정렬 — 새 배열로 (원본 mutate 금지)
+    const sorted = [...list]
+    switch (sortBy.value) {
+      case 'oldest':
+        sorted.sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+        break
+      case 'priceAsc':
+        sorted.sort((a, b) => a.totalPrice - b.totalPrice)
+        break
+      case 'priceDesc':
+        sorted.sort((a, b) => b.totalPrice - a.totalPrice)
+        break
+      default:
+        sorted.sort((a, b) => b.createdAt.localeCompare(a.createdAt)) // 'latest'
+    }
+    return sorted
   })
 
   const statusCounts = computed(() => {
@@ -345,6 +376,36 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
       SHIPPING: all.filter((o) => o.status === 'SHIPPING').length,
       COMPLETED: all.filter((o) => o.status === 'COMPLETED').length,
       REJECTED: all.filter((o) => o.status === 'REJECTED').length,
+    }
+  })
+
+  // 거래처 필터 옵션 — 발주에 등장한 unique vendor 만, 한국어 이름 오름차순
+  const vendorOptions = computed(() => {
+    const seen = new Map()
+    for (const o of purchaseOrders.value) {
+      if (!seen.has(o.vendorId)) {
+        seen.set(o.vendorId, { id: o.vendorId, name: o.vendorName })
+      }
+    }
+    return Array.from(seen.values()).sort((a, b) => a.name.localeCompare(b.name, 'ko'))
+  })
+
+  // 통계 요약 — 거래처/기간 컨텍스트만 반영, 상태 탭/검색은 무시
+  // 상태 분포는 탭 카운트로 충분하므로 총 건수/금액만 노출
+  const summary = computed(() => {
+    let base = purchaseOrders.value
+    if (vendorFilter.value) {
+      base = base.filter((o) => o.vendorId === vendorFilter.value)
+    }
+    if (dateFrom.value) {
+      base = base.filter((o) => o.createdAt.slice(0, 10) >= dateFrom.value)
+    }
+    if (dateTo.value) {
+      base = base.filter((o) => o.createdAt.slice(0, 10) <= dateTo.value)
+    }
+    return {
+      totalCount: base.length,
+      totalPrice: base.reduce((sum, o) => sum + o.totalPrice, 0),
     }
   })
 
@@ -517,10 +578,16 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
     selectedOrderId,
     activeStatusTab,
     searchKeyword,
+    vendorFilter,
+    dateFrom,
+    dateTo,
+    sortBy,
     // getters
     selectedOrder,
     filteredOrders,
     statusCounts,
+    vendorOptions,
+    summary,
     warehouses,
     // actions
     selectOrder,

--- a/src/views/hq/HqPurchaseOrderView.vue
+++ b/src/views/hq/HqPurchaseOrderView.vue
@@ -240,6 +240,29 @@ const TruckIcon = IconBase([
     @logout="handleLogout"
   >
     <div class="flex flex-col gap-4">
+      <!-- 총 발주 요약 (거래처/기간 컨텍스트 반영) -->
+      <section
+        class="flex items-center gap-4 border border-gray-200 bg-white px-5 py-4 shadow-sm"
+      >
+        <div
+          class="flex h-12 w-12 shrink-0 items-center justify-center bg-[#E6F2F0] text-[#004D3C]"
+        >
+          <TruckIcon :size="22" />
+        </div>
+        <div class="min-w-0 flex-1">
+          <p class="text-[10px] font-bold uppercase tracking-wider text-gray-500">총 발주</p>
+          <p class="mt-0.5 truncate text-2xl font-black text-[#004D3C]">
+            ₩{{ poStore.summary.totalPrice.toLocaleString() }}
+          </p>
+        </div>
+        <div class="text-right">
+          <p class="text-[10px] font-bold uppercase tracking-wider text-gray-500">건수</p>
+          <p class="mt-0.5 text-xl font-black text-gray-700">
+            {{ poStore.summary.totalCount }}<span class="ml-0.5 text-xs font-bold">건</span>
+          </p>
+        </div>
+      </section>
+
       <!-- 상단 헤더 영역: 상태 탭 -->
       <section class="border border-gray-300 bg-white p-3 shadow-sm">
         <!-- 상태 탭 -->
@@ -306,6 +329,43 @@ const TruckIcon = IconBase([
                 새 발주
               </button>
             </div>
+          </div>
+
+          <!-- 필터 줄: 거래처 / 기간 / 정렬 -->
+          <div
+            class="flex flex-wrap items-center gap-2 border-b border-gray-200 bg-gray-50 px-3 py-2"
+          >
+            <select
+              v-model="poStore.vendorFilter"
+              class="border border-gray-300 bg-white px-2 py-1.5 text-xs outline-none focus:border-[#004D3C]"
+            >
+              <option value="">전체 거래처</option>
+              <option v-for="v in poStore.vendorOptions" :key="v.id" :value="v.id">
+                {{ v.name }}
+              </option>
+            </select>
+
+            <input
+              v-model="poStore.dateFrom"
+              type="date"
+              class="border border-gray-300 bg-white px-2 py-1.5 text-xs outline-none focus:border-[#004D3C]"
+            />
+            <span class="text-xs text-gray-400">~</span>
+            <input
+              v-model="poStore.dateTo"
+              type="date"
+              class="border border-gray-300 bg-white px-2 py-1.5 text-xs outline-none focus:border-[#004D3C]"
+            />
+
+            <select
+              v-model="poStore.sortBy"
+              class="ml-auto border border-gray-300 bg-white px-2 py-1.5 text-xs outline-none focus:border-[#004D3C]"
+            >
+              <option value="latest">최신순</option>
+              <option value="oldest">오래된순</option>
+              <option value="priceDesc">총금액 ↓</option>
+              <option value="priceAsc">총금액 ↑</option>
+            </select>
           </div>
 
           <div class="overflow-auto">


### PR DESCRIPTION
## 📌 요약
- 본사 발주 목록에 거래처·기간·정렬 필터와 총 발주 요약 카드 추가

<br><br>

## 🎯 작업 내용
- 거래처 select (발주에 등장한 거래처만 동적 노출), 기간 picker (`createdAt` 날짜 비교), 정렬 select (최신/오래된/총금액 ↑↓) 추가
- 페이지 최상단에 총 발주 요약 카드 (총액 + 건수)
- 카드는 거래처·기간만 반영, 상태 탭·검색은 미반영

<br><br>

## ✔️ 참고 사항
- 카드 = 분포 컨텍스트, 탭 = 좁힘 도구로 역할 분리
- 상태별 분포는 탭 카운트가 이미 제공

<br><br>

## ✔️ 관련 이슈
- Close #212 

<br><br>