### PR TITLE
design: 본사 발주 상세에 진행 이력 타임라인 추가

### DIFF
--- a/src/stores/purchaseOrder.js
+++ b/src/stores/purchaseOrder.js
@@ -37,6 +37,12 @@ const SEED_ORDERS = [
     totalPrice: 4500000,
     createdAt: '2026-04-15T09:30:00',
     updatedAt: '2026-04-17T14:20:00',
+    statusHistory: [
+      { status: 'PENDING', at: '2026-04-15T09:30:00', byName: '이선엽' },
+      { status: 'APPROVED', at: '2026-04-15T11:00:00', byName: '이선엽' },
+      { status: 'SHIPPING', at: '2026-04-16T08:30:00', byName: '이선엽' },
+      { status: 'COMPLETED', at: '2026-04-17T14:20:00', byName: '이선엽' },
+    ],
     items: [
       {
         id: 'PI-001-1',
@@ -62,6 +68,10 @@ const SEED_ORDERS = [
     totalPrice: 2400000,
     createdAt: '2026-04-16T10:15:00',
     updatedAt: '2026-04-16T11:00:00',
+    statusHistory: [
+      { status: 'PENDING', at: '2026-04-16T10:15:00', byName: '이선엽' },
+      { status: 'APPROVED', at: '2026-04-16T11:00:00', byName: '이선엽' },
+    ],
     items: [
       {
         id: 'PI-002-1',
@@ -96,6 +106,11 @@ const SEED_ORDERS = [
     totalPrice: 5800000,
     createdAt: '2026-04-16T13:00:00',
     updatedAt: '2026-04-17T08:30:00',
+    statusHistory: [
+      { status: 'PENDING', at: '2026-04-16T13:00:00', byName: '이선엽' },
+      { status: 'APPROVED', at: '2026-04-16T18:00:00', byName: '이선엽' },
+      { status: 'SHIPPING', at: '2026-04-17T08:30:00', byName: '이선엽' },
+    ],
     items: [
       {
         id: 'PI-003-1',
@@ -121,6 +136,9 @@ const SEED_ORDERS = [
     totalPrice: 1250000,
     createdAt: '2026-04-17T09:00:00',
     updatedAt: '2026-04-17T09:00:00',
+    statusHistory: [
+      { status: 'PENDING', at: '2026-04-17T09:00:00', byName: '이선엽' },
+    ],
     items: [
       {
         id: 'PI-004-1',
@@ -147,6 +165,10 @@ const SEED_ORDERS = [
     cancelReason: '거래처 단가 변경으로 발주 취소',
     createdAt: '2026-04-17T11:30:00',
     updatedAt: '2026-04-17T14:00:00',
+    statusHistory: [
+      { status: 'PENDING', at: '2026-04-17T11:30:00', byName: '이선엽' },
+      { status: 'REJECTED', at: '2026-04-17T14:00:00', byName: '이선엽' },
+    ],
     items: [
       {
         id: 'PI-005-1',
@@ -172,6 +194,9 @@ const SEED_ORDERS = [
     totalPrice: 3200000,
     createdAt: '2026-04-18T08:45:00',
     updatedAt: '2026-04-18T08:45:00',
+    statusHistory: [
+      { status: 'PENDING', at: '2026-04-18T08:45:00', byName: '이선엽' },
+    ],
     items: [
       {
         id: 'PI-006-1',
@@ -206,6 +231,10 @@ const SEED_ORDERS = [
     totalPrice: 880000,
     createdAt: '2026-04-18T10:20:00',
     updatedAt: '2026-04-18T15:30:00',
+    statusHistory: [
+      { status: 'PENDING', at: '2026-04-18T10:20:00', byName: '이선엽' },
+      { status: 'APPROVED', at: '2026-04-18T15:30:00', byName: '이선엽' },
+    ],
     items: [
       {
         id: 'PI-007-1',
@@ -231,6 +260,9 @@ const SEED_ORDERS = [
     totalPrice: 1950000,
     createdAt: '2026-04-19T09:15:00',
     updatedAt: '2026-04-19T09:15:00',
+    statusHistory: [
+      { status: 'PENDING', at: '2026-04-19T09:15:00', byName: '이선엽' },
+    ],
     items: [
       {
         id: 'PI-008-1',
@@ -256,6 +288,11 @@ const SEED_ORDERS = [
     totalPrice: 450000,
     createdAt: '2026-04-19T11:00:00',
     updatedAt: '2026-04-19T16:00:00',
+    statusHistory: [
+      { status: 'PENDING', at: '2026-04-19T11:00:00', byName: '이선엽' },
+      { status: 'APPROVED', at: '2026-04-19T13:30:00', byName: '이선엽' },
+      { status: 'SHIPPING', at: '2026-04-19T16:00:00', byName: '이선엽' },
+    ],
     items: [
       {
         id: 'PI-009-1',
@@ -281,6 +318,9 @@ const SEED_ORDERS = [
     totalPrice: 650000,
     createdAt: '2026-04-20T08:00:00',
     updatedAt: '2026-04-20T08:00:00',
+    statusHistory: [
+      { status: 'PENDING', at: '2026-04-20T08:00:00', byName: '이선엽' },
+    ],
     items: [
       {
         id: 'PI-010-1',
@@ -442,6 +482,7 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
       totalPrice,
       createdAt: now,
       updatedAt: now,
+      statusHistory: [{ status: 'PENDING', at: now, byName: memberName }],
       items: items.map((item, idx) => ({
         id: `PI-${Date.now()}-${idx + 1}`,
         productId: item.productId,
@@ -500,9 +541,14 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
       return
     }
 
+    const now = new Date().toISOString()
     order.status = 'REJECTED'
     order.cancelReason = reason
-    order.updatedAt = new Date().toISOString()
+    order.statusHistory = [
+      ...(order.statusHistory ?? []),
+      { status: 'REJECTED', at: now, byName: order.memberName },
+    ]
+    order.updatedAt = now
     saveToStorage()
   }
 
@@ -510,8 +556,13 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
     const order = purchaseOrders.value.find((o) => o.id === id)
     if (!order || order.status !== 'PENDING') return
 
+    const now = new Date().toISOString()
     order.status = 'APPROVED'
-    order.updatedAt = new Date().toISOString()
+    order.statusHistory = [
+      ...(order.statusHistory ?? []),
+      { status: 'APPROVED', at: now, byName: order.memberName },
+    ]
+    order.updatedAt = now
     saveToStorage()
   }
 
@@ -519,8 +570,13 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
     const order = purchaseOrders.value.find((o) => o.id === id)
     if (!order || order.status !== 'APPROVED') return
 
+    const now = new Date().toISOString()
     order.status = 'SHIPPING'
-    order.updatedAt = new Date().toISOString()
+    order.statusHistory = [
+      ...(order.statusHistory ?? []),
+      { status: 'SHIPPING', at: now, byName: order.memberName },
+    ]
+    order.updatedAt = now
     saveToStorage()
   }
 
@@ -528,8 +584,13 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
     const order = purchaseOrders.value.find((o) => o.id === id)
     if (!order || order.status !== 'SHIPPING') return
 
+    const now = new Date().toISOString()
     order.status = 'COMPLETED'
-    order.updatedAt = new Date().toISOString()
+    order.statusHistory = [
+      ...(order.statusHistory ?? []),
+      { status: 'COMPLETED', at: now, byName: order.memberName },
+    ]
+    order.updatedAt = now
     saveToStorage()
   }
 
@@ -551,6 +612,10 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
         purchaseOrders.value = parsed.map((o) => ({
           ...o,
           cancelReason: o.cancelReason ?? '',
+          statusHistory:
+            o.statusHistory && o.statusHistory.length > 0
+              ? o.statusHistory
+              : [{ status: o.status, at: o.createdAt, byName: o.memberName }],
         }))
         return true
       }

--- a/src/views/hq/HqPurchaseOrderView.vue
+++ b/src/views/hq/HqPurchaseOrderView.vue
@@ -137,6 +137,29 @@ function formatDate(iso) {
   return iso.replace('T', ' ').slice(0, 16)
 }
 
+// 진행 이력 타임라인 — 점/텍스트 색상
+function historyDotClass(status) {
+  const map = {
+    PENDING: 'bg-amber-500',
+    APPROVED: 'bg-emerald-500',
+    SHIPPING: 'bg-blue-500',
+    COMPLETED: 'bg-gray-700',
+    REJECTED: 'bg-red-600',
+  }
+  return map[status] ?? 'bg-gray-400'
+}
+
+function historyTextClass(status) {
+  const map = {
+    PENDING: 'text-amber-700',
+    APPROVED: 'text-emerald-700',
+    SHIPPING: 'text-blue-600',
+    COMPLETED: 'text-gray-700',
+    REJECTED: 'text-red-700',
+  }
+  return map[status] ?? 'text-gray-700'
+}
+
 // ─── 발주 작성/수정 페이지 라우팅 ──────────────────────────────────────────
 function goCreatePage() {
   router.push({ name: 'hq-purchase-order-new' })
@@ -532,6 +555,35 @@ const TruckIcon = IconBase([
                   </tr>
                 </tfoot>
               </table>
+            </section>
+
+            <!-- 진행 이력 타임라인 -->
+            <section v-if="poStore.selectedOrder.statusHistory?.length">
+              <p class="mb-2 text-[10px] font-black uppercase text-gray-400">진행 이력</p>
+              <ol class="ml-2">
+                <li
+                  v-for="(h, idx) in poStore.selectedOrder.statusHistory"
+                  :key="idx"
+                  class="relative pb-3 pl-5 last:pb-0"
+                >
+                  <!-- 점 -->
+                  <span
+                    class="absolute left-0 top-1 block h-2.5 w-2.5"
+                    :class="historyDotClass(h.status)"
+                  />
+                  <!-- 다음 항목까지 잇는 세로선 (마지막 항목 제외) -->
+                  <span
+                    v-if="idx < poStore.selectedOrder.statusHistory.length - 1"
+                    class="absolute bottom-0 left-[4px] top-3.5 w-px bg-gray-300"
+                  />
+                  <p class="text-[11px] font-black" :class="historyTextClass(h.status)">
+                    {{ statusLabel(h.status) }}
+                  </p>
+                  <p class="text-[10px] text-gray-500">
+                    {{ formatDate(h.at) }} · {{ h.byName }}
+                  </p>
+                </li>
+              </ol>
             </section>
           </div>
 


### PR DESCRIPTION
## 📌 요약
- 본사 발주 상세에 상태 진행 이력 타임라인 추가

<br><br>

## 🎯 작업 내용
- `PurchaseOrder`에 `statusHistory` 배열 추가 (진입 시각·담당자 누적 기록)
- 모든 상태 전이 액션이 항목 push, `updateOrder`는 기록 대상 제외
- SEED 비-PENDING 발주에 흐름 채움, 구버전 localStorage는 normalize 단계에서 현재 상태 1줄 fallback
- 상세 패널 품목 테이블 아래 점+세로선 타임라인(`ol`) 추가

<br><br>

## ✔️ 참고 사항
- 타임라인 점 색은 `statusClass` 색계와 일관성 유지
- `createdAt`/`updatedAt`만으로 추적 불가하던 흐름 보강

<br><br>

## ✔️ 관련 이슈
- Close #213 

<br><br>