### PR TITLE
226 design whs 004 창고 보유 재고 조회 페이지 구현

### DIFF
--- a/src/config/roleMenus.js
+++ b/src/config/roleMenus.js
@@ -4,9 +4,7 @@ export const roleMenus = {
       label: '대시보드',
       path: '/hq/dashboard',
       icon: 'layout',
-      children: [
-        { label: '운영 현황', path: '/hq/dashboard' },
-      ],
+      children: [{ label: '운영 현황', path: '/hq/dashboard' }],
     },
     {
       label: '재고 관리',
@@ -81,17 +79,13 @@ export const roleMenus = {
       label: 'AI 리포트',
       path: '/hq/ai-report',
       icon: 'chart',
-      children: [
-        { label: 'AI 리포트', path: '/hq/ai-report' },
-      ],
+      children: [{ label: 'AI 리포트', path: '/hq/ai-report' }],
     },
     {
       label: 'ESG 대시보드',
       path: '/hq/esg',
       icon: 'leaf',
-      children: [
-        { label: '친환경 발자국 현황판', path: '/hq/esg' },
-      ],
+      children: [{ label: '친환경 발자국 현황판', path: '/hq/esg' }],
     },
   ],
   store: [
@@ -102,14 +96,17 @@ export const roleMenus = {
     { label: 'AI 리포트', path: '/store/ai-report', icon: 'chart' },
   ],
   warehouse: [
-    { label: '대시보드', path: '/warehouse/dashboard', icon: 'layout' },
+    {
+      label: '대시보드',
+      path: '/warehouse/dashboard',
+      icon: 'layout',
+      children: [{ label: '창고 대시보드', path: '/warehouse/dashboard' }],
+    },
     {
       label: '재고 관리',
       path: '/warehouse/inventory',
       icon: 'warehouse',
-      children: [
-        { label: '창고 재고 조회', path: '/warehouse/inventory' },
-      ],
+      children: [{ label: '창고 재고 조회', path: '/warehouse/inventory' }],
     },
     {
       label: '입/출고 관리',

--- a/src/config/roleMenus.js
+++ b/src/config/roleMenus.js
@@ -102,9 +102,23 @@ export const roleMenus = {
     { label: 'AI 리포트', path: '/store/ai-report', icon: 'chart' },
   ],
   warehouse: [
-    { label: '창고 재고 관리', path: '/warehouse/inventory', icon: 'warehouse' },
-    { label: '입고 관리', path: '/warehouse/inbound', icon: 'check' },
-    { label: '출고 관리', path: '/warehouse/outbound', icon: 'truck' },
+    {
+      label: '재고 관리',
+      path: '/warehouse/inventory',
+      icon: 'warehouse',
+      children: [
+        { label: '창고 재고 조회', path: '/warehouse/inventory' },
+      ],
+    },
+    {
+      label: '입/출고 관리',
+      path: '/warehouse/inbound',
+      icon: 'truck',
+      children: [
+        { label: '입고 관리', path: '/warehouse/inbound' },
+        { label: '출고 관리', path: '/warehouse/outbound' },
+      ],
+    },
   ],
 }
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -13,6 +13,7 @@ import StoreInboundView from '@/views/store/StoreInboundView.vue'
 import StoreAiReportView from '@/views/store/StoreAiReportView.vue'
 
 import WarehouseInventoryView from '@/views/warehouse/WarehouseInventoryView.vue'
+import WarehouseInventorySkuDetailView from '@/views/warehouse/WarehouseInventorySkuDetailView.vue'
 import WarehouseInboundView from '@/views/warehouse/WarehouseInboundView.vue'
 import WarehouseOutboundView from '@/views/warehouse/WarehouseOutboundView.vue'
 
@@ -20,6 +21,7 @@ import OperationStatusView from '@/views/hq/dashboard/OperationStatusView.vue'
 
 import HqCompanyWideInventoryView from '@/views/hq/inventory/HqCompanyWideInventoryView.vue'
 import HqWarehouseInventoryComparisonView from '@/views/hq/inventory/HqWarehouseInventoryComparisonView.vue'
+import HqCompanyWideInventorySkuDetailView from '@/views/hq/inventory/HqCompanyWideInventorySkuDetailView.vue'
 import HqOrderManagementView from '@/views/hq/HqOrderManagementView.vue'
 import HqProductManagementView from '@/views/hq/HqProductManagementView.vue'
 import HqInfrastructureManagementView from '@/views/hq/HqInfrastructureManagementView.vue'
@@ -50,6 +52,12 @@ const router = createRouter({
 
     { path: '/hq/inventory', redirect: { name: 'hq-inventory-company-wide' } },
     { path: '/hq/inventory/company-wide', name: 'hq-inventory-company-wide', component: HqCompanyWideInventoryView, meta: { requiresAuth: true, role: 'hq' } },
+    {
+      path: '/hq/inventory/company-wide/:itemCode/skus',
+      name: 'hq-inventory-sku-detail',
+      component: HqCompanyWideInventorySkuDetailView,
+      meta: { requiresAuth: true, role: 'hq' },
+    },
     { path: '/hq/inventory/warehouse-comparison', name: 'hq-inventory-warehouse-comparison', component: HqWarehouseInventoryComparisonView, meta: { requiresAuth: true, role: 'hq' } },
     { path: '/hq/orders', name: 'hq-orders', component: HqOrderManagementView, meta: { requiresAuth: true, role: 'hq' } },
     { path: '/hq/products', name: 'hq-products', component: HqProductManagementView, meta: { requiresAuth: true, role: 'hq' } },
@@ -96,6 +104,12 @@ const router = createRouter({
       path: '/warehouse/inventory',
       name: 'wh-inventory',
       component: WarehouseInventoryView,
+      meta: { requiresAuth: true, role: 'warehouse' },
+    },
+    {
+      path: '/warehouse/inventory/:itemCode/skus',
+      name: 'wh-inventory-sku-detail',
+      component: WarehouseInventorySkuDetailView,
       meta: { requiresAuth: true, role: 'warehouse' },
     },
     {

--- a/src/views/hq/inventory/HqCompanyWideInventorySkuDetailView.vue
+++ b/src/views/hq/inventory/HqCompanyWideInventorySkuDetailView.vue
@@ -1,0 +1,193 @@
+<script setup>
+import { computed, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import AppLayout from '@/components/common/AppLayout.vue'
+import { roleMenus } from '@/config/roleMenus.js'
+import { useAuthStore } from '@/stores/auth.js'
+
+const route = useRoute()
+const router = useRouter()
+const auth = useAuthStore()
+
+const hqMenus = roleMenus.hq
+const inventoryMenus = roleMenus.hq.find(menu => menu.label === '재고 관리')?.children ?? []
+
+const activeTopMenu = computed(() => '재고 관리')
+const activeSideMenu = ref('전사 재고 조회')
+
+const colorOptions = ['검정', '흰색', '그레이', '아이보리']
+const colorCodeMap = { 검정: 'BLK', 흰색: 'WHT', 그레이: 'GRY', 아이보리: 'IVR' }
+const sizeOptions = ['XS', 'S', 'M', 'L', 'XL']
+
+const itemCode = computed(() => String(route.params.itemCode ?? route.query.itemCode ?? ''))
+const itemName = computed(() => String(route.query.itemName ?? '선택 품목'))
+const parentCategory = computed(() => String(route.query.parentCategory ?? '-'))
+const childCategory = computed(() => String(route.query.childCategory ?? '-'))
+const locationType = computed(() => String(route.query.locationType ?? '-'))
+const locationName = computed(() => String(route.query.locationName ?? '-'))
+const filterLocationType = computed(() => {
+  const queryType = typeof route.query.type === 'string' ? route.query.type : ''
+  return queryType === '창고' ? '창고' : '매장'
+})
+const filterLocations = computed(() => {
+  if (typeof route.query.locations !== 'string') return []
+  return route.query.locations.split(',').map(location => location.trim()).filter(Boolean)
+})
+const filterLocationChips = computed(() =>
+  filterLocations.value.length > 3 ? filterLocations.value.slice(0, 2) : filterLocations.value,
+)
+const hiddenFilterLocationCount = computed(() =>
+  filterLocations.value.length > 3 ? filterLocations.value.length - 2 : 0,
+)
+const filterScopeLabel = computed(() =>
+  filterLocations.value.length > 0 ? `${filterLocationType.value} 기준` : `전체${filterLocationType.value}`,
+)
+
+const seed = computed(() =>
+  `${itemCode.value}-${locationName.value}`.split('').reduce((sum, char) => sum + char.charCodeAt(0), 0),
+)
+
+const skuRows = computed(() =>
+  colorOptions.flatMap((color, colorIndex) =>
+    sizeOptions.map((size, sizeIndex) => {
+      const actualStock = 14 + ((seed.value + colorIndex * 19 + sizeIndex * 7) % 85)
+      const reservedStock = (seed.value + colorIndex * 11 + sizeIndex * 5) % 14
+      const availableStock = Math.max(actualStock - reservedStock, 0)
+      const safetyStock = 20 + (sizeIndex % 3) * 6
+      const status = availableStock === 0 ? '품절' : availableStock < safetyStock ? '부족' : '정상'
+      const updatedAt = `2026.04.${String(25 - (colorIndex % 3)).padStart(2, '0')} ${String(10 + sizeIndex).padStart(2, '0')}:40`
+
+      return {
+        skuCode: `${itemCode.value}-${colorCodeMap[color]}-${size}`,
+        color,
+        size,
+        actualStock,
+        availableStock,
+        safetyStock,
+        status,
+        updatedAt,
+      }
+    }),
+  ),
+)
+
+const statusClass = (status) => ({
+  정상: 'bg-[#EBF5F5] text-black',
+  부족: 'bg-amber-50 text-amber-700',
+  품절: 'bg-red-50 text-red-700',
+})[status] ?? 'bg-gray-100 text-gray-600'
+
+const backQuery = computed(() => ({
+  type: typeof route.query.type === 'string' ? route.query.type : undefined,
+  locations: typeof route.query.locations === 'string' ? route.query.locations : undefined,
+  parent: typeof route.query.parent === 'string' ? route.query.parent : undefined,
+  child: typeof route.query.child === 'string' ? route.query.child : undefined,
+  status: typeof route.query.status === 'string' ? route.query.status : undefined,
+  search: typeof route.query.search === 'string' ? route.query.search : undefined,
+}))
+
+function goBackToInventory() {
+  router.push({
+    name: 'hq-inventory-company-wide',
+    query: backQuery.value,
+  })
+}
+
+function handleLogout() {
+  auth.logout()
+  router.push('/login')
+}
+</script>
+
+<template>
+  <AppLayout
+    :active-top-menu="activeTopMenu"
+    :top-menus="hqMenus"
+    :side-menus="inventoryMenus"
+    v-model:active-side-menu="activeSideMenu"
+    @logout="handleLogout"
+  >
+    <div class="flex flex-col gap-4">
+      <section class="border border-gray-200 bg-white p-4 shadow-sm">
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p class="text-[10px] font-black uppercase tracking-[0.16em] text-gray-400">SKU Inventory</p>
+            <h1 class="mt-1 text-lg font-black text-gray-900">SKU 재고 상세</h1>
+            <p class="mt-2 text-sm font-bold text-gray-700">{{ itemName }}</p>
+            <p class="mt-1 text-xs font-bold text-gray-500">
+              {{ itemCode }} · {{ parentCategory }} &gt; {{ childCategory }}
+            </p>
+            <p class="mt-1 text-xs font-bold text-gray-500">
+              조회 범위: {{ locationName }}
+            </p>
+            <div class="mt-2 flex flex-wrap items-center gap-1.5">
+              <span class="inline-flex items-center bg-[#EBF5F5] px-2 py-1 text-[11px] font-black text-black">
+                집계 유형: {{ locationType }}
+              </span>
+              <span class="inline-flex items-center bg-gray-100 px-2 py-1 text-[11px] font-black text-gray-700">
+                조회 기준: {{ filterScopeLabel }}
+              </span>
+              <template v-if="filterLocations.length > 0">
+                <span
+                  v-for="location in filterLocationChips"
+                  :key="location"
+                  class="inline-flex items-center bg-white px-2 py-1 text-[11px] font-black text-gray-700 ring-1 ring-gray-200"
+                >
+                  {{ location }}
+                </span>
+                <span
+                  v-if="hiddenFilterLocationCount > 0"
+                  class="inline-flex items-center bg-gray-100 px-2 py-1 text-[11px] font-black text-gray-600"
+                >
+                  외 {{ hiddenFilterLocationCount }}개
+                </span>
+              </template>
+            </div>
+          </div>
+          <button
+            type="button"
+            class="h-9 border border-gray-300 bg-white px-4 text-xs font-black text-gray-700 hover:bg-gray-50"
+            @click="goBackToInventory"
+          >
+            목록으로
+          </button>
+        </div>
+      </section>
+
+      <section class="min-h-0 border border-gray-200 bg-white shadow-sm">
+        <div class="overflow-x-auto">
+          <table class="min-w-[980px] w-full border-collapse text-left text-xs">
+            <thead class="bg-gray-50 text-[10px] uppercase tracking-[0.12em] text-gray-500">
+              <tr>
+                <th class="px-3 py-3 font-black">SKU 코드</th>
+                <th class="px-3 py-3 font-black">색상</th>
+                <th class="px-3 py-3 font-black">사이즈</th>
+                <th class="px-3 py-3 text-right font-black">실재고</th>
+                <th class="px-3 py-3 text-right font-black">가용재고</th>
+                <th class="px-3 py-3 text-right font-black">안전재고</th>
+                <th class="px-3 py-3 text-center font-black">상태</th>
+                <th class="px-3 py-3 font-black">최종 업데이트</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100">
+              <tr v-for="sku in skuRows" :key="sku.skuCode">
+                <td class="px-3 py-3 font-mono font-bold text-gray-600">{{ sku.skuCode }}</td>
+                <td class="px-3 py-3 font-bold text-gray-800">{{ sku.color }}</td>
+                <td class="px-3 py-3 font-black text-gray-900">{{ sku.size }}</td>
+                <td class="px-3 py-3 text-right font-black text-gray-900">{{ sku.actualStock.toLocaleString() }}</td>
+                <td class="px-3 py-3 text-right font-black text-gray-900">{{ sku.availableStock.toLocaleString() }}</td>
+                <td class="px-3 py-3 text-right font-bold text-gray-500">{{ sku.safetyStock.toLocaleString() }}</td>
+                <td class="px-3 py-3 text-center">
+                  <span class="inline-flex min-w-12 justify-center px-2 py-1 text-[11px] font-black" :class="statusClass(sku.status)">
+                    {{ sku.status }}
+                  </span>
+                </td>
+                <td class="px-3 py-3 font-bold text-gray-500">{{ sku.updatedAt }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  </AppLayout>
+</template>

--- a/src/views/hq/inventory/HqCompanyWideInventoryView.vue
+++ b/src/views/hq/inventory/HqCompanyWideInventoryView.vue
@@ -1,11 +1,12 @@
 <script setup>
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
 
 const router = useRouter()
+const route = useRoute()
 const auth = useAuthStore()
 const hqMenus = roleMenus.hq
 const inventoryMenus = roleMenus.hq.find(menu => menu.label === '재고 관리')?.children ?? []
@@ -34,6 +35,8 @@ const locationOptions = {
   창고: ['인천 제1창고', '이천 풀필먼트', '부산 물류창고', '대전 허브창고'],
 }
 
+const locationTypeOptions = ['매장', '창고']
+
 const inventoryData = [
   { itemCode: 'SPA-TOP-001', parentCategory: '상의', childCategory: '반팔', itemName: '코튼 베이직 반팔 티셔츠', locationType: '매장', locationName: '강남 플래그십', actualStock: 184, availableStock: 172, safetyStock: 60, status: '정상', updatedAt: '2026.04.22 09:20' },
   { itemCode: 'SPA-TOP-002', parentCategory: '상의', childCategory: '긴팔', itemName: '슬림핏 긴팔 티셔츠', locationType: '매장', locationName: '홍대 스토어', actualStock: 38, availableStock: 32, safetyStock: 45, status: '부족', updatedAt: '2026.04.22 09:10' },
@@ -58,6 +61,28 @@ const childCategoryOptions = computed(() =>
 
 const currentLocationOptions = computed(() => locationOptions[locationType.value])
 
+const parseQueryList = (value) => {
+  if (typeof value !== 'string') return []
+  return value.split(',').map(v => v.trim()).filter(Boolean)
+}
+
+const initializeFiltersFromQuery = () => {
+  const queryType = typeof route.query.type === 'string' ? route.query.type : ''
+  locationType.value = locationTypeOptions.includes(queryType) ? queryType : '매장'
+
+  selectedParentCategory.value = typeof route.query.parent === 'string' ? route.query.parent : ''
+  selectedChildCategory.value = typeof route.query.child === 'string' ? route.query.child : ''
+  selectedStatus.value = typeof route.query.status === 'string' ? route.query.status : ''
+  searchTerm.value = typeof route.query.search === 'string' ? route.query.search : ''
+
+  const queryLocations = parseQueryList(route.query.locations)
+  selectedLocations.value = queryLocations.filter(location =>
+    locationOptions[locationType.value].includes(location),
+  )
+}
+
+initializeFiltersFromQuery()
+
 const isAllLocationSelected = computed(() =>
   currentLocationOptions.value.length > 0
   && currentLocationOptions.value.every(location => selectedLocations.value.includes(location)),
@@ -71,7 +96,7 @@ const hiddenLocationCount = computed(() =>
   selectedLocations.value.length >= 3 ? selectedLocations.value.length - 1 : 0,
 )
 
-const filteredInventory = computed(() => {
+const locationScopedInventory = computed(() => {
   const keyword = searchTerm.value.trim().toLowerCase()
 
   return inventoryData.filter((item) => {
@@ -79,12 +104,46 @@ const filteredInventory = computed(() => {
     const matchesLocation = selectedLocations.value.length === 0 || selectedLocations.value.includes(item.locationName)
     const matchesParentCategory = !selectedParentCategory.value || item.parentCategory === selectedParentCategory.value
     const matchesChildCategory = !selectedChildCategory.value || item.childCategory === selectedChildCategory.value
-    const matchesStatus = !selectedStatus.value || item.status === selectedStatus.value
     const matchesKeyword = !keyword || [item.itemCode, item.itemName, item.locationName].join(' ').toLowerCase().includes(keyword)
 
-    return matchesType && matchesLocation && matchesParentCategory && matchesChildCategory && matchesStatus && matchesKeyword
+    return matchesType && matchesLocation && matchesParentCategory && matchesChildCategory && matchesKeyword
   })
 })
+
+const aggregatedInventory = computed(() => {
+  const grouped = new Map()
+
+  locationScopedInventory.value.forEach((item) => {
+    const existing = grouped.get(item.itemCode)
+    if (!existing) {
+      grouped.set(item.itemCode, {
+        itemCode: item.itemCode,
+        parentCategory: item.parentCategory,
+        childCategory: item.childCategory,
+        itemName: item.itemName,
+        actualStock: item.actualStock,
+        availableStock: item.availableStock,
+        safetyStock: item.safetyStock,
+        updatedAt: item.updatedAt,
+      })
+      return
+    }
+
+    existing.actualStock += item.actualStock
+    existing.availableStock += item.availableStock
+    existing.safetyStock += item.safetyStock
+    if (item.updatedAt > existing.updatedAt) existing.updatedAt = item.updatedAt
+  })
+
+  return [...grouped.values()].map((item) => ({
+    ...item,
+    status: item.availableStock === 0 ? '품절' : item.availableStock < item.safetyStock ? '부족' : '정상',
+  }))
+})
+
+const filteredInventory = computed(() =>
+  aggregatedInventory.value.filter((item) => !selectedStatus.value || item.status === selectedStatus.value),
+)
 
 const locationSummary = computed(() => {
   if (selectedLocations.value.length === 0) return `전체 ${locationType.value}`
@@ -120,6 +179,27 @@ const clearLocations = () => {
 
 const removeLocation = (location) => {
   selectedLocations.value = selectedLocations.value.filter(selectedLocation => selectedLocation !== location)
+}
+
+const moveToSkuDetail = (item) => {
+  router.push({
+    name: 'hq-inventory-sku-detail',
+    params: { itemCode: item.itemCode },
+    query: {
+      itemCode: item.itemCode,
+      itemName: item.itemName,
+      parentCategory: item.parentCategory,
+      childCategory: item.childCategory,
+      locationType: locationType.value,
+      locationName: locationSummary.value,
+      type: locationType.value,
+      locations: selectedLocations.value.length > 0 ? selectedLocations.value.join(',') : undefined,
+      parent: selectedParentCategory.value || undefined,
+      child: selectedChildCategory.value || undefined,
+      status: selectedStatus.value || undefined,
+      search: searchTerm.value || undefined,
+    },
+  })
 }
 
 const handleDocumentClick = (event) => {
@@ -329,7 +409,6 @@ function handleLogout() {
                 <th class="px-3 py-3 font-black">품목 코드</th>
                 <th class="px-3 py-3 font-black">카테고리</th>
                 <th class="px-3 py-3 font-black">품목명</th>
-                <th class="px-3 py-3 font-black">위치</th>
                 <th class="px-3 py-3 text-right font-black">실제고</th>
                 <th class="px-3 py-3 text-right font-black">가용재고</th>
                 <th class="px-3 py-3 text-right font-black">안전재고</th>
@@ -338,11 +417,15 @@ function handleLogout() {
               </tr>
             </thead>
             <tbody class="divide-y divide-gray-100">
-              <tr v-for="item in filteredInventory" :key="`${item.itemCode}-${item.locationName}`" class="hover:bg-[#EBF5F5]/60">
+              <tr
+                v-for="item in filteredInventory"
+                :key="item.itemCode"
+                class="cursor-pointer hover:bg-[#EBF5F5]/60"
+                @click="moveToSkuDetail(item)"
+              >
                 <td class="px-3 py-3 font-mono font-bold text-gray-500">{{ item.itemCode }}</td>
                 <td class="px-3 py-3 font-bold text-gray-800">{{ item.parentCategory }} &gt; {{ item.childCategory }}</td>
                 <td class="px-3 py-3 font-bold text-gray-900">{{ item.itemName }}</td>
-                <td class="px-3 py-3 text-gray-700">{{ item.locationType }}: {{ item.locationName }}</td>
                 <td class="px-3 py-3 text-right font-black text-gray-900">{{ item.actualStock.toLocaleString() }}</td>
                 <td class="px-3 py-3 text-right font-black text-gray-900">{{ item.availableStock.toLocaleString() }}</td>
                 <td class="px-3 py-3 text-right font-bold text-gray-500">{{ item.safetyStock.toLocaleString() }}</td>
@@ -354,7 +437,7 @@ function handleLogout() {
                 <td class="px-3 py-3 font-bold text-gray-500">{{ item.updatedAt }}</td>
               </tr>
               <tr v-if="filteredInventory.length === 0">
-                <td colspan="9" class="px-3 py-14 text-center text-sm font-bold text-gray-400">
+                <td colspan="8" class="px-3 py-14 text-center text-sm font-bold text-gray-400">
                   조건에 맞는 전사 재고가 없습니다.
                 </td>
               </tr>

--- a/src/views/warehouse/WarehouseDashboardView.vue
+++ b/src/views/warehouse/WarehouseDashboardView.vue
@@ -16,8 +16,10 @@ const router = useRouter()
 const auth = useAuthStore()
 const poStore = usePurchaseOrderStore()
 
-const sideMenus = roleMenus.warehouse
-const activeSideMenu = ref('대시보드')
+const topMenus = roleMenus.warehouse
+const sideMenus = roleMenus.warehouse.find((menu) => menu.label === '대시보드')?.children ?? []
+const activeTopMenu = computed(() => '대시보드')
+const activeSideMenu = ref('창고 대시보드')
 
 function handleLogout() {
   auth.logout()
@@ -190,7 +192,8 @@ function formatDate(iso) {
 
 <template>
   <AppLayout
-    active-top-menu="대시보드"
+    :active-top-menu="activeTopMenu"
+    :top-menus="topMenus"
     :side-menus="sideMenus"
     v-model:active-side-menu="activeSideMenu"
     @logout="handleLogout"

--- a/src/views/warehouse/WarehouseInboundView.vue
+++ b/src/views/warehouse/WarehouseInboundView.vue
@@ -11,11 +11,9 @@ const auth = useAuthStore()
 const inbound = useInboundStore()
 
 // ─── 레이아웃 ────────────────────────────────────────────────────────────────
-const sideMenus = roleMenus.warehouse
-const activeSideMenu = ref('입고 관리')
 const activeSideMenu = ref('입고 관리')
 const topMenus = roleMenus.warehouse
-const sideMenus = roleMenus.warehouse.find((menu) => menu.label === '입/출고관리')?.children ?? []
+const sideMenus = roleMenus.warehouse.find((menu) => menu.label === '입/출고 관리')?.children ?? []
 
 function handleLogout() {
   auth.logout()
@@ -183,7 +181,7 @@ const CheckIcon = IconBase([{ tag: 'polyline', attrs: { points: '20 6 9 17 4 12'
 
 <template>
   <AppLayout
-    active-top-menu="입/출고관리"
+    active-top-menu="입/출고 관리"
     :top-menus="topMenus"
     :side-menus="sideMenus"
     v-model:active-side-menu="activeSideMenu"

--- a/src/views/warehouse/WarehouseInboundView.vue
+++ b/src/views/warehouse/WarehouseInboundView.vue
@@ -8,7 +8,8 @@ import { useAuthStore } from '@/stores/auth.js'
 const router = useRouter()
 const auth = useAuthStore()
 const activeSideMenu = ref('입고 관리')
-const sideMenus = roleMenus.warehouse
+const topMenus = roleMenus.warehouse
+const sideMenus = roleMenus.warehouse.find((menu) => menu.label === '입/출고관리')?.children ?? []
 
 function handleLogout() {
   auth.logout()
@@ -18,7 +19,8 @@ function handleLogout() {
 
 <template>
   <AppLayout
-    active-top-menu="입고 관리"
+    active-top-menu="입/출고관리"
+    :top-menus="topMenus"
     :side-menus="sideMenus"
     v-model:active-side-menu="activeSideMenu"
     @logout="handleLogout"

--- a/src/views/warehouse/WarehouseInventorySkuDetailView.vue
+++ b/src/views/warehouse/WarehouseInventorySkuDetailView.vue
@@ -1,0 +1,146 @@
+<script setup>
+import { computed, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import AppLayout from '@/components/common/AppLayout.vue'
+import { roleMenus } from '@/config/roleMenus.js'
+import { useAuthStore } from '@/stores/auth.js'
+
+const route = useRoute()
+const router = useRouter()
+const auth = useAuthStore()
+
+const warehouseTopMenus = roleMenus.warehouse
+const warehouseSideMenus = roleMenus.warehouse.find((menu) => menu.label === '재고 관리')?.children ?? []
+
+const activeSideMenu = ref('창고 재고 조회')
+const activeTopMenu = computed(() => '재고 관리')
+
+const colorOptions = ['검정', '흰색', '그레이', '아이보리']
+const colorCodeMap = { 검정: 'BLK', 흰색: 'WHT', 그레이: 'GRY', 아이보리: 'IVR' }
+const sizeOptions = ['XS', 'S', 'M', 'L', 'XL']
+
+const itemCode = computed(() => String(route.params.itemCode ?? route.query.itemCode ?? ''))
+const itemName = computed(() => String(route.query.itemName ?? '선택 품목'))
+const parentCategory = computed(() => String(route.query.parentCategory ?? '-'))
+const childCategory = computed(() => String(route.query.childCategory ?? '-'))
+
+const seed = computed(() =>
+  itemCode.value.split('').reduce((sum, char) => sum + char.charCodeAt(0), 0),
+)
+
+const skuRows = computed(() =>
+  colorOptions.flatMap((color, colorIndex) =>
+    sizeOptions.map((size, sizeIndex) => {
+      const actualStock = 20 + ((seed.value + colorIndex * 17 + sizeIndex * 11) % 90)
+      const reservedStock = (seed.value + colorIndex * 7 + sizeIndex * 13) % 12
+      const availableStock = Math.max(actualStock - reservedStock, 0)
+      const safetyStock = 22 + (sizeIndex % 3) * 6
+      const status = availableStock === 0 ? '품절' : availableStock < safetyStock ? '부족' : '정상'
+      const updatedAt = `2026.04.${String(27 - (colorIndex % 3)).padStart(2, '0')} ${String(9 + sizeIndex).padStart(2, '0')}:15`
+
+      return {
+        skuCode: `${itemCode.value}-${colorCodeMap[color]}-${size}`,
+        color,
+        size,
+        actualStock,
+        availableStock,
+        safetyStock,
+        status,
+        updatedAt,
+      }
+    }),
+  ),
+)
+
+const statusClass = (status) => ({
+  정상: 'bg-[#EBF5F5] text-black',
+  부족: 'bg-amber-50 text-amber-700',
+  품절: 'bg-red-50 text-red-700',
+})[status] ?? 'bg-gray-100 text-gray-600'
+
+const backQuery = computed(() => ({
+  search: typeof route.query.search === 'string' ? route.query.search : undefined,
+  parent: typeof route.query.parent === 'string' ? route.query.parent : undefined,
+  child: typeof route.query.child === 'string' ? route.query.child : undefined,
+  status: typeof route.query.status === 'string' ? route.query.status : undefined,
+}))
+
+function goBackToInventory() {
+  router.push({
+    name: 'wh-inventory',
+    query: backQuery.value,
+  })
+}
+
+function handleLogout() {
+  auth.logout()
+  router.push('/login')
+}
+</script>
+
+<template>
+  <AppLayout
+    :active-top-menu="activeTopMenu"
+    :top-menus="warehouseTopMenus"
+    :side-menus="warehouseSideMenus"
+    v-model:active-side-menu="activeSideMenu"
+    @logout="handleLogout"
+  >
+    <div class="flex flex-col gap-4">
+      <section class="border border-gray-200 bg-white p-4 shadow-sm">
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p class="text-[10px] font-black uppercase tracking-[0.16em] text-gray-400">SKU Inventory</p>
+            <h1 class="mt-1 text-lg font-black text-gray-900">SKU 재고 상세</h1>
+            <p class="mt-2 text-sm font-bold text-gray-700">{{ itemName }}</p>
+            <p class="mt-1 text-xs font-bold text-gray-500">
+              {{ itemCode }} · {{ parentCategory }} &gt; {{ childCategory }}
+            </p>
+          </div>
+          <button
+            type="button"
+            class="h-9 border border-gray-300 bg-white px-4 text-xs font-black text-gray-700 hover:bg-gray-50"
+            @click="goBackToInventory"
+          >
+            목록으로
+          </button>
+        </div>
+      </section>
+
+      <section class="min-h-0 border border-gray-200 bg-white shadow-sm">
+        <div class="overflow-x-auto">
+          <table class="min-w-[980px] w-full border-collapse text-left text-xs">
+            <thead class="bg-gray-50 text-[10px] uppercase tracking-[0.12em] text-gray-500">
+              <tr>
+                <th class="px-3 py-3 font-black">SKU 코드</th>
+                <th class="px-3 py-3 font-black">색상</th>
+                <th class="px-3 py-3 font-black">사이즈</th>
+                <th class="px-3 py-3 text-right font-black">실재고</th>
+                <th class="px-3 py-3 text-right font-black">가용재고</th>
+                <th class="px-3 py-3 text-right font-black">안전재고</th>
+                <th class="px-3 py-3 text-center font-black">상태</th>
+                <th class="px-3 py-3 font-black">최종 업데이트</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100">
+              <tr v-for="sku in skuRows" :key="sku.skuCode">
+                <td class="px-3 py-3 font-mono font-bold text-gray-600">{{ sku.skuCode }}</td>
+                <td class="px-3 py-3 font-bold text-gray-800">{{ sku.color }}</td>
+                <td class="px-3 py-3 font-black text-gray-900">{{ sku.size }}</td>
+                <td class="px-3 py-3 text-right font-black text-gray-900">{{ sku.actualStock.toLocaleString() }}</td>
+                <td class="px-3 py-3 text-right font-black text-gray-900">{{ sku.availableStock.toLocaleString() }}</td>
+                <td class="px-3 py-3 text-right font-bold text-gray-500">{{ sku.safetyStock.toLocaleString() }}</td>
+                <td class="px-3 py-3 text-center">
+                  <span class="inline-flex min-w-12 justify-center px-2 py-1 text-[11px] font-black" :class="statusClass(sku.status)">
+                    {{ sku.status }}
+                  </span>
+                </td>
+                <td class="px-3 py-3 font-bold text-gray-500">{{ sku.updatedAt }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  </AppLayout>
+</template>

--- a/src/views/warehouse/WarehouseInventoryView.vue
+++ b/src/views/warehouse/WarehouseInventoryView.vue
@@ -1,540 +1,243 @@
 <script setup>
-import { ref, computed } from 'vue'
-import { useRouter } from 'vue-router'
-import {
-  Warehouse,
-  Search,
-  RotateCcw,
-  Download,
-  X,
-  Package,
-  TriangleAlert,
-  ArrowDownToLine,
-  ArrowUpFromLine,
-  ChevronLeft,
-  ChevronRight,
-} from 'lucide-vue-next'
+import { computed, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
 
 const router = useRouter()
+const route = useRoute()
 const auth = useAuthStore()
-const warehouseMenus = roleMenus.warehouse
+const warehouseTopMenus = roleMenus.warehouse
+const warehouseSideMenus = roleMenus.warehouse.find((menu) => menu.label === '재고 관리')?.children ?? []
 
-const activeSideMenu = ref('창고 재고 관리')
-const activeTopMenu = computed(() => '창고 재고 관리')
+const activeSideMenu = ref('창고 재고 조회')
+const activeTopMenu = computed(() => '재고 관리')
+
+const warehouseInfo = {
+  code: 'WH-ICN-01',
+  name: '인천 제1창고',
+}
+
+const categoryMap = {
+  상의: ['반팔', '긴팔', '셔츠', '니트', '후드티'],
+  바지: ['청바지', '반바지', '긴바지', '츄리닝'],
+  치마: ['미니스커트', '롱스커트'],
+  아우터: ['패딩', '후드집업', '자켓', '가디건'],
+}
+
+const inventoryData = [
+  { itemCode: 'SPA-TOP-001', parentCategory: '상의', childCategory: '반팔', itemName: '코튼 베이직 반팔 티셔츠', actualStock: 184, availableStock: 172, safetyStock: 60, status: '정상', updatedAt: '2026.04.27 09:20' },
+  { itemCode: 'SPA-TOP-002', parentCategory: '상의', childCategory: '긴팔', itemName: '슬림핏 긴팔 티셔츠', actualStock: 38, availableStock: 32, safetyStock: 45, status: '부족', updatedAt: '2026.04.27 09:10' },
+  { itemCode: 'SPA-TOP-003', parentCategory: '상의', childCategory: '셔츠', itemName: '오버핏 옥스포드 셔츠', actualStock: 420, availableStock: 402, safetyStock: 120, status: '정상', updatedAt: '2026.04.27 08:50' },
+  { itemCode: 'SPA-TOP-004', parentCategory: '상의', childCategory: '니트', itemName: '라운드넥 소프트 니트', actualStock: 0, availableStock: 0, safetyStock: 80, status: '품절', updatedAt: '2026.04.27 08:30' },
+  { itemCode: 'SPA-PNT-001', parentCategory: '바지', childCategory: '청바지', itemName: '스트레이트 워싱 데님', actualStock: 128, availableStock: 121, safetyStock: 60, status: '정상', updatedAt: '2026.04.27 08:15' },
+  { itemCode: 'SPA-PNT-002', parentCategory: '바지', childCategory: '반바지', itemName: '라이트 코튼 쇼츠', actualStock: 22, availableStock: 18, safetyStock: 40, status: '부족', updatedAt: '2026.04.27 07:55' },
+  { itemCode: 'SPA-PNT-003', parentCategory: '바지', childCategory: '긴바지', itemName: '와이드 밴딩 팬츠', actualStock: 76, availableStock: 69, safetyStock: 55, status: '정상', updatedAt: '2026.04.27 07:35' },
+  { itemCode: 'SPA-SKT-001', parentCategory: '치마', childCategory: '미니스커트', itemName: 'A라인 데님 미니스커트', actualStock: 14, availableStock: 10, safetyStock: 35, status: '부족', updatedAt: '2026.04.26 19:45' },
+  { itemCode: 'SPA-SKT-002', parentCategory: '치마', childCategory: '롱스커트', itemName: '플리츠 롱스커트', actualStock: 0, availableStock: 0, safetyStock: 25, status: '품절', updatedAt: '2026.04.26 19:20' },
+  { itemCode: 'SPA-OUT-001', parentCategory: '아우터', childCategory: '패딩', itemName: '라이트 숏 패딩', actualStock: 98, availableStock: 92, safetyStock: 45, status: '정상', updatedAt: '2026.04.26 18:40' },
+  { itemCode: 'SPA-OUT-002', parentCategory: '아우터', childCategory: '후드집업', itemName: '스웨트 후드 집업', actualStock: 17, availableStock: 12, safetyStock: 30, status: '부족', updatedAt: '2026.04.26 18:10' },
+  { itemCode: 'SPA-OUT-003', parentCategory: '아우터', childCategory: '자켓', itemName: '싱글 브레스트 자켓', actualStock: 64, availableStock: 58, safetyStock: 25, status: '정상', updatedAt: '2026.04.26 17:55' },
+]
+
+const selectedParentCategory = ref(typeof route.query.parent === 'string' ? route.query.parent : '')
+const selectedChildCategory = ref(typeof route.query.child === 'string' ? route.query.child : '')
+const selectedStatus = ref(typeof route.query.status === 'string' ? route.query.status : '')
+const searchTerm = ref(typeof route.query.search === 'string' ? route.query.search : '')
+
+const childCategoryOptions = computed(() =>
+  selectedParentCategory.value ? categoryMap[selectedParentCategory.value] : [],
+)
+
+const filteredInventory = computed(() => {
+  const keyword = searchTerm.value.trim().toLowerCase()
+  return inventoryData.filter((item) => {
+    const matchesParent = !selectedParentCategory.value || item.parentCategory === selectedParentCategory.value
+    const matchesChild = !selectedChildCategory.value || item.childCategory === selectedChildCategory.value
+    const matchesStatus = !selectedStatus.value || item.status === selectedStatus.value
+    const matchesKeyword = !keyword || [item.itemCode, item.itemName].join(' ').toLowerCase().includes(keyword)
+    return matchesParent && matchesChild && matchesStatus && matchesKeyword
+  })
+})
+
+const statusClass = (status) => ({
+  정상: 'bg-[#EBF5F5] text-black',
+  부족: 'bg-amber-50 text-amber-700',
+  품절: 'bg-red-50 text-red-700',
+})[status] ?? 'bg-gray-100 text-gray-600'
+
+const today = new Intl.DateTimeFormat('ko-KR', {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+}).format(new Date())
+
+function handleParentCategoryChange() {
+  selectedChildCategory.value = ''
+}
+
+function resetFilters() {
+  selectedParentCategory.value = ''
+  selectedChildCategory.value = ''
+  selectedStatus.value = ''
+  searchTerm.value = ''
+}
+
+function moveToSkuDetail(item) {
+  router.push({
+    name: 'wh-inventory-sku-detail',
+    params: { itemCode: item.itemCode },
+    query: {
+      itemCode: item.itemCode,
+      itemName: item.itemName,
+      parentCategory: item.parentCategory,
+      childCategory: item.childCategory,
+      search: searchTerm.value || undefined,
+      parent: selectedParentCategory.value || undefined,
+      child: selectedChildCategory.value || undefined,
+      status: selectedStatus.value || undefined,
+    },
+  })
+}
 
 function handleLogout() {
   auth.logout()
   router.push('/login')
-}
-
-/* ── 창고 정보 ── */
-const warehouseInfo = {
-  id: 'WH-001',
-  name: '인천 제1물류센터',
-  manager: '이후경',
-  maxQty: 50000,
-  usedQty: 31480,
-}
-
-/* ── 재고 데이터 ── */
-const inventoryData = ref([
-  { code: 'IT-0001', name: '아메리카노 원두 (500g)',    category: '음료 원료', unit: '개',   available: 850,  hold: 50,  damaged: 0,  location: 'A-01-03' },
-  { code: 'IT-0002', name: '유기농 우유 1L',            category: '유제품',   unit: '팩',   available: 2400, hold: 0,   damaged: 12, location: 'B-02-01' },
-  { code: 'IT-0003', name: '친환경 종이컵 (1000ea)',    category: '소모품',   unit: '박스', available: 320,  hold: 80,  damaged: 0,  location: 'C-01-05' },
-  { code: 'IT-0004', name: '무라벨 생수 500ml',         category: '음료',     unit: '박스', available: 1500, hold: 200, damaged: 30, location: 'A-03-02' },
-  { code: 'IT-0005', name: '에스프레소 시럽 750ml',     category: '음료 원료', unit: '병',  available: 640,  hold: 0,   damaged: 8,  location: 'A-01-07' },
-  { code: 'IT-0006', name: '아이스 컵 (Large, 500ea)', category: '소모품',   unit: '박스', available: 180,  hold: 20,  damaged: 0,  location: 'C-02-01' },
-  { code: 'IT-0007', name: '녹차 파우더 (1kg)',         category: '음료 원료', unit: '개',  available: 0,    hold: 120, damaged: 0,  location: 'A-02-04' },
-  { code: 'IT-0008', name: '냉동 블루베리 (1kg)',       category: '식재료',   unit: '봉지', available: 880,  hold: 0,   damaged: 44, location: 'D-01-02' },
-  { code: 'IT-0009', name: '빨대 (개별 포장, 200ea)',   category: '소모품',   unit: '박스', available: 510,  hold: 0,   damaged: 0,  location: 'C-03-06' },
-  { code: 'IT-0010', name: '시나몬 파우더 (500g)',      category: '음료 원료', unit: '개',  available: 230,  hold: 40,  damaged: 0,  location: 'A-02-01' },
-  { code: 'IT-0011', name: '두유 (190ml, 24입)',        category: '유제품',   unit: '박스', available: 440,  hold: 0,   damaged: 6,  location: 'B-01-03' },
-  { code: 'IT-0012', name: '캐러멜 시럽 750ml',         category: '음료 원료', unit: '병',  available: 380,  hold: 60,  damaged: 0,  location: 'A-01-09' },
-  { code: 'IT-0013', name: '핫초코 파우더 (1kg)',       category: '음료 원료', unit: '개',  available: 165,  hold: 0,   damaged: 0,  location: 'A-02-06' },
-  { code: 'IT-0014', name: '냅킨 (500매)',              category: '소모품',   unit: '묶음', available: 720,  hold: 0,   damaged: 20, location: 'C-01-08' },
-  { code: 'IT-0015', name: '딸기 시럽 750ml',           category: '음료 원료', unit: '병',  available: 290,  hold: 30,  damaged: 4,  location: 'A-01-11' },
-])
-
-const categories = ['전체', '음료 원료', '유제품', '소모품', '음료', '식재료']
-
-/* ── 상태 헬퍼 ── */
-function rowStatus(item) {
-  if (item.available === 0 && item.hold > 0) return '전량보류'
-  if (item.damaged > 0 && item.available === 0) return '전량파손'
-  if (item.damaged > 0) return '파손있음'
-  if (item.hold > 0)    return '보류있음'
-  return '정상'
-}
-
-function statusStyle(st) {
-  if (st === '정상')    return 'bg-emerald-50 text-emerald-700 border border-emerald-200'
-  if (st === '보류있음' || st === '전량보류') return 'bg-amber-50 text-amber-700 border border-amber-200'
-  if (st === '파손있음' || st === '전량파손') return 'bg-red-50 text-red-600 border border-red-200'
-  return 'bg-gray-100 text-gray-500'
-}
-
-/* ── 필터 ── */
-const searchQuery  = ref('')
-const filterCat    = ref('전체')
-const filterStatus = ref('전체')
-
-const filtered = computed(() =>
-  inventoryData.value.filter(item => {
-    const q = searchQuery.value.toLowerCase()
-    const nameMatch   = item.name.toLowerCase().includes(q) || item.code.toLowerCase().includes(q)
-    const catMatch    = filterCat.value === '전체' || item.category === filterCat.value
-    const st = rowStatus(item)
-    const statusMatch = filterStatus.value === '전체'
-      || (filterStatus.value === '정상'    && st === '정상')
-      || (filterStatus.value === '보류있음' && (st === '보류있음' || st === '전량보류'))
-      || (filterStatus.value === '파손있음' && (st === '파손있음' || st === '전량파손'))
-    return nameMatch && catMatch && statusMatch
-  })
-)
-
-const PAGE_SIZE   = 10
-const currentPage = ref(1)
-const totalPages  = computed(() => Math.ceil(filtered.value.length / PAGE_SIZE) || 1)
-const paginated   = computed(() => {
-  const s = (currentPage.value - 1) * PAGE_SIZE
-  return filtered.value.slice(s, s + PAGE_SIZE)
-})
-
-function resetFilters() {
-  searchQuery.value  = ''
-  filterCat.value    = '전체'
-  filterStatus.value = '전체'
-  currentPage.value  = 1
-}
-function onFilterChange() { currentPage.value = 1 }
-
-/* ── KPI ── */
-const kpi = computed(() => {
-  const all = inventoryData.value
-  return {
-    전체품목:   all.length,
-    총가용수량: all.reduce((s, i) => s + i.available, 0).toLocaleString(),
-    총보류수량: all.reduce((s, i) => s + i.hold, 0).toLocaleString(),
-    총파손수량: all.reduce((s, i) => s + i.damaged, 0).toLocaleString(),
-    공간점유율: Math.round((warehouseInfo.usedQty / warehouseInfo.maxQty) * 100),
-  }
-})
-
-/* ── 상세 패널 ── */
-const selectedItem = ref(null)
-function selectItem(item) { selectedItem.value = item }
-function closePanel()     { selectedItem.value = null }
-
-/* ── 입출고 이력 (더미) ── */
-const recentHistory = [
-  { type: '입고', qty: '+500', date: '2026-04-18', memo: '(주)커피네트웍스 입고' },
-  { type: '출고', qty: '-120', date: '2026-04-17', memo: '성수 직영점 배송' },
-  { type: '출고', qty: '-80',  date: '2026-04-16', memo: '판교 테크노점 배송' },
-  { type: '입고', qty: '+300', date: '2026-04-14', memo: '(주)커피네트웍스 입고' },
-]
-
-function downloadExcel() { alert('창고 재고 현황 엑셀 다운로드가 시작됩니다.') }
-
-const today = new Intl.DateTimeFormat('ko-KR', {
-  year: 'numeric', month: '2-digit', day: '2-digit',
-}).format(new Date())
-
-/* ── 시각화 바 높이 계산 ── */
-function barHeight(val, item) {
-  const total = item.available + item.hold + item.damaged
-  return total > 0 ? Math.round((val / total) * 80) : 4
 }
 </script>
 
 <template>
   <AppLayout
     :active-top-menu="activeTopMenu"
-    :side-menus="warehouseMenus"
+    :top-menus="warehouseTopMenus"
+    :side-menus="warehouseSideMenus"
     v-model:active-side-menu="activeSideMenu"
     @logout="handleLogout"
   >
-    <div class="flex flex-col gap-3">
-
-      <!-- 페이지 헤더 -->
-      <section class="flex flex-wrap items-center justify-between gap-3 border border-gray-300 bg-white px-3 py-2.5 shadow-sm">
-        <div class="flex flex-wrap items-center gap-3">
-          <h2 class="inline-flex items-center gap-2 text-[15px] font-semibold text-gray-900">
-            <Warehouse :size="18" />
-            창고 재고 조회
-          </h2>
-          <span class="border border-gray-200 bg-gray-50 px-2 py-1 text-[11px] font-medium text-gray-500">
-            {{ warehouseInfo.id }} · {{ warehouseInfo.name }}
-          </span>
-          <span class="border border-gray-200 bg-gray-50 px-2 py-1 text-[11px] font-medium text-gray-500">
-            기준일: {{ today }}
-          </span>
+    <div class="flex flex-col gap-4">
+      <section class="border border-gray-200 bg-white p-4 shadow-sm">
+        <div class="mb-4 flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <p class="text-[10px] font-black uppercase tracking-[0.18em] text-gray-400">Inventory</p>
+            <h1 class="mt-1 text-lg font-black text-gray-900">창고 재고 조회</h1>
+          </div>
+          <div class="text-right text-[11px] font-bold text-gray-500">
+            <p>{{ warehouseInfo.code }} · {{ warehouseInfo.name }}</p>
+            <p class="mt-1 text-gray-400">기준일 {{ today }} · 조회 {{ filteredInventory.length }}건</p>
+          </div>
         </div>
-        <button
-          class="inline-flex items-center gap-1.5 border border-gray-300 bg-white px-3 py-1.5 text-[13px] font-medium text-gray-600 transition hover:border-[#004D3C] hover:text-[#004D3C]"
-          @click="downloadExcel"
-        >
-          <Download :size="14" />
-          엑셀 다운로드
-        </button>
-      </section>
 
-      <!-- 창고 공간 점유율 배너 -->
-      <section
-        class="flex flex-wrap items-center gap-4 border bg-white px-3 py-3 shadow-sm"
-        :class="kpi.공간점유율 >= 80 ? 'border-red-300 bg-red-50' : 'border-gray-300'"
-      >
-        <div class="flex items-center gap-2 shrink-0">
-          <Warehouse :size="15" :class="kpi.공간점유율 >= 80 ? 'text-red-500' : 'text-gray-400'" />
-          <span class="text-[12px] font-medium text-gray-500">창고 공간 점유율</span>
-          <span class="text-[16px] font-bold" :class="kpi.공간점유율 >= 80 ? 'text-red-600' : 'text-[#004D3C]'">
-            {{ kpi.공간점유율 }}%
-          </span>
-          <span v-if="kpi.공간점유율 >= 80" class="inline-flex items-center gap-1 rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-[11px] font-medium text-red-600">
-            <TriangleAlert :size="11" /> 과부하 주의
-          </span>
-        </div>
-        <div class="flex flex-1 items-center gap-3 min-w-[200px]">
-          <div class="h-2 flex-1 overflow-hidden bg-gray-200">
-            <div
-              class="h-full transition-all duration-500"
-              :class="kpi.공간점유율 >= 80 ? 'bg-red-500' : 'bg-[#004D3C]'"
-              :style="{ width: kpi.공간점유율 + '%' }"
+        <div class="grid gap-3 xl:grid-cols-[1.2fr_1fr_1fr_1fr_1.2fr]">
+          <label class="flex flex-col gap-1.5">
+            <span class="text-[11px] font-bold text-gray-500">검색</span>
+            <input
+              v-model="searchTerm"
+              type="search"
+              class="h-9 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none placeholder:text-gray-400 focus:border-[#004D3C]"
+              placeholder="품목 코드, 품목명"
             />
-          </div>
-          <span class="text-[11px] font-medium text-gray-400 whitespace-nowrap">
-            {{ warehouseInfo.usedQty.toLocaleString() }} / {{ warehouseInfo.maxQty.toLocaleString() }} EA
-          </span>
-        </div>
-      </section>
+          </label>
 
-      <!-- KPI 카드 -->
-      <section class="grid grid-cols-2 gap-3 md:grid-cols-2 xl:grid-cols-4">
-        <article class="flex h-[80px] flex-col justify-between border border-gray-300 bg-white px-3 py-3 shadow-sm">
-          <p class="text-[11px] font-medium leading-tight text-gray-500">전체 품목</p>
-          <div class="flex items-end justify-between gap-1">
-            <span class="text-[20px] font-bold tracking-tight text-gray-900">{{ kpi.전체품목 }}</span>
-            <Package :size="14" class="text-gray-400" />
-          </div>
-        </article>
-        <article class="flex h-[80px] flex-col justify-between border border-l-[3px] border-emerald-300 bg-white px-3 py-3 shadow-sm">
-          <p class="text-[11px] font-medium leading-tight text-gray-500">총 가용 수량</p>
-          <div class="flex items-end justify-between gap-1">
-            <span class="text-[20px] font-bold tracking-tight text-emerald-600">{{ kpi.총가용수량 }}</span>
-            <ArrowDownToLine :size="14" class="text-emerald-400" />
-          </div>
-        </article>
-        <article class="flex h-[80px] flex-col justify-between border border-l-[3px] border-amber-300 bg-white px-3 py-3 shadow-sm">
-          <p class="text-[11px] font-medium leading-tight text-gray-500">총 보류 수량</p>
-          <div class="flex items-end justify-between gap-1">
-            <span class="text-[20px] font-bold tracking-tight text-amber-500">{{ kpi.총보류수량 }}</span>
-            <TriangleAlert :size="14" class="text-amber-400" />
-          </div>
-        </article>
-        <article class="flex h-[80px] flex-col justify-between border border-l-[3px] border-red-300 bg-white px-3 py-3 shadow-sm">
-          <p class="text-[11px] font-medium leading-tight text-gray-500">총 파손 수량</p>
-          <div class="flex items-end justify-between gap-1">
-            <span class="text-[20px] font-bold tracking-tight text-red-600">{{ kpi.총파손수량 }}</span>
-            <TriangleAlert :size="14" class="text-red-400" />
-          </div>
-        </article>
-      </section>
-
-      <!-- 필터 바 -->
-      <section class="flex flex-wrap items-center gap-2 border border-gray-300 bg-white px-3 py-2.5 shadow-sm">
-        <div class="relative flex items-center">
-          <Search :size="13" class="absolute left-2.5 text-gray-400 pointer-events-none" />
-          <input
-            v-model="searchQuery"
-            type="text"
-            placeholder="품목명 또는 품목 코드 검색"
-            class="h-9 w-56 border border-gray-300 bg-gray-50 pl-8 pr-3 text-[13px] text-gray-800 outline-none transition placeholder:text-gray-400 focus:border-[#004D3C] focus:bg-white"
-            @input="onFilterChange"
-          />
-        </div>
-        <select v-model="filterCat" class="h-9 border border-gray-300 bg-gray-50 px-3 text-[13px] text-gray-700 outline-none transition focus:border-[#004D3C] focus:bg-white" @change="onFilterChange">
-          <option v-for="c in categories" :key="c" :value="c">{{ c === '전체' ? '카테고리 전체' : c }}</option>
-        </select>
-        <select v-model="filterStatus" class="h-9 border border-gray-300 bg-gray-50 px-3 text-[13px] text-gray-700 outline-none transition focus:border-[#004D3C] focus:bg-white" @change="onFilterChange">
-          <option value="전체">재고 상태 전체</option>
-          <option value="정상">정상</option>
-          <option value="보류있음">보류 포함</option>
-          <option value="파손있음">파손 포함</option>
-        </select>
-        <button
-          class="inline-flex h-9 items-center gap-1.5 border border-gray-300 bg-white px-3 text-[13px] font-medium text-gray-500 transition hover:bg-gray-50"
-          @click="resetFilters"
-        >
-          <RotateCcw :size="13" />
-          초기화
-        </button>
-        <span class="ml-auto text-[12px] font-medium text-gray-400">총 {{ filtered.length }}건</span>
-      </section>
-
-      <!-- 테이블 카드 -->
-      <section class="border border-gray-300 bg-white shadow-sm">
-        <div class="flex items-center justify-between gap-3 border-b border-gray-200 px-3 py-2.5">
-          <h3 class="inline-flex items-center gap-2 text-sm font-medium text-gray-800">
-            <Package :size="16" />
-            재고 목록
-          </h3>
-          <span class="text-[10px] font-medium text-gray-400">행 클릭 시 상세 조회</span>
-        </div>
-
-        <div class="overflow-auto">
-          <table class="w-full min-w-[900px] text-[13px]">
-            <thead class="bg-gray-50 text-[11px] uppercase text-gray-500">
-              <tr>
-                <th class="px-3 py-2.5 text-left font-bold">품목 코드</th>
-                <th class="px-3 py-2.5 text-left font-bold">품목명</th>
-                <th class="px-3 py-2.5 text-left font-bold">카테고리</th>
-                <th class="px-3 py-2.5 text-center font-bold">단위</th>
-                <th class="px-3 py-2.5 text-right font-bold">가용</th>
-                <th class="px-3 py-2.5 text-right font-bold">보류</th>
-                <th class="px-3 py-2.5 text-right font-bold">파손</th>
-                <th class="px-3 py-2.5 text-right font-bold">합계</th>
-                <th class="px-3 py-2.5 text-left font-bold">보관 위치</th>
-                <th class="px-3 py-2.5 text-left font-bold">상태</th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-gray-100 border-t border-gray-200">
-              <tr
-                v-for="item in paginated"
-                :key="item.code"
-                class="cursor-pointer transition-colors hover:bg-gray-50/50"
-                :class="{
-                  'bg-[#eef7f4] hover:bg-[#e4f2ef]': selectedItem?.code === item.code,
-                  'bg-amber-50/40': rowStatus(item).includes('보류') && selectedItem?.code !== item.code,
-                  'bg-red-50/40':   rowStatus(item).includes('파손') && selectedItem?.code !== item.code,
-                }"
-                @click="selectItem(item)"
-              >
-                <td class="px-3 py-2.5 text-[11px] text-gray-400">{{ item.code }}</td>
-                <td class="px-3 py-2.5 font-semibold text-gray-800">{{ item.name }}</td>
-                <td class="px-3 py-2.5">
-                  <span class="rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-600">{{ item.category }}</span>
-                </td>
-                <td class="px-3 py-2.5 text-center text-gray-600">{{ item.unit }}</td>
-                <td class="px-3 py-2.5 text-right font-semibold text-emerald-600">{{ item.available.toLocaleString() }}</td>
-                <td class="px-3 py-2.5 text-right">
-                  <span v-if="item.hold > 0" class="font-semibold text-amber-600">{{ item.hold.toLocaleString() }}</span>
-                  <span v-else class="text-gray-300">—</span>
-                </td>
-                <td class="px-3 py-2.5 text-right">
-                  <span v-if="item.damaged > 0" class="font-semibold text-red-600">{{ item.damaged.toLocaleString() }}</span>
-                  <span v-else class="text-gray-300">—</span>
-                </td>
-                <td class="px-3 py-2.5 text-right font-semibold text-gray-700">
-                  {{ (item.available + item.hold + item.damaged).toLocaleString() }}
-                </td>
-                <td class="px-3 py-2.5">
-                  <span class="rounded-full bg-violet-50 px-2 py-0.5 text-[11px] font-medium text-violet-700">{{ item.location }}</span>
-                </td>
-                <td class="px-3 py-2.5">
-                  <span class="inline-flex items-center rounded-full px-2 py-1 text-[11px] font-medium" :class="statusStyle(rowStatus(item))">
-                    {{ rowStatus(item) }}
-                  </span>
-                </td>
-              </tr>
-              <tr v-if="paginated.length === 0">
-                <td colspan="10" class="px-3 py-10 text-center text-[13px] text-gray-400">조회 결과가 없습니다.</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-
-        <!-- 페이지네이션 -->
-        <div class="flex items-center justify-between border-t border-gray-200 bg-gray-50 px-3 py-2">
-          <span class="text-[11px] font-medium text-gray-400">
-            {{ (currentPage - 1) * PAGE_SIZE + 1 }}–{{ Math.min(currentPage * PAGE_SIZE, filtered.length) }} / 전체 {{ filtered.length }}건
-          </span>
-          <div class="flex items-center gap-1">
-            <button
-              type="button"
-              :disabled="currentPage === 1"
-              class="flex h-7 w-7 items-center justify-center border border-gray-300 bg-white text-gray-500 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
-              @click="currentPage--"
+          <label class="flex flex-col gap-1.5">
+            <span class="text-[11px] font-bold text-gray-500">카테고리 1단계</span>
+            <select
+              v-model="selectedParentCategory"
+              class="h-9 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none focus:border-[#004D3C]"
+              @change="handleParentCategoryChange"
             >
-              <ChevronLeft :size="14" />
-            </button>
-            <button
-              v-for="p in totalPages"
-              :key="p"
-              type="button"
-              class="flex h-7 min-w-[28px] items-center justify-center border text-[12px] font-medium transition"
-              :class="p === currentPage ? 'border-[#004D3C] bg-[#004D3C] text-white' : 'border-gray-300 bg-white text-gray-500 hover:bg-gray-100'"
-              @click="currentPage = p"
-            >{{ p }}</button>
-            <button
-              type="button"
-              :disabled="currentPage === totalPages"
-              class="flex h-7 w-7 items-center justify-center border border-gray-300 bg-white text-gray-500 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
-              @click="currentPage++"
+              <option value="">전체</option>
+              <option v-for="category in Object.keys(categoryMap)" :key="category" :value="category">
+                {{ category }}
+              </option>
+            </select>
+          </label>
+
+          <label class="flex flex-col gap-1.5">
+            <span class="text-[11px] font-bold text-gray-500">카테고리 2단계</span>
+            <select
+              v-model="selectedChildCategory"
+              class="h-9 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none focus:border-[#004D3C] disabled:bg-gray-50 disabled:text-gray-400"
+              :disabled="!selectedParentCategory"
             >
-              <ChevronRight :size="14" />
+              <option value="">전체</option>
+              <option v-for="category in childCategoryOptions" :key="category" :value="category">
+                {{ category }}
+              </option>
+            </select>
+          </label>
+
+          <label class="flex flex-col gap-1.5">
+            <span class="text-[11px] font-bold text-gray-500">재고 상태</span>
+            <select
+              v-model="selectedStatus"
+              class="h-9 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none focus:border-[#004D3C]"
+            >
+              <option value="">전체</option>
+              <option value="정상">정상</option>
+              <option value="부족">부족</option>
+              <option value="품절">품절</option>
+            </select>
+          </label>
+
+          <div class="flex items-end">
+            <button
+              type="button"
+              class="h-9 w-full border border-gray-300 bg-white px-3 text-xs font-black text-gray-600 hover:bg-gray-50"
+              @click="resetFilters"
+            >
+              필터 초기화
             </button>
           </div>
         </div>
       </section>
 
-    </div>
-
-    <!-- ── 상세 패널 ── -->
-    <transition name="slide">
-      <div
-        v-if="selectedItem"
-        class="fixed inset-0 z-50 flex justify-end bg-black/20"
-        @click.self="closePanel"
-      >
-        <div class="detail-panel flex h-full w-[440px] flex-col border-l border-gray-300 bg-white shadow-2xl">
-
-          <!-- 헤더 -->
-          <div class="flex shrink-0 items-start justify-between border-b border-gray-200 bg-gray-50 px-4 py-3">
-            <div>
-              <p class="text-[11px] font-bold uppercase tracking-widest text-gray-400">{{ selectedItem.code }} · {{ selectedItem.location }}</p>
-              <h2 class="mt-1 text-[16px] font-bold leading-snug text-gray-900">{{ selectedItem.name }}</h2>
-            </div>
-            <button
-              type="button"
-              class="flex h-8 w-8 items-center justify-center border border-gray-200 bg-white text-gray-400 transition hover:bg-gray-100 hover:text-gray-700"
-              @click="closePanel"
-            >
-              <X :size="16" />
-            </button>
-          </div>
-
-          <div class="flex flex-1 flex-col gap-5 overflow-y-auto p-4">
-
-            <!-- 상태 -->
-            <div>
-              <p class="mb-2 text-[11px] font-bold uppercase tracking-widest text-gray-400">처리 상태</p>
-              <span class="inline-flex items-center rounded-full px-3 py-1.5 text-[12px] font-medium" :class="statusStyle(rowStatus(selectedItem))">
-                {{ rowStatus(selectedItem) }}
-              </span>
-            </div>
-
-            <!-- 재고 현황 시각화 -->
-            <div>
-              <p class="mb-3 text-[11px] font-bold uppercase tracking-widest text-gray-400">재고 현황 (가용 / 보류 / 파손)</p>
-              <div class="flex items-end gap-5">
-                <!-- 가용 -->
-                <div class="flex flex-1 flex-col items-center gap-1.5">
-                  <span class="text-[18px] font-bold text-emerald-600">{{ selectedItem.available.toLocaleString() }}</span>
-                  <div class="flex w-full items-end" style="height:80px">
-                    <div class="w-full rounded-t bg-emerald-500" :style="{ height: barHeight(selectedItem.available, selectedItem) + 'px' }" />
-                  </div>
-                  <span class="text-[11px] font-medium text-gray-500">가용</span>
-                </div>
-                <!-- 보류 -->
-                <div class="flex flex-1 flex-col items-center gap-1.5">
-                  <span class="text-[18px] font-bold text-amber-500">{{ selectedItem.hold.toLocaleString() }}</span>
-                  <div class="flex w-full items-end" style="height:80px">
-                    <div class="w-full rounded-t bg-amber-400" :style="{ height: barHeight(selectedItem.hold, selectedItem) + 'px' }" />
-                  </div>
-                  <span class="text-[11px] font-medium text-gray-500">보류</span>
-                </div>
-                <!-- 파손 -->
-                <div class="flex flex-1 flex-col items-center gap-1.5">
-                  <span class="text-[18px] font-bold text-red-600">{{ selectedItem.damaged.toLocaleString() }}</span>
-                  <div class="flex w-full items-end" style="height:80px">
-                    <div class="w-full rounded-t bg-red-500" :style="{ height: barHeight(selectedItem.damaged, selectedItem) + 'px' }" />
-                  </div>
-                  <span class="text-[11px] font-medium text-gray-500">파손</span>
-                </div>
-                <!-- 합계 -->
-                <div class="flex flex-[0.8] flex-col items-center gap-1.5">
-                  <span class="text-[18px] font-bold text-gray-500">{{ (selectedItem.available + selectedItem.hold + selectedItem.damaged).toLocaleString() }}</span>
-                  <div class="flex w-full items-end" style="height:80px">
-                    <div class="w-full rounded-t bg-gray-200" style="height:80px" />
-                  </div>
-                  <span class="text-[11px] font-medium text-gray-500">합계</span>
-                </div>
-              </div>
-            </div>
-
-            <!-- 품목 정보 -->
-            <div>
-              <p class="mb-2 text-[11px] font-bold uppercase tracking-widest text-gray-400">품목 정보</p>
-              <div class="divide-y divide-gray-100 border border-gray-200">
-                <div class="flex items-center gap-3 px-3 py-2.5">
-                  <span class="w-20 shrink-0 text-[11px] font-medium text-gray-400">카테고리</span>
-                  <span class="text-[13px] text-gray-800">{{ selectedItem.category }}</span>
-                </div>
-                <div class="flex items-center gap-3 px-3 py-2.5">
-                  <span class="w-20 shrink-0 text-[11px] font-medium text-gray-400">단위</span>
-                  <span class="text-[13px] text-gray-800">{{ selectedItem.unit }}</span>
-                </div>
-                <div class="flex items-center gap-3 px-3 py-2.5">
-                  <span class="w-20 shrink-0 text-[11px] font-medium text-gray-400">보관 위치</span>
-                  <span class="rounded-full bg-violet-50 px-2 py-0.5 text-[11px] font-medium text-violet-700">{{ selectedItem.location }}</span>
-                </div>
-                <div class="flex items-center gap-3 px-3 py-2.5">
-                  <span class="w-20 shrink-0 text-[11px] font-medium text-gray-400">창고 ID</span>
-                  <span class="text-[13px] text-gray-800">{{ warehouseInfo.id }}</span>
-                </div>
-              </div>
-            </div>
-
-            <!-- 최근 입출고 이력 -->
-            <div>
-              <p class="mb-2 text-[11px] font-bold uppercase tracking-widest text-gray-400">최근 입출고 이력</p>
-              <div class="flex flex-col gap-2">
-                <div
-                  v-for="h in recentHistory"
-                  :key="h.date + h.type"
-                  class="flex items-center gap-3 border border-gray-100 bg-gray-50 px-3 py-2.5"
+      <section class="min-h-0">
+        <div class="min-w-0 border border-gray-200 bg-white shadow-sm">
+          <div class="overflow-x-auto">
+            <table class="min-w-[1100px] w-full border-collapse text-left text-xs">
+              <thead class="bg-gray-50 text-[10px] uppercase tracking-[0.12em] text-gray-500">
+                <tr>
+                  <th class="px-3 py-3 font-black">품목 코드</th>
+                  <th class="px-3 py-3 font-black">카테고리</th>
+                  <th class="px-3 py-3 font-black">품목명</th>
+                  <th class="px-3 py-3 text-right font-black">실제고</th>
+                  <th class="px-3 py-3 text-right font-black">가용재고</th>
+                  <th class="px-3 py-3 text-right font-black">안전재고</th>
+                  <th class="px-3 py-3 text-center font-black">상태</th>
+                  <th class="px-3 py-3 font-black">최종 업데이트</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-100">
+                <tr
+                  v-for="item in filteredInventory"
+                  :key="item.itemCode"
+                  class="cursor-pointer hover:bg-[#EBF5F5]/60"
+                  @click="moveToSkuDetail(item)"
                 >
-                  <span
-                    class="inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium"
-                    :class="h.type === '입고' ? 'bg-emerald-50 text-emerald-700' : 'bg-red-50 text-red-600'"
-                  >
-                    <component :is="h.type === '입고' ? ArrowDownToLine : ArrowUpFromLine" :size="11" />
-                    {{ h.type }}
-                  </span>
-                  <div class="flex-1 min-w-0">
-                    <p class="text-[13px] text-gray-700">{{ h.memo }}</p>
-                    <p class="text-[11px] text-gray-400">{{ h.date }}</p>
-                  </div>
-                  <span class="text-[13px] font-bold shrink-0" :class="h.type === '입고' ? 'text-emerald-600' : 'text-red-600'">
-                    {{ h.qty }}
-                  </span>
-                </div>
-              </div>
-            </div>
-
+                  <td class="px-3 py-3 font-mono font-bold text-gray-500">{{ item.itemCode }}</td>
+                  <td class="px-3 py-3 font-bold text-gray-800">{{ item.parentCategory }} &gt; {{ item.childCategory }}</td>
+                  <td class="px-3 py-3 font-bold text-gray-900">{{ item.itemName }}</td>
+                  <td class="px-3 py-3 text-right font-black text-gray-900">{{ item.actualStock.toLocaleString() }}</td>
+                  <td class="px-3 py-3 text-right font-black text-gray-900">{{ item.availableStock.toLocaleString() }}</td>
+                  <td class="px-3 py-3 text-right font-bold text-gray-500">{{ item.safetyStock.toLocaleString() }}</td>
+                  <td class="px-3 py-3 text-center">
+                    <span class="inline-flex min-w-12 justify-center px-2 py-1 text-[11px] font-black" :class="statusClass(item.status)">
+                      {{ item.status }}
+                    </span>
+                  </td>
+                  <td class="px-3 py-3 font-bold text-gray-500">{{ item.updatedAt }}</td>
+                </tr>
+                <tr v-if="filteredInventory.length === 0">
+                  <td colspan="8" class="px-3 py-14 text-center text-sm font-bold text-gray-400">
+                    조건에 맞는 창고 재고가 없습니다.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
           </div>
-
-          <!-- 푸터 -->
-          <div class="flex shrink-0 items-center justify-end gap-2 border-t border-gray-200 bg-gray-50 px-4 py-3">
-            <button
-              class="inline-flex h-9 items-center gap-2 bg-[#004D3C] px-5 text-[13px] font-medium text-white transition hover:bg-[#003d30]"
-              @click="downloadExcel"
-            >
-              <Download :size="14" />
-              엑셀 다운로드
-            </button>
-            <button
-              class="h-9 border border-gray-300 bg-white px-5 text-[13px] font-medium text-gray-600 transition hover:bg-gray-50"
-              @click="closePanel"
-            >닫기</button>
-          </div>
-
         </div>
-      </div>
-    </transition>
-
+      </section>
+    </div>
   </AppLayout>
 </template>
-
-<style scoped>
-.slide-enter-active,
-.slide-leave-active { transition: opacity 0.2s ease; }
-.slide-enter-active .detail-panel,
-.slide-leave-active .detail-panel { transition: transform 0.25s ease; }
-.slide-enter-from { opacity: 0; }
-.slide-enter-from .detail-panel { transform: translateX(100%); }
-.slide-leave-to { opacity: 0; }
-.slide-leave-to .detail-panel { transform: translateX(100%); }
-</style>

--- a/src/views/warehouse/WarehouseOutboundView.vue
+++ b/src/views/warehouse/WarehouseOutboundView.vue
@@ -9,7 +9,7 @@ const router = useRouter()
 const auth = useAuthStore()
 const activeSideMenu = ref('출고 관리')
 const topMenus = roleMenus.warehouse
-const sideMenus = roleMenus.warehouse.find((menu) => menu.label === '입/출고관리')?.children ?? []
+const sideMenus = roleMenus.warehouse.find((menu) => menu.label === '입/출고 관리')?.children ?? []
 
 function handleLogout() {
   auth.logout()
@@ -19,7 +19,7 @@ function handleLogout() {
 
 <template>
   <AppLayout
-    active-top-menu="입/출고관리"
+    active-top-menu="입/출고 관리"
     :top-menus="topMenus"
     :side-menus="sideMenus"
     v-model:active-side-menu="activeSideMenu"

--- a/src/views/warehouse/WarehouseOutboundView.vue
+++ b/src/views/warehouse/WarehouseOutboundView.vue
@@ -8,7 +8,8 @@ import { useAuthStore } from '@/stores/auth.js'
 const router = useRouter()
 const auth = useAuthStore()
 const activeSideMenu = ref('출고 관리')
-const sideMenus = roleMenus.warehouse
+const topMenus = roleMenus.warehouse
+const sideMenus = roleMenus.warehouse.find((menu) => menu.label === '입/출고관리')?.children ?? []
 
 function handleLogout() {
   auth.logout()
@@ -18,7 +19,8 @@ function handleLogout() {
 
 <template>
   <AppLayout
-    active-top-menu="출고 관리"
+    active-top-menu="입/출고관리"
+    :top-menus="topMenus"
     :side-menus="sideMenus"
     v-model:active-side-menu="activeSideMenu"
     @logout="handleLogout"


### PR DESCRIPTION
## 📌 요약
- 창고 관리자용 창고 보유 재고 조회 화면을 재구성해, 필터 기반 품목 조회와 SKU 상세 이동 흐름을 구현했습니다.

<br><br>

## 🎯 작업 내용
-  창고 재고 조회 페이지 UI/데이터 구조 개편
- 필터/조회 동작 정비
- SKU 상세 페이지 라우팅 연동

<br><br>

## ✔️ 참고 사항
- 본 작업은 UI/라우팅/더미 데이터 기반 구현 범위이며, 실제 API 연동/영속 저장은 제외했습니다.
- 창고 좌측 메뉴 구조는 접힘형(대시보드, 재고 관리, 입/출고 관리)으로 정합성을 맞췄습니다.

<br><br>

## ✔️ 관련 이슈

- Close #226 

<br><br>
