### PR TITLE
feat: 본사 공급처별 제품 axios 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.2",
+        "axios": "^1.15.2",
         "chart.js": "^4.5.1",
         "lucide-vue-next": "^1.0.0",
         "pinia": "^3.0.4",
@@ -1477,6 +1478,23 @@
         "url": "https://github.com/sponsors/sxzz"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.18",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.18.tgz",
@@ -1550,6 +1568,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001788",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
@@ -1597,6 +1628,18 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/confbox": {
@@ -1694,6 +1737,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1702,6 +1754,20 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -1747,6 +1813,51 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -1786,6 +1897,42 @@
         }
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1801,6 +1948,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -1811,12 +1967,100 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/hookable": {
       "version": "5.5.3",
@@ -2256,6 +2500,36 @@
         "url": "https://github.com/sponsors/sxzz"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
@@ -2470,6 +2744,15 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/quansync": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
+    "axios": "^1.15.2",
     "chart.js": "^4.5.1",
     "lucide-vue-next": "^1.0.0",
     "pinia": "^3.0.4",

--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -1,0 +1,27 @@
+import axios from 'axios'
+
+// 공통 axios 인스턴스
+// baseURL 빈 문자열 (상대경로) — dev 환경은 vite.config.js 의 server.proxy 가
+// /api/** 를 BE(8080) 로 리버스 프록시. 운영 빌드는 동일 origin 또는 별도 게이트웨이.
+// VITE_API_BASE 환경변수로 override 가능 (다른 BE 호스트 가리킬 때).
+export const apiClient = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE ?? '',
+  timeout: 10000,
+})
+
+/**
+ * BaseResponse<T> 언랩 헬퍼.
+ * BE 응답 형태: { success, code, message, result }.
+ * success=false 면 한국어 message 로 Error throw.
+ *
+ * @param {import('axios').AxiosResponse} res
+ * @returns {*} result
+ */
+export function unwrap(res) {
+  const body = res?.data
+  if (!body || body.success !== true) {
+    const msg = body?.message ?? '요청에 실패했습니다.'
+    throw new Error(msg)
+  }
+  return body.result
+}

--- a/src/api/vendor.js
+++ b/src/api/vendor.js
@@ -1,0 +1,53 @@
+/**
+ * vendor.js — BE 연동 (CEN-027~031, 033)
+ *
+ * BE 엔드포인트:
+ *   GET    /api/vendors                            (목록, 등록은 SQL 직접)
+ *   GET    /api/vendors/{code}
+ *   GET    /api/vendor-products?vendorCode=...     (CEN-031)
+ *   GET    /api/vendor-products/{code}             (CEN-033)
+ *   POST   /api/vendor-products                    (CEN-027)
+ *   PATCH  /api/vendor-products/{code}             (CEN-028)
+ *   PATCH  /api/vendor-products/{code}/status      (CEN-029)
+ *   DELETE /api/vendor-products/{code}             (CEN-030, SOFT DELETE)
+ *
+ * 응답: BaseResponse<T>. unwrap() 으로 result 만 추출, 실패 시 throw.
+ */
+
+import { apiClient, unwrap } from './axios.js'
+
+export const vendorApi = {
+  // ─── 거래처 (read-only) ──────────────────────────────────────────────────
+  listVendors: () => apiClient.get('/api/vendors').then(unwrap),
+  getVendor: (code) => apiClient.get(`/api/vendors/${code}`).then(unwrap),
+
+  // ─── 거래처별 계약 제품 ─────────────────────────────────────────────────
+  listVendorProducts: (vendorCode) =>
+    apiClient.get('/api/vendor-products', { params: { vendorCode } }).then(unwrap),
+  getVendorProduct: (code) => apiClient.get(`/api/vendor-products/${code}`).then(unwrap),
+
+  /**
+   * 등록 (CEN-027)
+   * @param {{vendorCode, productCode, productName, unitPrice, moq, leadTimeDays, contractStart, contractEnd}} req
+   */
+  createVendorProduct: (req) => apiClient.post('/api/vendor-products', req).then(unwrap),
+
+  /**
+   * 수정 (CEN-028)
+   * @param {string} code
+   * @param {{productName, unitPrice, moq, leadTimeDays, contractStart, contractEnd}} req
+   */
+  updateVendorProduct: (code, req) =>
+    apiClient.patch(`/api/vendor-products/${code}`, req).then(unwrap),
+
+  /**
+   * 상태 변경 (CEN-029)
+   * @param {string} code
+   * @param {'ACTIVE'|'SUSPENDED'|'EXPIRED'} status — BE enum 대문자
+   */
+  updateVendorProductStatus: (code, status) =>
+    apiClient.patch(`/api/vendor-products/${code}/status`, { status }).then(unwrap),
+
+  /** 삭제 (CEN-030, SOFT DELETE) */
+  deleteVendorProduct: (code) => apiClient.delete(`/api/vendor-products/${code}`).then(unwrap),
+}

--- a/src/stores/vendor.js
+++ b/src/stores/vendor.js
@@ -1,401 +1,44 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
+import { vendorApi } from '@/api/vendor.js'
 
-const VENDORS_KEY = 'stockit:vendors'
-const VENDOR_PRODUCTS_KEY = 'stockit:vendor-products'
+// ─── BE 응답 → FE 모델 매핑 ─────────────────────────────────────────────
+// BE 의 code 를 FE 의 id 로 노출하고, status 는 소문자로 변환해 기존 화면·헬퍼와 호환.
 
-// 초기 더미 데이터 — 거래처 5개
-const INITIAL_VENDORS = [
-  {
-    id: 'VND-001',
-    name: '(주)테크서플라이',
-    contactPerson: '김민준',
-    contactEmail: 'minjun.kim@techsupply.co.kr',
-    phone: '02-1234-5678',
-    status: 'active',
-  },
-  {
-    id: 'VND-002',
-    name: '한국생활물산',
-    contactPerson: '이수연',
-    contactEmail: 'suyeon.lee@kliving.co.kr',
-    phone: '031-9876-5432',
-    status: 'active',
-  },
-  {
-    id: 'VND-003',
-    name: '글로벌오피스',
-    contactPerson: '박재현',
-    contactEmail: 'jaehyun.park@globaloffice.com',
-    phone: '02-5555-3333',
-    status: 'active',
-  },
-  {
-    id: 'VND-004',
-    name: '위생물자(주)',
-    contactPerson: '최영희',
-    contactEmail: 'younghee.choi@hygiene.co.kr',
-    phone: '032-7777-8888',
-    status: 'inactive',
-  },
-  {
-    id: 'VND-005',
-    name: '스마트주방솔루션',
-    contactPerson: '정도현',
-    contactEmail: 'dohyun.jung@smartkitchen.kr',
-    phone: '051-4444-2222',
-    status: 'active',
-  },
-]
-
-// 초기 더미 데이터 — 거래처당 계약 제품 3~8개
-const INITIAL_VENDOR_PRODUCTS = [
-  // VND-001 (주)테크서플라이 — 전자제품 6건
-  {
-    id: 'VP-001-01',
-    vendorId: 'VND-001',
-    productCode: 'ITM-E001',
-    productName: '고속 충전기 (C타입) 25W',
-    unitPrice: 14200,
-    moq: 100,
-    leadTimeDays: 5,
-    contractStart: '2024-01-01',
-    contractEnd: '2024-12-31',
-    status: 'active',
-  },
-  {
-    id: 'VP-001-02',
-    vendorId: 'VND-001',
-    productCode: 'ITM-E004',
-    productName: '무소음 무선 마우스 (블랙)',
-    unitPrice: 22500,
-    moq: 50,
-    leadTimeDays: 7,
-    contractStart: '2024-01-01',
-    contractEnd: '2024-12-31',
-    status: 'active',
-  },
-  {
-    id: 'VP-001-03',
-    vendorId: 'VND-001',
-    productCode: 'ITM-E008',
-    productName: '대용량 보조배터리 20000mAh',
-    unitPrice: 38000,
-    moq: 30,
-    leadTimeDays: 7,
-    contractStart: '2024-01-01',
-    contractEnd: '2024-12-31',
-    status: 'active',
-  },
-  {
-    id: 'VP-001-04',
-    vendorId: 'VND-001',
-    productCode: 'ITM-E015',
-    productName: '절전형 5구 멀티탭 3m',
-    unitPrice: 11800,
-    moq: 80,
-    leadTimeDays: 5,
-    contractStart: '2024-01-01',
-    contractEnd: '2024-12-31',
-    status: 'active',
-  },
-  {
-    id: 'VP-001-05',
-    vendorId: 'VND-001',
-    productCode: 'ITM-E016',
-    productName: 'HDMI 2.1 케이블 1.5m',
-    unitPrice: 8500,
-    moq: 100,
-    leadTimeDays: 4,
-    contractStart: '2024-01-01',
-    contractEnd: '2024-06-30',
-    status: 'expired',
-  },
-  {
-    id: 'VP-001-06',
-    vendorId: 'VND-001',
-    productCode: 'ITM-E031',
-    productName: '알루미늄 노트북 스탠드',
-    unitPrice: 27000,
-    moq: 20,
-    leadTimeDays: 10,
-    contractStart: '2024-03-01',
-    contractEnd: '2025-02-28',
-    status: 'active',
-  },
-  // VND-002 한국생활물산 — 위생/주방 5건
-  {
-    id: 'VP-002-01',
-    vendorId: 'VND-002',
-    productCode: 'ITM-H002',
-    productName: '휴대용 가글 (중) 250ml',
-    unitPrice: 2800,
-    moq: 200,
-    leadTimeDays: 3,
-    contractStart: '2024-01-01',
-    contractEnd: '2024-12-31',
-    status: 'active',
-  },
-  {
-    id: 'VP-002-02',
-    vendorId: 'VND-002',
-    productCode: 'ITM-K003',
-    productName: '유리제 머그컵 350ml',
-    unitPrice: 7200,
-    moq: 50,
-    leadTimeDays: 6,
-    contractStart: '2024-01-01',
-    contractEnd: '2024-12-31',
-    status: 'active',
-  },
-  {
-    id: 'VP-002-03',
-    vendorId: 'VND-002',
-    productCode: 'ITM-H010',
-    productName: '손세정제 리필 500ml',
-    unitPrice: 3200,
-    moq: 100,
-    leadTimeDays: 3,
-    contractStart: '2024-02-01',
-    contractEnd: '2024-12-31',
-    status: 'active',
-  },
-  {
-    id: 'VP-002-04',
-    vendorId: 'VND-002',
-    productCode: 'ITM-K019',
-    productName: '주방세제 3L (대용량)',
-    unitPrice: 5400,
-    moq: 60,
-    leadTimeDays: 4,
-    contractStart: '2024-01-01',
-    contractEnd: '2024-12-31',
-    status: 'suspended',
-  },
-  {
-    id: 'VP-002-05',
-    vendorId: 'VND-002',
-    productCode: 'ITM-K027',
-    productName: '종이컵 6.5온스 (1000입)',
-    unitPrice: 9800,
-    moq: 40,
-    leadTimeDays: 5,
-    contractStart: '2024-01-01',
-    contractEnd: '2024-12-31',
-    status: 'active',
-  },
-  // VND-003 글로벌오피스 — 문구/사무 8건
-  {
-    id: 'VP-003-01',
-    vendorId: 'VND-003',
-    productCode: 'ITM-S005',
-    productName: 'A4 복사용지 80g (500매)',
-    unitPrice: 4100,
-    moq: 300,
-    leadTimeDays: 2,
-    contractStart: '2024-01-01',
-    contractEnd: '2024-12-31',
-    status: 'active',
-  },
-  {
-    id: 'VP-003-02',
-    vendorId: 'VND-003',
-    productCode: 'ITM-S006',
-    productName: '리무버블 데코 스티커 셋트',
-    unitPrice: 2100,
-    moq: 200,
-    leadTimeDays: 3,
-    contractStart: '2024-01-01',
-    contractEnd: '2024-12-31',
-    status: 'active',
-  },
-  {
-    id: 'VP-003-03',
-    vendorId: 'VND-003',
-    productCode: 'ITM-S007',
-    productName: '스테이플러 심 (10호)',
-    unitPrice: 850,
-    moq: 500,
-    leadTimeDays: 2,
-    contractStart: '2024-01-01',
-    contractEnd: '2024-12-31',
-    status: 'active',
-  },
-  {
-    id: 'VP-003-04',
-    vendorId: 'VND-003',
-    productCode: 'ITM-S012',
-    productName: '수정테이프 5mm x 10m',
-    unitPrice: 1600,
-    moq: 200,
-    leadTimeDays: 2,
-    contractStart: '2024-01-01',
-    contractEnd: '2024-12-31',
-    status: 'active',
-  },
-  {
-    id: 'VP-003-05',
-    vendorId: 'VND-003',
-    productCode: 'ITM-S017',
-    productName: '점착식 메모지 (노랑)',
-    unitPrice: 1200,
-    moq: 400,
-    leadTimeDays: 2,
-    contractStart: '2024-01-01',
-    contractEnd: '2024-12-31',
-    status: 'active',
-  },
-  {
-    id: 'VP-003-06',
-    vendorId: 'VND-003',
-    productCode: 'ITM-S022',
-    productName: 'L자 파일 홀더 (100매)',
-    unitPrice: 2900,
-    moq: 100,
-    leadTimeDays: 3,
-    contractStart: '2024-01-01',
-    contractEnd: '2024-12-31',
-    status: 'active',
-  },
-  {
-    id: 'VP-003-07',
-    vendorId: 'VND-003',
-    productCode: 'ITM-S028',
-    productName: '투명 박스 테이프 50mm',
-    unitPrice: 980,
-    moq: 300,
-    leadTimeDays: 2,
-    contractStart: '2024-03-01',
-    contractEnd: '2024-09-30',
-    status: 'expired',
-  },
-  {
-    id: 'VP-003-08',
-    vendorId: 'VND-003',
-    productCode: 'ITM-S034',
-    productName: '더블클립 (중/20입)',
-    unitPrice: 1500,
-    moq: 200,
-    leadTimeDays: 2,
-    contractStart: '2024-01-01',
-    contractEnd: '2024-12-31',
-    status: 'active',
-  },
-  // VND-004 위생물자(주) — 위생제품 3건 (inactive 거래처)
-  {
-    id: 'VP-004-01',
-    vendorId: 'VND-004',
-    productCode: 'ITM-H018',
-    productName: 'KF94 마스크 (50매입)',
-    unitPrice: 5800,
-    moq: 100,
-    leadTimeDays: 4,
-    contractStart: '2023-07-01',
-    contractEnd: '2024-06-30',
-    status: 'expired',
-  },
-  {
-    id: 'VP-004-02',
-    vendorId: 'VND-004',
-    productCode: 'ITM-H025',
-    productName: '탁상용 미니 가습기',
-    unitPrice: 18500,
-    moq: 20,
-    leadTimeDays: 8,
-    contractStart: '2023-07-01',
-    contractEnd: '2024-06-30',
-    status: 'expired',
-  },
-  {
-    id: 'VP-004-03',
-    vendorId: 'VND-004',
-    productCode: 'ITM-H026',
-    productName: '퍼퓸 핸드크림 50ml',
-    unitPrice: 3200,
-    moq: 150,
-    leadTimeDays: 5,
-    contractStart: '2023-07-01',
-    contractEnd: '2024-06-30',
-    status: 'suspended',
-  },
-  // VND-005 스마트주방솔루션 — 주방잡화 4건
-  {
-    id: 'VP-005-01',
-    vendorId: 'VND-005',
-    productCode: 'ITM-K011',
-    productName: '니트릴 고무장갑 (M/100입)',
-    unitPrice: 8900,
-    moq: 30,
-    leadTimeDays: 6,
-    contractStart: '2024-02-01',
-    contractEnd: '2024-12-31',
-    status: 'active',
-  },
-  {
-    id: 'VP-005-02',
-    vendorId: 'VND-005',
-    productCode: 'ITM-K020',
-    productName: '다목적 수세미 (5입)',
-    unitPrice: 2200,
-    moq: 100,
-    leadTimeDays: 4,
-    contractStart: '2024-02-01',
-    contractEnd: '2024-12-31',
-    status: 'active',
-  },
-  {
-    id: 'VP-005-03',
-    vendorId: 'VND-005',
-    productCode: 'ITM-K003',
-    productName: '유리제 머그컵 350ml',
-    unitPrice: 7500,
-    moq: 40,
-    leadTimeDays: 7,
-    contractStart: '2024-01-01',
-    contractEnd: '2024-06-30',
-    status: 'expired',
-  },
-  {
-    id: 'VP-005-04',
-    vendorId: 'VND-005',
-    productCode: 'ITM-K027',
-    productName: '종이컵 6.5온스 (1000입)',
-    unitPrice: 10200,
-    moq: 30,
-    leadTimeDays: 5,
-    contractStart: '2024-04-01',
-    contractEnd: '2025-03-31',
-    status: 'active',
-  },
-]
-
-function loadFromStorage(key, fallback) {
-  try {
-    const saved = localStorage.getItem(key)
-    return saved ? JSON.parse(saved) : fallback
-  } catch {
-    return fallback
+function fromApiVendor(v) {
+  return {
+    id: v.code,
+    name: v.name,
+    contactPerson: v.contactName,
+    contactEmail: v.contactEmail,
+    phone: v.contactPhone,
+    status: (v.status ?? '').toLowerCase(),
   }
 }
 
-function saveToStorage(key, value) {
-  try {
-    localStorage.setItem(key, JSON.stringify(value))
-  } catch {
-    // 스토리지 저장 실패 시 무시
+function fromApiVendorProduct(vp) {
+  return {
+    id: vp.code,
+    vendorId: vp.vendorCode,
+    vendorName: vp.vendorName,
+    productCode: vp.productCode,
+    productName: vp.productName,
+    unitPrice: vp.unitPrice,
+    moq: vp.moq,
+    leadTimeDays: vp.leadTimeDays,
+    contractStart: vp.contractStart,
+    contractEnd: vp.contractEnd,
+    status: (vp.status ?? '').toLowerCase(),
   }
-}
-
-function generateId(prefix) {
-  return `${prefix}-${Date.now()}-${Math.floor(Math.random() * 1000)}`
 }
 
 export const useVendorStore = defineStore('vendor', () => {
   // --- state ---
-  const vendors = ref(loadFromStorage(VENDORS_KEY, INITIAL_VENDORS))
-  const vendorProducts = ref(loadFromStorage(VENDOR_PRODUCTS_KEY, INITIAL_VENDOR_PRODUCTS))
+  const vendors = ref([])
+  const vendorProducts = ref([]) // 현재 선택된 vendor 의 계약 제품만 보유
   const selectedVendorId = ref(null)
   const selectedProductId = ref(null)
+  const loading = ref(false)
 
   // --- getters ---
   const currentVendorProducts = computed(() => {
@@ -420,15 +63,14 @@ export const useVendorStore = defineStore('vendor', () => {
       const matchKeyword =
         !keyword ||
         v.name.toLowerCase().includes(keyword) ||
-        v.contactPerson.toLowerCase().includes(keyword) ||
-        v.contactEmail.toLowerCase().includes(keyword)
+        (v.contactPerson ?? '').toLowerCase().includes(keyword) ||
+        (v.contactEmail ?? '').toLowerCase().includes(keyword)
       return matchStatus && matchKeyword
     })
   }
 
-  // 같은 거래처에 같은 제품 코드가 이미 등록되어 있는지 검사
-  // - CEN-027 등록: excludeId 없이 호출
-  // - CEN-028 수정: 자기 자신은 중복 판정에서 제외하기 위해 excludeId = 현재 VP id
+  // 같은 거래처에 같은 제품 코드가 이미 등록되어 있는지 검사 (UX 즉시 피드백용)
+  // BE 도 DUPLICATE_VENDOR_PRODUCT_CODE 로 막지만 입력 시점 즉시 알림.
   function isProductCodeDuplicate(vendorId, productCode, excludeId = null) {
     if (!vendorId || !productCode) return false
     return vendorProducts.value.some(
@@ -441,86 +83,122 @@ export const useVendorStore = defineStore('vendor', () => {
 
   // --- actions ---
 
-  // 거래처 선택
-  function selectVendor(id) {
-    selectedVendorId.value = id
-    selectedProductId.value = null
+  // 거래처 목록 fetch (mount 시)
+  async function fetchVendors() {
+    loading.value = true
+    try {
+      const list = await vendorApi.listVendors()
+      vendors.value = (list ?? []).map(fromApiVendor)
+    } finally {
+      loading.value = false
+    }
   }
 
-  // 계약 제품 선택
+  // 거래처별 계약 제품 fetch
+  async function fetchProductsByVendor(vendorCode) {
+    if (!vendorCode) {
+      vendorProducts.value = []
+      return
+    }
+    loading.value = true
+    try {
+      const list = await vendorApi.listVendorProducts(vendorCode)
+      vendorProducts.value = (list ?? []).map(fromApiVendorProduct)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  // 거래처 선택 + 그 거래처의 제품 자동 fetch
+  async function selectVendor(id) {
+    selectedVendorId.value = id
+    selectedProductId.value = null
+    await fetchProductsByVendor(id)
+  }
+
   function selectProduct(id) {
     selectedProductId.value = id
   }
 
-  // 계약 제품 등록 (SO-018)
-  function createProduct(data) {
-    const newProduct = {
-      id: generateId('VP'),
-      vendorId: selectedVendorId.value,
+  // 계약 제품 등록 (CEN-027)
+  async function createProduct(data) {
+    const created = await vendorApi.createVendorProduct({
+      vendorCode: selectedVendorId.value,
       productCode: data.productCode,
       productName: data.productName,
       unitPrice: Number(data.unitPrice),
-      moq: Number(data.moq),
-      leadTimeDays: Number(data.leadTimeDays),
-      contractStart: data.contractStart,
-      contractEnd: data.contractEnd,
-      status: data.status ?? 'active',
-    }
-    vendorProducts.value = [...vendorProducts.value, newProduct]
-    saveToStorage(VENDOR_PRODUCTS_KEY, vendorProducts.value)
-    return newProduct
+      moq: data.moq != null ? Number(data.moq) : null,
+      leadTimeDays: data.leadTimeDays != null ? Number(data.leadTimeDays) : null,
+      contractStart: data.contractStart || null,
+      contractEnd: data.contractEnd || null,
+    })
+    const mapped = fromApiVendorProduct(created)
+    vendorProducts.value = [...vendorProducts.value, mapped]
+    return mapped
   }
 
-  // 계약 제품 수정 (SO-019)
-  function updateProduct(id, data) {
-    const idx = vendorProducts.value.findIndex((vp) => vp.id === id)
-    if (idx === -1) return false
-    vendorProducts.value[idx] = {
-      ...vendorProducts.value[idx],
-      productCode: data.productCode,
+  // 계약 제품 수정 (CEN-028) — id 는 BE 의 code 와 동일
+  async function updateProduct(id, data) {
+    const updated = await vendorApi.updateVendorProduct(id, {
       productName: data.productName,
       unitPrice: Number(data.unitPrice),
-      moq: Number(data.moq),
-      leadTimeDays: Number(data.leadTimeDays),
-      contractStart: data.contractStart,
-      contractEnd: data.contractEnd,
-    }
-    saveToStorage(VENDOR_PRODUCTS_KEY, vendorProducts.value)
-    return true
-  }
-
-  // 계약 제품 상태 변경 (SO-020): active ↔ suspended
-  function updateStatus(id, newStatus) {
+      moq: data.moq != null ? Number(data.moq) : null,
+      leadTimeDays: data.leadTimeDays != null ? Number(data.leadTimeDays) : null,
+      contractStart: data.contractStart || null,
+      contractEnd: data.contractEnd || null,
+    })
+    const mapped = fromApiVendorProduct(updated)
     const idx = vendorProducts.value.findIndex((vp) => vp.id === id)
-    if (idx === -1) return false
-    vendorProducts.value[idx] = { ...vendorProducts.value[idx], status: newStatus }
-    saveToStorage(VENDOR_PRODUCTS_KEY, vendorProducts.value)
-    if (selectedProductId.value === id) {
-      // 선택 상태 유지 (computed 자동 반영)
+    if (idx !== -1) {
+      const next = [...vendorProducts.value]
+      next[idx] = mapped
+      vendorProducts.value = next
     }
-    return true
+    return mapped
   }
 
-  // 계약 제품 삭제 (SO-021)
-  function deleteProduct(id) {
+  // 계약 제품 상태 변경 (CEN-029): active ↔ suspended
+  async function updateStatus(id, newStatus) {
+    const beStatus = String(newStatus).toUpperCase()
+    const updated = await vendorApi.updateVendorProductStatus(id, beStatus)
+    const mapped = fromApiVendorProduct(updated)
+    const idx = vendorProducts.value.findIndex((vp) => vp.id === id)
+    if (idx !== -1) {
+      const next = [...vendorProducts.value]
+      next[idx] = mapped
+      vendorProducts.value = next
+    }
+    return mapped
+  }
+
+  // 계약 제품 삭제 (CEN-030, SOFT DELETE) — 로컬 배열에서 제거
+  async function deleteProduct(id) {
+    await vendorApi.deleteVendorProduct(id)
     vendorProducts.value = vendorProducts.value.filter((vp) => vp.id !== id)
     if (selectedProductId.value === id) {
       selectedProductId.value = null
     }
-    saveToStorage(VENDOR_PRODUCTS_KEY, vendorProducts.value)
     return true
   }
+
+  // 스토어 생성 시 자동으로 거래처 목록 fetch
+  fetchVendors().catch((err) => {
+    console.error('[vendor] fetchVendors 실패', err)
+  })
 
   return {
     vendors,
     vendorProducts,
     selectedVendorId,
     selectedProductId,
+    loading,
     currentVendorProducts,
     selectedProductDetail,
     selectedVendor,
     filteredVendors,
     isProductCodeDuplicate,
+    fetchVendors,
+    fetchProductsByVendor,
     selectVendor,
     selectProduct,
     createProduct,

--- a/src/views/hq/HqVendorManagementView.vue
+++ b/src/views/hq/HqVendorManagementView.vue
@@ -167,17 +167,21 @@ function triggerToast(message) {
   }, 3000)
 }
 
-function handleSubmitForm() {
+async function handleSubmitForm() {
   if (!validateForm()) return
 
-  if (modalMode.value === 'create') {
-    vendor.createProduct(formData.value)
-    closeModal()
-    triggerToast('계약 제품이 등록되었습니다')
-  } else {
-    vendor.updateProduct(vendor.selectedProductId, formData.value)
-    closeModal()
-    triggerToast('계약 제품 정보가 수정되었습니다')
+  try {
+    if (modalMode.value === 'create') {
+      await vendor.createProduct(formData.value)
+      closeModal()
+      triggerToast('계약 제품이 등록되었습니다')
+    } else {
+      await vendor.updateProduct(vendor.selectedProductId, formData.value)
+      closeModal()
+      triggerToast('계약 제품 정보가 수정되었습니다')
+    }
+  } catch (err) {
+    triggerToast(err?.message ?? '요청 처리 중 오류가 발생했습니다')
   }
 }
 
@@ -201,12 +205,17 @@ function handleToggleStatus() {
   showStatusConfirm.value = true
 }
 
-function confirmStatusChange() {
+async function confirmStatusChange() {
   const change = pendingStatusChange.value
   if (!change) return
-  vendor.updateStatus(change.productId, change.newStatus)
-  triggerToast(`계약이 "${change.label}" 상태로 변경되었습니다`)
-  cancelStatusChange()
+  try {
+    await vendor.updateStatus(change.productId, change.newStatus)
+    triggerToast(`계약이 "${change.label}" 상태로 변경되었습니다`)
+  } catch (err) {
+    triggerToast(err?.message ?? '상태 변경에 실패했습니다')
+  } finally {
+    cancelStatusChange()
+  }
 }
 
 function cancelStatusChange() {
@@ -215,11 +224,15 @@ function cancelStatusChange() {
 }
 
 // --- 삭제 ---
-function handleDeleteProduct() {
+async function handleDeleteProduct() {
   const detail = vendor.selectedProductDetail
   if (!detail) return
-  if (confirm(`[${detail.productName}] 계약을 삭제하시겠습니까?\n이 작업은 되돌릴 수 없습니다.`)) {
-    vendor.deleteProduct(detail.id)
+  if (!confirm(`[${detail.productName}] 계약을 삭제하시겠습니까?\n이 작업은 되돌릴 수 없습니다.`)) return
+  try {
+    await vendor.deleteProduct(detail.id)
+    triggerToast('계약 제품이 삭제되었습니다')
+  } catch (err) {
+    triggerToast(err?.message ?? '삭제에 실패했습니다')
   }
 }
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -17,4 +17,14 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url))
     },
   },
+  server: {
+    proxy: {
+      // /api/** 요청을 BE(8080) 로 리버스 프록시 — dev 단계 CORS 회피용.
+      // 운영 빌드(npm run build) 결과물에는 영향 없음 (Vite dev 서버 한정).
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
## 📌 요약
- 본사 공급처별 제품 관리 영역의 데이터 레이어를 **localStorage 시드 → BE axios 연동**으로 전환 (`/api/vendors`, `/api/vendor-products` 호출 기반)

<br><br>

## 🎯 작업 내용
- **axios 공통화 및 API 모듈 분리**
  - `src/api/axios.js` 신규 — axios 인스턴스 공통화 + `unwrap` 헬퍼 (BaseResponse `success=false` 응답을 한국어 `message`로 `Error` throw)
  - `src/api/vendor.js` 신규 — 거래처/계약 제품 도메인 함수 8개 노출
- **store 리팩토링 (`src/stores/vendor.js`)**
  - `INITIAL_VENDORS` / `INITIAL_VENDOR_PRODUCTS` 시드 및 localStorage 로직 제거
  - BE 응답 → FE 화면 모델 매핑 함수 추가 (`code → id`, `vendorCode → vendorId`, `contactName → contactPerson`, `status` 대문자 → 소문자)
- **개발 환경 CORS 처리**
  - `vite.config.js`에 `/api` 리버스 프록시 설정
  - axios `baseURL`은 빈 문자열로 두어 same-origin 요청 처리
  - 운영 빌드 시 `VITE_API_BASE` 환경변수로 BE 도메인 분기 가능
- **`HqVendorManagementView` 호출부 비동기 전환**
  - 등록·수정·상태변경·삭제 4곳을 `async` + `try/catch`로 교체
  - 실패 시 `err.message`를 토스트로 노출

<br><br>

## ✔️ 참고 사항
- 마크업 및 검증 로직은 변경 없이 데이터 레이어만 교체 — 화면 동작 동일
- `isProductCodeDuplicate` 로컬 중복 검사는 즉시 UX 피드백 용도로 유지 (BE 검증과 이중 방어)
- BE는 SOFT DELETE 처리 — DELETE 호출 시 `status=DELETED`로 변경되며 목록 조회에서 제외됨

<br><br>

## ✔️ 관련 이슈
- Close #273 

<br><br>