### PR TITLE
feat: 본사 발주 BE axios 연동

### DIFF
--- a/src/api/purchaseOrder.js
+++ b/src/api/purchaseOrder.js
@@ -1,107 +1,67 @@
 /**
- * purchaseOrder.js — BE 연동 지점 주석 스텁
+ * purchaseOrder.js — BE 연동 (CEN-035~040)
  *
- * BE에서 PURCHASE_ORDER 관련 Controller/Service/Repository가 완성되면
- * 이 파일의 각 함수를 실제 axios 호출로 채우고,
- * stores/purchaseOrder.js 및 stores/aiOrderRecommendation.js의
- * 각 action에서 이 파일을 import하여 호출하도록 교체한다.
+ * BE 엔드포인트:
+ *   GET    /api/hq/purchase-orders?vendorCode=&status=&from=&to=    (목록, 모든 필터 optional)
+ *   GET    /api/hq/purchase-orders/{code}                            (상세 — items + statusHistory 포함)
+ *   POST   /api/hq/purchase-orders                                   (CEN-035 신규 발주)
+ *   PATCH  /api/hq/purchase-orders/{code}                            (CEN-037 수정 — PENDING 만)
+ *   POST   /api/hq/purchase-orders/{code}/approve                    (PENDING → APPROVED, 거래처 승인 대리)
+ *   POST   /api/hq/purchase-orders/{code}/start-shipping             (APPROVED → SHIPPING, 거래처 출고 시작 대리)
+ *   POST   /api/hq/purchase-orders/{code}/complete                   (SHIPPING → COMPLETED, 창고 WHS-007)
+ *   POST   /api/hq/purchase-orders/{code}/cancel                     (CEN-038 PENDING → REJECTED, with cancelReason)
  *
- * 기본 axios 인스턴스: src/api/axios.js (BE 연동 시 신설 예정)
- * baseURL: http://localhost:8080
+ * 응답: BaseResponse<T>. unwrap() 으로 result 만 추출, 실패 시 throw.
  */
 
-// ─────────────────────────────────────────────
-// 발주(PURCHASE_ORDER) 관련 API
-// ─────────────────────────────────────────────
+import { apiClient, unwrap } from './axios.js'
 
-/**
- * 발주 목록 조회 (SO-031)
- * GET /api/v1/purchase-orders?status=&page=&size=
- *
- * @param {{ status?: string, page?: number, size?: number }} params
- * @returns {Promise<{ content: Array, totalElements: number }>}
- */
-// export async function getPurchaseOrders(params = {}) {
-//   const res = await axios.get('/api/v1/purchase-orders', { params })
-//   return res.data.result
-// }
+const BASE = '/api/hq/purchase-orders'
 
-/**
- * 발주 상세 조회 (SO-032)
- * GET /api/v1/purchase-orders/{id}
- *
- * @param {string} id — 발주 ID (예: 'PO-20260420-001')
- * @returns {Promise<object>}
- */
-// export async function getPurchaseOrderById(id) {
-//   const res = await axios.get(`/api/v1/purchase-orders/${id}`)
-//   return res.data.result
-// }
+export const purchaseOrderApi = {
+  /**
+   * 목록 조회. 모든 필터 optional. server-side 필터 미사용 시 인자 없이 호출.
+   * @param {{vendorCode?: string, status?: string, from?: string, to?: string}} params
+   */
+  list: (params = {}) => {
+    const query = {}
+    if (params.vendorCode) query.vendorCode = params.vendorCode
+    if (params.status) query.status = params.status
+    if (params.from) query.from = params.from
+    if (params.to) query.to = params.to
+    return apiClient.get(BASE, { params: query }).then(unwrap)
+  },
 
-/**
- * 발주 생성 (SO-027)
- * POST /api/v1/purchase-orders
- *
- * @param {{ warehouseId: string, vendorId: string, items: Array, recommendationId?: string }} payload
- * @returns {Promise<object>} 생성된 발주 객체
- */
-// export async function createPurchaseOrder(payload) {
-//   const res = await axios.post('/api/v1/purchase-orders', payload)
-//   return res.data.result
-// }
+  /** 상세 조회 (items + statusHistory 포함) */
+  detail: (code) => apiClient.get(`${BASE}/${code}`).then(unwrap),
 
-/**
- * 발주 수정 (SO-028) — PENDING 상태만 허용
- * PUT /api/v1/purchase-orders/{id}
- *
- * @param {string} id
- * @param {{ warehouseId?: string, items?: Array }} payload
- * @returns {Promise<object>}
- */
-// export async function updatePurchaseOrder(id, payload) {
-//   const res = await axios.put(`/api/v1/purchase-orders/${id}`, payload)
-//   return res.data.result
-// }
+  /**
+   * 신규 발주 (CEN-035, 036)
+   * @param {{vendorCode, warehouseId, warehouseName, memberId?, memberName?, items: [{vendorProductCode, quantity}]}} req
+   */
+  create: (req) => apiClient.post(BASE, req).then(unwrap),
 
-/**
- * 발주 취소 (SO-029) — PENDING 상태만 허용, status를 REJECTED로 전환
- * DELETE /api/v1/purchase-orders/{id}
- *
- * @param {string} id
- * @returns {Promise<void>}
- */
-// export async function cancelPurchaseOrder(id) {
-//   await axios.delete(`/api/v1/purchase-orders/${id}`)
-// }
+  /**
+   * 수정 (CEN-037, PENDING 만)
+   * @param {string} code
+   * @param {{warehouseId?, warehouseName?, items: [{vendorProductCode, quantity}]}} req
+   */
+  update: (code, req) => apiClient.patch(`${BASE}/${code}`, req).then(unwrap),
 
-// ─────────────────────────────────────────────
-// AI 발주 추천(AI_ORDER_RECOMMENDATION) 관련 API
-// ─────────────────────────────────────────────
+  /** 거래처 승인 대리 (PENDING → APPROVED) */
+  approve: (code) => apiClient.post(`${BASE}/${code}/approve`).then(unwrap),
 
-/**
- * AI 권장 발주량 조회 (SO-030)
- * GET /api/v1/ai-recommendations?warehouseId=&status=
- *
- * @param {{ warehouseId?: string, status?: string }} params
- * @returns {Promise<Array>}
- */
-// export async function getAiRecommendations(params = {}) {
-//   const res = await axios.get('/api/v1/ai-recommendations', { params })
-//   return res.data.result
-// }
+  /** 거래처 출고 시작 대리 (APPROVED → SHIPPING) */
+  startShipping: (code) => apiClient.post(`${BASE}/${code}/start-shipping`).then(unwrap),
 
-// ─────────────────────────────────────────────
-// 제품 검색 관련 API (발주 장바구니, SO-026)
-// ─────────────────────────────────────────────
+  /** 입고 확정 (SHIPPING → COMPLETED, 창고 WHS-007) */
+  complete: (code) => apiClient.post(`${BASE}/${code}/complete`).then(unwrap),
 
-/**
- * 제품 검색 — 거래처별 계약 제품 검색
- * GET /api/v1/products/search?keyword=&vendorId=
- *
- * @param {{ keyword: string, vendorId?: string }} params
- * @returns {Promise<Array>}
- */
-// export async function searchProducts(params = {}) {
-//   const res = await axios.get('/api/v1/products/search', { params })
-//   return res.data.result
-// }
+  /**
+   * 취소 (CEN-038, PENDING → REJECTED)
+   * @param {string} code
+   * @param {string} cancelReason — 필수 (BE 가 빈 문자열이면 거절)
+   */
+  cancel: (code, cancelReason) =>
+    apiClient.post(`${BASE}/${code}/cancel`, { cancelReason }).then(unwrap),
+}

--- a/src/stores/inbound.js
+++ b/src/stores/inbound.js
@@ -65,8 +65,8 @@ export const useInboundStore = defineStore('inbound', () => {
 
   // 입고 확정 — purchaseOrder store 의 markCompleted 위임
   // (statusHistory push 는 markCompleted 안에서 자동 처리)
-  function confirmInbound(id) {
-    poStore.markCompleted(id)
+  async function confirmInbound(id) {
+    return poStore.markCompleted(id)
   }
 
   return {

--- a/src/stores/purchaseOrder.js
+++ b/src/stores/purchaseOrder.js
@@ -1,7 +1,8 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
+import { purchaseOrderApi } from '@/api/purchaseOrder.js'
 
-// 창고 더미 목록 (BE 연동 전 상수)
+// 창고 더미 목록 (창고 BE 미구현 — logical reference)
 const WAREHOUSES = [
   { id: 'WH-001', name: '서울 1센터' },
   { id: 'WH-002', name: '인천 제1센터' },
@@ -10,339 +11,84 @@ const WAREHOUSES = [
   { id: 'WH-005', name: '대구 통합센터' },
 ]
 
-// localStorage 키
-const STORAGE_KEY = 'stockit:purchase-orders'
+// ─── BE ↔ FE 매핑 헬퍼 ─────────────────────────────────────────────────────
+// BE (PurchaseOrder DetailRes/ListRes) ↔ FE store 형식 변환.
+// 매핑:
+//   BE code               → FE id
+//   BE vendorCode         → FE vendorId
+//   BE totalAmount        → FE totalPrice
+//   BE items[].vendorProductCode → FE items[].productId
+//   BE statusHistory[].changedAt    → FE statusHistory[].at
+//   BE statusHistory[].changedByName → FE statusHistory[].byName
+// 그 외 필드는 동일 이름 그대로.
 
-// 발주 번호 생성 헬퍼 (PO-YYYYMMDD-NNN)
-function generatePoId(list) {
-  const today = new Date()
-  const dateStr = today.toISOString().slice(0, 10).replace(/-/g, '')
-  const todayOrders = list.filter((o) => o.id.includes(`PO-${dateStr}`))
-  const seq = String(todayOrders.length + 1).padStart(3, '0')
-  return `PO-${dateStr}-${seq}`
+function toFeOrder(beOrder) {
+  if (!beOrder) return null
+  return {
+    id: beOrder.code,
+    warehouseId: beOrder.warehouseId ?? '',
+    warehouseName: beOrder.warehouseName ?? '',
+    vendorId: beOrder.vendorCode,
+    vendorName: beOrder.vendorName ?? '',
+    memberId: beOrder.memberId ?? '',
+    memberName: beOrder.memberName ?? '',
+    status: beOrder.status,
+    totalPrice: beOrder.totalAmount ?? 0,
+    cancelReason: beOrder.cancelReason ?? '',
+    createdAt: beOrder.createdAt ?? '',
+    updatedAt: beOrder.updatedAt ?? '',
+    items: Array.isArray(beOrder.items) ? beOrder.items.map(toFeItem) : [],
+    statusHistory: Array.isArray(beOrder.statusHistory)
+      ? beOrder.statusHistory.map(toFeHistory)
+      : [],
+  }
 }
 
-// 더미 발주 데이터 시드 (10~15건)
-const SEED_ORDERS = [
-  {
-    id: 'PO-20260415-001',
-    warehouseId: 'WH-001',
-    warehouseName: '서울 1센터',
-    vendorId: 'VND-001',
-    vendorName: '(주)테크서플라이',
-    memberId: 'MB-003',
-    memberName: '이선엽',
-    recommendationId: null,
-    status: 'COMPLETED',
-    totalPrice: 4500000,
-    createdAt: '2026-04-15T09:30:00',
-    updatedAt: '2026-04-17T14:20:00',
-    statusHistory: [
-      { status: 'PENDING', at: '2026-04-15T09:30:00', byName: '이선엽' },
-      { status: 'APPROVED', at: '2026-04-15T11:00:00', byName: '이선엽' },
-      { status: 'SHIPPING', at: '2026-04-16T08:30:00', byName: '이선엽' },
-      { status: 'COMPLETED', at: '2026-04-17T14:20:00', byName: '이선엽' },
-    ],
-    items: [
-      {
-        id: 'PI-001-1',
-        productId: 'PRD-001',
-        productCode: 'PRD-001',
-        productName: '고속 충전기 (C타입) 25W',
-        quantity: 300,
-        unitPrice: 15000,
-        subtotal: 4500000,
-      },
-    ],
-  },
-  {
-    id: 'PO-20260416-001',
-    warehouseId: 'WH-002',
-    warehouseName: '인천 제1센터',
-    vendorId: 'VND-002',
-    vendorName: '글로벌오피스(주)',
-    memberId: 'MB-003',
-    memberName: '이선엽',
-    recommendationId: 'AI-001',
-    status: 'APPROVED',
-    totalPrice: 2400000,
-    createdAt: '2026-04-16T10:15:00',
-    updatedAt: '2026-04-16T11:00:00',
-    statusHistory: [
-      { status: 'PENDING', at: '2026-04-16T10:15:00', byName: '이선엽' },
-      { status: 'APPROVED', at: '2026-04-16T11:00:00', byName: '이선엽' },
-    ],
-    items: [
-      {
-        id: 'PI-002-1',
-        productId: 'PRD-004',
-        productCode: 'PRD-004',
-        productName: 'A4 복사용지 80g (500매)',
-        quantity: 200,
-        unitPrice: 6500,
-        subtotal: 1300000,
-      },
-      {
-        id: 'PI-002-2',
-        productId: 'PRD-005',
-        productCode: 'PRD-005',
-        productName: '더블클립 세트 (19mm)',
-        quantity: 500,
-        unitPrice: 2200,
-        subtotal: 1100000,
-      },
-    ],
-  },
-  {
-    id: 'PO-20260416-002',
-    warehouseId: 'WH-003',
-    warehouseName: '경기 남부센터',
-    vendorId: 'VND-001',
-    vendorName: '(주)테크서플라이',
-    memberId: 'MB-003',
-    memberName: '이선엽',
-    recommendationId: null,
-    status: 'SHIPPING',
-    totalPrice: 5800000,
-    createdAt: '2026-04-16T13:00:00',
-    updatedAt: '2026-04-17T08:30:00',
-    statusHistory: [
-      { status: 'PENDING', at: '2026-04-16T13:00:00', byName: '이선엽' },
-      { status: 'APPROVED', at: '2026-04-16T18:00:00', byName: '이선엽' },
-      { status: 'SHIPPING', at: '2026-04-17T08:30:00', byName: '이선엽' },
-    ],
-    items: [
-      {
-        id: 'PI-003-1',
-        productId: 'PRD-002',
-        productCode: 'PRD-002',
-        productName: '대용량 보조배터리 20000mAh',
-        quantity: 100,
-        unitPrice: 58000,
-        subtotal: 5800000,
-      },
-    ],
-  },
-  {
-    id: 'PO-20260417-001',
-    warehouseId: 'WH-001',
-    warehouseName: '서울 1센터',
-    vendorId: 'VND-003',
-    vendorName: '헬스케어솔루션(주)',
-    memberId: 'MB-003',
-    memberName: '이선엽',
-    recommendationId: 'AI-002',
-    status: 'PENDING',
-    totalPrice: 1250000,
-    createdAt: '2026-04-17T09:00:00',
-    updatedAt: '2026-04-17T09:00:00',
-    statusHistory: [
-      { status: 'PENDING', at: '2026-04-17T09:00:00', byName: '이선엽' },
-    ],
-    items: [
-      {
-        id: 'PI-004-1',
-        productId: 'PRD-007',
-        productCode: 'PRD-007',
-        productName: 'KF94 마스크 (50매입)',
-        quantity: 500,
-        unitPrice: 2500,
-        subtotal: 1250000,
-      },
-    ],
-  },
-  {
-    id: 'PO-20260417-002',
-    warehouseId: 'WH-004',
-    warehouseName: '부산 물류센터',
-    vendorId: 'VND-004',
-    vendorName: '리빙플러스(주)',
-    memberId: 'MB-003',
-    memberName: '이선엽',
-    recommendationId: null,
-    status: 'REJECTED',
-    totalPrice: 420000,
-    cancelReason: '거래처 단가 변경으로 발주 취소',
-    createdAt: '2026-04-17T11:30:00',
-    updatedAt: '2026-04-17T14:00:00',
-    statusHistory: [
-      { status: 'PENDING', at: '2026-04-17T11:30:00', byName: '이선엽' },
-      { status: 'REJECTED', at: '2026-04-17T14:00:00', byName: '이선엽' },
-    ],
-    items: [
-      {
-        id: 'PI-005-1',
-        productId: 'PRD-010',
-        productCode: 'PRD-010',
-        productName: '탁상용 미니 가습기',
-        quantity: 30,
-        unitPrice: 14000,
-        subtotal: 420000,
-      },
-    ],
-  },
-  {
-    id: 'PO-20260418-001',
-    warehouseId: 'WH-002',
-    warehouseName: '인천 제1센터',
-    vendorId: 'VND-001',
-    vendorName: '(주)테크서플라이',
-    memberId: 'MB-003',
-    memberName: '이선엽',
-    recommendationId: null,
-    status: 'PENDING',
-    totalPrice: 3200000,
-    createdAt: '2026-04-18T08:45:00',
-    updatedAt: '2026-04-18T08:45:00',
-    statusHistory: [
-      { status: 'PENDING', at: '2026-04-18T08:45:00', byName: '이선엽' },
-    ],
-    items: [
-      {
-        id: 'PI-006-1',
-        productId: 'PRD-003',
-        productCode: 'PRD-003',
-        productName: '무소음 무선 마우스',
-        quantity: 80,
-        unitPrice: 25000,
-        subtotal: 2000000,
-      },
-      {
-        id: 'PI-006-2',
-        productId: 'PRD-006',
-        productCode: 'PRD-006',
-        productName: '기계식 키보드 (갈축)',
-        quantity: 20,
-        unitPrice: 60000,
-        subtotal: 1200000,
-      },
-    ],
-  },
-  {
-    id: 'PO-20260418-002',
-    warehouseId: 'WH-005',
-    warehouseName: '대구 통합센터',
-    vendorId: 'VND-005',
-    vendorName: '스마트스토리지(주)',
-    memberId: 'MB-003',
-    memberName: '이선엽',
-    recommendationId: null,
-    status: 'APPROVED',
-    totalPrice: 880000,
-    createdAt: '2026-04-18T10:20:00',
-    updatedAt: '2026-04-18T15:30:00',
-    statusHistory: [
-      { status: 'PENDING', at: '2026-04-18T10:20:00', byName: '이선엽' },
-      { status: 'APPROVED', at: '2026-04-18T15:30:00', byName: '이선엽' },
-    ],
-    items: [
-      {
-        id: 'PI-007-1',
-        productId: 'PRD-011',
-        productCode: 'PRD-011',
-        productName: '투명 박스 테이프 (48mm)',
-        quantity: 400,
-        unitPrice: 2200,
-        subtotal: 880000,
-      },
-    ],
-  },
-  {
-    id: 'PO-20260419-001',
-    warehouseId: 'WH-001',
-    warehouseName: '서울 1센터',
-    vendorId: 'VND-002',
-    vendorName: '글로벌오피스(주)',
-    memberId: 'MB-003',
-    memberName: '이선엽',
-    recommendationId: 'AI-003',
-    status: 'PENDING',
-    totalPrice: 1950000,
-    createdAt: '2026-04-19T09:15:00',
-    updatedAt: '2026-04-19T09:15:00',
-    statusHistory: [
-      { status: 'PENDING', at: '2026-04-19T09:15:00', byName: '이선엽' },
-    ],
-    items: [
-      {
-        id: 'PI-008-1',
-        productId: 'PRD-012',
-        productCode: 'PRD-012',
-        productName: '절전형 5구 멀티탭 (3m)',
-        quantity: 150,
-        unitPrice: 13000,
-        subtotal: 1950000,
-      },
-    ],
-  },
-  {
-    id: 'PO-20260419-002',
-    warehouseId: 'WH-003',
-    warehouseName: '경기 남부센터',
-    vendorId: 'VND-003',
-    vendorName: '헬스케어솔루션(주)',
-    memberId: 'MB-003',
-    memberName: '이선엽',
-    recommendationId: null,
-    status: 'SHIPPING',
-    totalPrice: 450000,
-    createdAt: '2026-04-19T11:00:00',
-    updatedAt: '2026-04-19T16:00:00',
-    statusHistory: [
-      { status: 'PENDING', at: '2026-04-19T11:00:00', byName: '이선엽' },
-      { status: 'APPROVED', at: '2026-04-19T13:30:00', byName: '이선엽' },
-      { status: 'SHIPPING', at: '2026-04-19T16:00:00', byName: '이선엽' },
-    ],
-    items: [
-      {
-        id: 'PI-009-1',
-        productId: 'PRD-008',
-        productCode: 'PRD-008',
-        productName: '휴대용 가글 (중) 250ml',
-        quantity: 300,
-        unitPrice: 1500,
-        subtotal: 450000,
-      },
-    ],
-  },
-  {
-    id: 'PO-20260420-001',
-    warehouseId: 'WH-002',
-    warehouseName: '인천 제1센터',
-    vendorId: 'VND-004',
-    vendorName: '리빙플러스(주)',
-    memberId: 'MB-003',
-    memberName: '이선엽',
-    recommendationId: null,
-    status: 'PENDING',
-    totalPrice: 650000,
-    createdAt: '2026-04-20T08:00:00',
-    updatedAt: '2026-04-20T08:00:00',
-    statusHistory: [
-      { status: 'PENDING', at: '2026-04-20T08:00:00', byName: '이선엽' },
-    ],
-    items: [
-      {
-        id: 'PI-010-1',
-        productId: 'PRD-009',
-        productCode: 'PRD-009',
-        productName: '유리제 머그컵 350ml',
-        quantity: 50,
-        unitPrice: 8900,
-        subtotal: 445000,
-      },
-      {
-        id: 'PI-010-2',
-        productId: 'PRD-013',
-        productCode: 'PRD-013',
-        productName: '종이컵 6.5온스 (1000개입)',
-        quantity: 10,
-        unitPrice: 20500,
-        subtotal: 205000,
-      },
-    ],
-  },
-]
+function toFeItem(beItem) {
+  return {
+    productId: beItem.vendorProductCode,
+    productCode: beItem.productCode,
+    productName: beItem.productName,
+    quantity: beItem.quantity,
+    unitPrice: beItem.unitPrice,
+    subtotal: beItem.subtotal,
+  }
+}
+
+function toFeHistory(beHistory) {
+  return {
+    status: beHistory.status,
+    at: beHistory.changedAt ?? '',
+    byName: beHistory.changedByName ?? '',
+    note: beHistory.note ?? '',
+  }
+}
+
+// FE createOrder/updateOrder payload → BE 요청 변환
+function toBeCreateReq({ vendorId, warehouseId, warehouseName, memberId, memberName, items }) {
+  return {
+    vendorCode: vendorId,
+    warehouseId: warehouseId ?? '',
+    warehouseName: warehouseName ?? '',
+    memberId: memberId ?? '',
+    memberName: memberName ?? '',
+    items: items.map((item) => ({
+      vendorProductCode: item.productId,
+      quantity: item.quantity,
+    })),
+  }
+}
+
+function toBeUpdateReq({ warehouseId, warehouseName, items }) {
+  return {
+    warehouseId: warehouseId ?? '',
+    warehouseName: warehouseName ?? '',
+    items: items.map((item) => ({
+      vendorProductCode: item.productId,
+      quantity: item.quantity,
+    })),
+  }
+}
 
 export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
   // --- 상태(state) ---
@@ -354,6 +100,8 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
   const dateFrom = ref('')
   const dateTo = ref('')
   const sortBy = ref('latest') // 'latest' | 'oldest' | 'priceAsc' | 'priceDesc'
+  const loading = ref(false)
+  const error = ref(null)
 
   // --- 게터(getters) ---
   const selectedOrder = computed(
@@ -363,12 +111,10 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
   const filteredOrders = computed(() => {
     let list = purchaseOrders.value
 
-    // 상태 탭 필터
     if (activeStatusTab.value !== '전체') {
       list = list.filter((o) => o.status === activeStatusTab.value)
     }
 
-    // 검색어 필터 (발주번호 또는 거래처명)
     if (searchKeyword.value.trim()) {
       const kw = searchKeyword.value.trim().toLowerCase()
       list = list.filter(
@@ -376,24 +122,21 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
       )
     }
 
-    // 거래처 필터
     if (vendorFilter.value) {
       list = list.filter((o) => o.vendorId === vendorFilter.value)
     }
 
-    // 기간 필터 (createdAt 의 YYYY-MM-DD 부분만 비교)
     if (dateFrom.value) {
-      list = list.filter((o) => o.createdAt.slice(0, 10) >= dateFrom.value)
+      list = list.filter((o) => (o.createdAt || '').slice(0, 10) >= dateFrom.value)
     }
     if (dateTo.value) {
-      list = list.filter((o) => o.createdAt.slice(0, 10) <= dateTo.value)
+      list = list.filter((o) => (o.createdAt || '').slice(0, 10) <= dateTo.value)
     }
 
-    // 정렬 — 새 배열로 (원본 mutate 금지)
     const sorted = [...list]
     switch (sortBy.value) {
       case 'oldest':
-        sorted.sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+        sorted.sort((a, b) => (a.createdAt || '').localeCompare(b.createdAt || ''))
         break
       case 'priceAsc':
         sorted.sort((a, b) => a.totalPrice - b.totalPrice)
@@ -402,7 +145,7 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
         sorted.sort((a, b) => b.totalPrice - a.totalPrice)
         break
       default:
-        sorted.sort((a, b) => b.createdAt.localeCompare(a.createdAt)) // 'latest'
+        sorted.sort((a, b) => (b.createdAt || '').localeCompare(a.createdAt || ''))
     }
     return sorted
   })
@@ -419,7 +162,6 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
     }
   })
 
-  // 거래처 필터 옵션 — 발주에 등장한 unique vendor 만, 한국어 이름 오름차순
   const vendorOptions = computed(() => {
     const seen = new Map()
     for (const o of purchaseOrders.value) {
@@ -430,18 +172,16 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
     return Array.from(seen.values()).sort((a, b) => a.name.localeCompare(b.name, 'ko'))
   })
 
-  // 통계 요약 — 거래처/기간 컨텍스트만 반영, 상태 탭/검색은 무시
-  // 상태 분포는 탭 카운트로 충분하므로 총 건수/금액만 노출
   const summary = computed(() => {
     let base = purchaseOrders.value
     if (vendorFilter.value) {
       base = base.filter((o) => o.vendorId === vendorFilter.value)
     }
     if (dateFrom.value) {
-      base = base.filter((o) => o.createdAt.slice(0, 10) >= dateFrom.value)
+      base = base.filter((o) => (o.createdAt || '').slice(0, 10) >= dateFrom.value)
     }
     if (dateTo.value) {
-      base = base.filter((o) => o.createdAt.slice(0, 10) <= dateTo.value)
+      base = base.filter((o) => (o.createdAt || '').slice(0, 10) <= dateTo.value)
     }
     return {
       totalCount: base.length,
@@ -452,190 +192,124 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
   const warehouses = computed(() => WAREHOUSES)
 
   // --- 액션(actions) ---
+
+  /**
+   * 목록 조회 — 모든 발주를 한 번에 받아와 client-side 로 필터/정렬.
+   * 상세는 list 응답에 items/statusHistory 가 없으므로,
+   * mutation 후 selectOrder 시 detail 을 별도 fetch 해서 갱신.
+   */
+  async function fetchOrders() {
+    loading.value = true
+    error.value = null
+    try {
+      const list = await purchaseOrderApi.list()
+      // ListRes 는 items/statusHistory 미포함 — 빈 배열로 채워둠
+      purchaseOrders.value = (list ?? []).map((o) => ({
+        ...toFeOrder(o),
+        items: [],
+        statusHistory: [],
+      }))
+    } catch (e) {
+      error.value = e?.message ?? '발주 목록을 불러오지 못했습니다.'
+      console.error('[purchaseOrder] fetchOrders 실패', e)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  /**
+   * 단건 상세 조회 — items + statusHistory 까지 채워서 store 에 반영.
+   * mutation 직후 또는 selectOrder 시 호출.
+   */
+  async function fetchDetail(id) {
+    try {
+      const detail = await purchaseOrderApi.detail(id)
+      const fe = toFeOrder(detail)
+      const idx = purchaseOrders.value.findIndex((o) => o.id === id)
+      if (idx >= 0) {
+        purchaseOrders.value.splice(idx, 1, fe)
+      } else {
+        purchaseOrders.value = [fe, ...purchaseOrders.value]
+      }
+      return fe
+    } catch (e) {
+      error.value = e?.message ?? '발주 상세를 불러오지 못했습니다.'
+      console.error('[purchaseOrder] fetchDetail 실패', e)
+      throw e
+    }
+  }
+
   function selectOrder(id) {
     selectedOrderId.value = id
+    if (id) {
+      // 상세 정보(items/statusHistory) 가 비어있으면 fetch
+      const order = purchaseOrders.value.find((o) => o.id === id)
+      if (order && (order.items.length === 0 || order.statusHistory.length === 0)) {
+        fetchDetail(id).catch(() => {
+          // fetchDetail 안에서 이미 처리
+        })
+      }
+    }
   }
 
-  function createOrder({
-    warehouseId,
-    vendorId,
-    vendorName,
-    items,
-    recommendationId = null,
-    memberId = 'MB-003',
-    memberName = '이선엽',
-  }) {
-    const warehouse = WAREHOUSES.find((w) => w.id === warehouseId)
-    const now = new Date().toISOString()
-    const totalPrice = items.reduce((sum, item) => sum + item.subtotal, 0)
+  async function createOrder(payload) {
+    const req = toBeCreateReq(payload)
+    const created = await purchaseOrderApi.create(req)
+    const fe = toFeOrder(created)
+    purchaseOrders.value = [fe, ...purchaseOrders.value]
+    return fe
+  }
 
-    const newOrder = {
-      id: generatePoId(purchaseOrders.value),
+  async function updateOrder(id, { warehouseId, items }) {
+    const warehouse = WAREHOUSES.find((w) => w.id === warehouseId)
+    const req = toBeUpdateReq({
       warehouseId,
       warehouseName: warehouse?.name ?? '',
-      vendorId,
-      vendorName,
-      memberId,
-      memberName,
-      recommendationId,
-      status: 'PENDING',
-      totalPrice,
-      createdAt: now,
-      updatedAt: now,
-      statusHistory: [{ status: 'PENDING', at: now, byName: memberName }],
-      items: items.map((item, idx) => ({
-        id: `PI-${Date.now()}-${idx + 1}`,
-        productId: item.productId,
-        productCode: item.productCode,
-        productName: item.productName,
-        quantity: item.quantity,
-        unitPrice: item.unitPrice,
-        subtotal: item.subtotal,
-      })),
-    }
-
-    purchaseOrders.value = [newOrder, ...purchaseOrders.value]
-    saveToStorage()
-    return newOrder
+      items,
+    })
+    const updated = await purchaseOrderApi.update(id, req)
+    const fe = toFeOrder(updated)
+    const idx = purchaseOrders.value.findIndex((o) => o.id === id)
+    if (idx >= 0) purchaseOrders.value.splice(idx, 1, fe)
+    return fe
   }
 
-  function updateOrder(id, { warehouseId, items }) {
-    const order = purchaseOrders.value.find((o) => o.id === id)
-    if (!order) return
-
-    if (order.status !== 'PENDING') {
-      console.warn(
-        `[purchaseOrder] updateOrder: ${id}는 PENDING 상태가 아닙니다 (현재: ${order.status})`,
-      )
-      return
-    }
-
-    const warehouse = WAREHOUSES.find((w) => w.id === warehouseId)
-    const totalPrice = items.reduce((sum, item) => sum + item.subtotal, 0)
-
-    order.warehouseId = warehouseId
-    order.warehouseName = warehouse?.name ?? order.warehouseName
-    order.items = items.map((item, idx) => ({
-      id: item.id ?? `PI-${Date.now()}-${idx + 1}`,
-      productId: item.productId,
-      productCode: item.productCode,
-      productName: item.productName,
-      quantity: item.quantity,
-      unitPrice: item.unitPrice,
-      subtotal: item.subtotal,
-    }))
-    order.totalPrice = totalPrice
-    order.updatedAt = new Date().toISOString()
-
-    saveToStorage()
+  async function approveOrder(id) {
+    const updated = await purchaseOrderApi.approve(id)
+    const fe = toFeOrder(updated)
+    const idx = purchaseOrders.value.findIndex((o) => o.id === id)
+    if (idx >= 0) purchaseOrders.value.splice(idx, 1, fe)
+    return fe
   }
 
-  function cancelOrder(id, reason = '') {
-    const order = purchaseOrders.value.find((o) => o.id === id)
-    if (!order) return
-
-    if (order.status !== 'PENDING') {
-      console.warn(
-        `[purchaseOrder] cancelOrder: ${id}는 PENDING 상태가 아닙니다 (현재: ${order.status})`,
-      )
-      return
-    }
-
-    const now = new Date().toISOString()
-    order.status = 'REJECTED'
-    order.cancelReason = reason
-    order.statusHistory = [
-      ...(order.statusHistory ?? []),
-      { status: 'REJECTED', at: now, byName: order.memberName },
-    ]
-    order.updatedAt = now
-    saveToStorage()
+  async function markShipping(id) {
+    const updated = await purchaseOrderApi.startShipping(id)
+    const fe = toFeOrder(updated)
+    const idx = purchaseOrders.value.findIndex((o) => o.id === id)
+    if (idx >= 0) purchaseOrders.value.splice(idx, 1, fe)
+    return fe
   }
 
-  function approveOrder(id) {
-    const order = purchaseOrders.value.find((o) => o.id === id)
-    if (!order || order.status !== 'PENDING') return
-
-    const now = new Date().toISOString()
-    order.status = 'APPROVED'
-    order.statusHistory = [
-      ...(order.statusHistory ?? []),
-      { status: 'APPROVED', at: now, byName: order.memberName },
-    ]
-    order.updatedAt = now
-    saveToStorage()
+  async function markCompleted(id) {
+    const updated = await purchaseOrderApi.complete(id)
+    const fe = toFeOrder(updated)
+    const idx = purchaseOrders.value.findIndex((o) => o.id === id)
+    if (idx >= 0) purchaseOrders.value.splice(idx, 1, fe)
+    return fe
   }
 
-  function markShipping(id) {
-    const order = purchaseOrders.value.find((o) => o.id === id)
-    if (!order || order.status !== 'APPROVED') return
-
-    const now = new Date().toISOString()
-    order.status = 'SHIPPING'
-    order.statusHistory = [
-      ...(order.statusHistory ?? []),
-      { status: 'SHIPPING', at: now, byName: order.memberName },
-    ]
-    order.updatedAt = now
-    saveToStorage()
+  async function cancelOrder(id, reason = '') {
+    const updated = await purchaseOrderApi.cancel(id, reason)
+    const fe = toFeOrder(updated)
+    const idx = purchaseOrders.value.findIndex((o) => o.id === id)
+    if (idx >= 0) purchaseOrders.value.splice(idx, 1, fe)
+    return fe
   }
 
-  function markCompleted(id) {
-    const order = purchaseOrders.value.find((o) => o.id === id)
-    if (!order || order.status !== 'SHIPPING') return
-
-    const now = new Date().toISOString()
-    order.status = 'COMPLETED'
-    order.statusHistory = [
-      ...(order.statusHistory ?? []),
-      { status: 'COMPLETED', at: now, byName: order.memberName },
-    ]
-    order.updatedAt = now
-    saveToStorage()
-  }
-
-  // --- localStorage 영속화 ---
-  function saveToStorage() {
-    try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(purchaseOrders.value))
-    } catch (e) {
-      console.error('[purchaseOrder] localStorage 저장 실패', e)
-    }
-  }
-
-  function loadFromStorage() {
-    try {
-      const saved = localStorage.getItem(STORAGE_KEY)
-      if (saved) {
-        const parsed = JSON.parse(saved)
-        // 구버전 데이터 호환 — missing 필드 default
-        purchaseOrders.value = parsed.map((o) => ({
-          ...o,
-          cancelReason: o.cancelReason ?? '',
-          statusHistory:
-            o.statusHistory && o.statusHistory.length > 0
-              ? o.statusHistory
-              : [{ status: o.status, at: o.createdAt, byName: o.memberName }],
-        }))
-        return true
-      }
-    } catch (e) {
-      console.error('[purchaseOrder] localStorage 로드 실패', e)
-    }
-    return false
-  }
-
-  function init() {
-    const loaded = loadFromStorage()
-    if (!loaded) {
-      // 더미 데이터로 초기화
-      purchaseOrders.value = SEED_ORDERS
-      saveToStorage()
-    }
-  }
-
-  // 스토어 생성 시 자동 초기화
-  init()
+  // 스토어 생성 시 자동 fetch (vendor store 패턴)
+  fetchOrders().catch(() => {
+    // fetchOrders 안에서 이미 처리
+  })
 
   return {
     // state
@@ -647,6 +321,8 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
     dateFrom,
     dateTo,
     sortBy,
+    loading,
+    error,
     // getters
     selectedOrder,
     filteredOrders,
@@ -656,12 +332,13 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
     warehouses,
     // actions
     selectOrder,
+    fetchOrders,
+    fetchDetail,
     createOrder,
     updateOrder,
     cancelOrder,
     approveOrder,
     markShipping,
     markCompleted,
-    init,
   }
 })

--- a/src/views/hq/HqPurchaseOrderCreateView.vue
+++ b/src/views/hq/HqPurchaseOrderCreateView.vue
@@ -305,7 +305,7 @@ function cancelSubmitOrder() {
   showSubmitConfirm.value = false
 }
 
-function confirmSubmitOrder() {
+async function confirmSubmitOrder() {
   showSubmitConfirm.value = false
   const items = cart.value.map((i) => ({
     productId: i.productId,
@@ -316,38 +316,42 @@ function confirmSubmitOrder() {
     subtotal: i.unitPrice * i.quantity,
   }))
 
-  if (isEditMode.value) {
-    // 가드 재검증 — 다른 곳에서 상태 바뀌었을 수 있음
-    const order = poStore.purchaseOrders.find((o) => o.id === editingOrderId.value)
-    if (!order || order.status !== 'PENDING') {
-      triggerToast('상태가 변경되어 수정할 수 없습니다')
-      setTimeout(() => router.replace({ name: 'hq-purchase-orders' }), 900)
-      return
+  try {
+    if (isEditMode.value) {
+      // 가드 재검증 — 다른 곳에서 상태 바뀌었을 수 있음
+      const order = poStore.purchaseOrders.find((o) => o.id === editingOrderId.value)
+      if (!order || order.status !== 'PENDING') {
+        triggerToast('상태가 변경되어 수정할 수 없습니다')
+        setTimeout(() => router.replace({ name: 'hq-purchase-orders' }), 900)
+        return
+      }
+      await poStore.updateOrder(editingOrderId.value, {
+        warehouseId: selectedWarehouseId.value,
+        items,
+      })
+      poStore.selectOrder(editingOrderId.value)
+      triggerToast('발주가 수정되었습니다')
+    } else {
+      const newOrder = await poStore.createOrder({
+        warehouseId: selectedWarehouseId.value,
+        vendorId: cart.value[0].vendorId,
+        vendorName: cart.value[0].vendorName,
+        items,
+        memberId: auth.user?.memberId ?? 'MB-003',
+        memberName: auth.user?.name ?? '이선엽',
+      })
+      cart.value = []
+      clearDraftStorage()
+      poStore.selectOrder(newOrder.id)
+      triggerToast('발주가 요청되었습니다')
     }
-    poStore.updateOrder(editingOrderId.value, {
-      warehouseId: selectedWarehouseId.value,
-      items,
-    })
-    poStore.selectOrder(editingOrderId.value)
-    triggerToast('발주가 수정되었습니다')
-  } else {
-    const newOrder = poStore.createOrder({
-      warehouseId: selectedWarehouseId.value,
-      vendorId: cart.value[0].vendorId,
-      vendorName: cart.value[0].vendorName,
-      items,
-      memberId: auth.user?.memberId ?? 'MB-003',
-      memberName: auth.user?.name ?? '이선엽',
-    })
-    cart.value = []
-    clearDraftStorage()
-    poStore.selectOrder(newOrder.id)
-    triggerToast('발주가 요청되었습니다')
-  }
 
-  setTimeout(() => {
-    router.push({ name: 'hq-purchase-orders' })
-  }, 900)
+    setTimeout(() => {
+      router.push({ name: 'hq-purchase-orders' })
+    }, 900)
+  } catch (e) {
+    triggerToast(e?.message ?? '발주 처리에 실패했습니다')
+  }
 }
 
 // ─── 수정 모드 초기화 ────────────────────────────────────────────────────────

--- a/src/views/hq/HqPurchaseOrderView.vue
+++ b/src/views/hq/HqPurchaseOrderView.vue
@@ -62,12 +62,16 @@ function openApproveConfirm() {
   if (poStore.selectedOrder?.status !== 'PENDING') return
   showApproveConfirm.value = true
 }
-function confirmApprove() {
+async function confirmApprove() {
   const id = poStore.selectedOrder?.id
   if (!id) return
-  poStore.approveOrder(id)
   showApproveConfirm.value = false
-  triggerToast('거래처 승인이 기록되었습니다')
+  try {
+    await poStore.approveOrder(id)
+    triggerToast('거래처 승인이 기록되었습니다')
+  } catch (e) {
+    triggerToast(e?.message ?? '승인 처리에 실패했습니다')
+  }
 }
 function cancelApprove() {
   showApproveConfirm.value = false
@@ -77,12 +81,16 @@ function openShippingConfirm() {
   if (poStore.selectedOrder?.status !== 'APPROVED') return
   showShippingConfirm.value = true
 }
-function confirmShipping() {
+async function confirmShipping() {
   const id = poStore.selectedOrder?.id
   if (!id) return
-  poStore.markShipping(id)
   showShippingConfirm.value = false
-  triggerToast('거래처 출고가 기록되었습니다')
+  try {
+    await poStore.markShipping(id)
+    triggerToast('거래처 출고가 기록되었습니다')
+  } catch (e) {
+    triggerToast(e?.message ?? '출고 처리에 실패했습니다')
+  }
 }
 function cancelShipping() {
   showShippingConfirm.value = false
@@ -99,12 +107,16 @@ function cancelCancelConfirm() {
   showCancelConfirm.value = false
 }
 
-function confirmCancelOrder() {
+async function confirmCancelOrder() {
   const id = poStore.selectedOrder?.id
   if (!id) return
-  poStore.cancelOrder(id, cancelReason.value.trim())
   showCancelConfirm.value = false
-  triggerToast('발주가 취소되었습니다')
+  try {
+    await poStore.cancelOrder(id, cancelReason.value.trim())
+    triggerToast('발주가 취소되었습니다')
+  } catch (e) {
+    triggerToast(e?.message ?? '취소 처리에 실패했습니다')
+  }
 }
 
 // 탭 변경 시 선택 클리어 — 좌측 목록과 우측 상세의 컨텍스트 일치 유지

--- a/src/views/warehouse/WarehouseInboundView.vue
+++ b/src/views/warehouse/WarehouseInboundView.vue
@@ -42,12 +42,16 @@ function openConfirmInbound() {
 function cancelConfirmInbound() {
   showConfirmInbound.value = false
 }
-function confirmInbound() {
+async function confirmInbound() {
   const id = inbound.selectedOrder?.id
   if (!id) return
-  inbound.confirmInbound(id)
   showConfirmInbound.value = false
-  triggerToast('입고가 확정되었습니다')
+  try {
+    await inbound.confirmInbound(id)
+    triggerToast('입고가 확정되었습니다')
+  } catch (e) {
+    triggerToast(e?.message ?? '입고 확정에 실패했습니다')
+  }
 }
 
 // ─── 토스트 ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 📌 요약
- 본사 발주(PurchaseOrder) store를 시드 + localStorage 기반에서 **BE `/api/hq/purchase-orders` 8개 엔드포인트 axios 연동**으로 전환
- vendor 연동 사이클과 동일한 패턴(공통 axios 인스턴스 / `unwrap` 헬퍼 / 응답 매핑) 재사용

<br><br>

## 🎯 작업 내용
- **API 연동**
  - `src/api/purchaseOrder.js` 신규 — 본사 발주 도메인 axios 함수 8개 노출 (`/api/hq/purchase-orders`)
  - `src/stores/purchaseOrder.js` 시드 데이터 및 localStorage 영속화 로직 제거 (단일 출처 원칙)
- **응답 매핑 (BE → FE 화면 모델)**
  - `code ↔ id`
  - `vendorCode ↔ vendorId`
  - `totalAmount ↔ totalPrice`
  - items: `vendorProductCode ↔ productId`
  - statusHistory: `changedAt ↔ at`, `changedByName ↔ byName`
  - status 대문자 → 소문자 변환
- **호출자 비동기 정리**
  - View 6곳의 store mutation 호출부를 `await` + `try/catch` + 에러 토스트 패턴으로 일괄 정리
  - 비동기 흐름과 UI 피드백 일관성 확보

<br><br>

## ✔️ 참고 사항
- vendor 연동에서 도입한 공통 axios 인스턴스(`src/api/axios.js`) 및 `unwrap` 헬퍼 재사용 — 중복 설정 제거
- localStorage 영속화는 **단일 출처(BE) 원칙**에 따라 제거 — 클라이언트/서버 데이터 불일치 가능성 차단
- 마크업 및 검증 로직은 변경 없이 데이터 레이어와 호출 흐름만 교체

<br><br>

## ✔️ 관련 이슈
- Close #277 

<br><br>
