### PR TITLE
feat: 카테고리 등록 및 조회, 수정, 삭제 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -483,6 +482,29 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1537,7 +1559,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1607,7 +1628,6 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -2674,7 +2694,6 @@
       "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
       "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^7.7.7"
       },
@@ -3033,7 +3052,6 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3242,7 +3260,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.32.tgz",
       "integrity": "sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.32",
         "@vue/compiler-sfc": "3.5.32",

--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -9,6 +9,8 @@ export const apiClient = axios.create({
   timeout: 10000,
 })
 
+export default apiClient
+
 /**
  * BaseResponse<T> 언랩 헬퍼.
  * BE 응답 형태: { success, code, message, result }.

--- a/src/api/category.js
+++ b/src/api/category.js
@@ -14,3 +14,13 @@ export async function createCategory(payload) {
   const res = await api.post('/api/hq/categories', payload)
   return res.data.result
 }
+
+export async function updateCategory(code, payload) {
+  const res = await api.patch(`/api/hq/categories/${code}`, payload)
+  return res.data.result
+}
+
+export async function deleteCategory(code) {
+  const res = await api.delete(`/api/hq/categories/${code}`)
+  return res.data.result
+}

--- a/src/api/category.js
+++ b/src/api/category.js
@@ -1,0 +1,16 @@
+import api from '@/api/axios.js'
+
+export async function getCategories() {
+  const res = await api.get('/api/hq/categories')
+  return res.data.result
+}
+
+export async function getCategory(code) {
+  const res = await api.get(`/api/hq/categories/${code}`)
+  return res.data.result
+}
+
+export async function createCategory(payload) {
+  const res = await api.post('/api/hq/categories', payload)
+  return res.data.result
+}

--- a/src/views/hq/HqCategoryAddView.vue
+++ b/src/views/hq/HqCategoryAddView.vue
@@ -1,10 +1,11 @@
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { ArrowLeft, ChevronRight, Tags } from 'lucide-vue-next'
 import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
+import { createCategory, getCategories } from '@/api/category.js'
 
 const router = useRouter()
 const auth = useAuthStore()
@@ -23,20 +24,18 @@ const productSideMenus = [
   { label: '제품 마스터', icon: 'package', id: 'SO-011', path: '/hq/products' },
 ]
 
-const parentCategories = [
-  { id: 'CAT-100', name: '상의' },
-  { id: 'CAT-200', name: '바지' },
-  { id: 'CAT-300', name: '치마' },
-  { id: 'CAT-400', name: '아우터' },
-]
+const parentCategories = ref([])
 
 const level = ref('대분류')
 const name = ref('')
-const parentId = ref('CAT-100')
+const parentId = ref('')
 const status = ref('사용중')
+const submitError = ref('')
+const isSubmitting = ref(false)
+const submitSuccess = ref('')
 
 const nameError = computed(() => name.value.trim() === '' ? '카테고리명을 입력해주세요.' : '')
-const selectedParentCategory = computed(() => parentCategories.find((cat) => cat.id === parentId.value))
+const selectedParentCategory = computed(() => parentCategories.value.find((cat) => cat.id === parentId.value))
 const requiredProgress = computed(() => {
   const requiredSteps = [
     Boolean(level.value),
@@ -47,13 +46,67 @@ const requiredProgress = computed(() => {
 })
 
 function handleSubmit() {
-  if (nameError.value) return
-  router.push('/hq/products')
+  submitCategory()
 }
 
 function handleCancel() {
   router.push('/hq/products')
 }
+
+const statusEnumMap = {
+  사용중: 'ACTIVE',
+  점검중: 'SUSPENDED',
+  미사용: 'INACTIVE',
+}
+
+const levelEnumMap = {
+  대분류: 'ROOT',
+  소분류: 'CHILD',
+}
+
+async function loadParentCategories() {
+  try {
+    const list = await getCategories()
+    parentCategories.value = list.map((item) => ({ id: item.code, name: item.name }))
+    if (!parentId.value && parentCategories.value.length > 0) {
+      parentId.value = parentCategories.value[0].id
+    }
+  } catch (error) {
+    submitError.value = error.message
+  }
+}
+
+async function submitCategory() {
+  if (nameError.value) return
+  if (level.value === '소분류' && !parentId.value) {
+    submitError.value = '상위 분류를 선택해주세요.'
+    return
+  }
+  try {
+    isSubmitting.value = true
+    submitError.value = ''
+    submitSuccess.value = ''
+    const payload = {
+      name: name.value.trim(),
+      level: levelEnumMap[level.value],
+      status: statusEnumMap[status.value],
+      parentCode: level.value === '소분류' ? parentId.value : null,
+    }
+    await createCategory(payload)
+    submitSuccess.value = '카테고리가 등록되었습니다.'
+    setTimeout(() => {
+      router.push('/hq/products?tab=categories')
+    }, 500)
+  } catch (error) {
+    submitError.value = error.message
+  } finally {
+    isSubmitting.value = false
+  }
+}
+
+onMounted(() => {
+  loadParentCategories()
+})
 </script>
 
 <template>
@@ -208,6 +261,12 @@ function handleCancel() {
             </div>
 
             <div class="-mx-5 border-t border-gray-100 bg-gray-50 px-5 pt-4">
+              <p v-if="submitError" class="mb-2 border border-red-200 bg-red-50 px-2 py-1 text-[11px] font-bold text-red-600">
+                {{ submitError }}
+              </p>
+              <p v-if="submitSuccess" class="mb-2 border border-emerald-200 bg-emerald-50 px-2 py-1 text-[11px] font-bold text-emerald-700">
+                {{ submitSuccess }}
+              </p>
               <div class="flex gap-2">
                 <button
                   type="button"
@@ -219,9 +278,9 @@ function handleCancel() {
                 <button
                   type="submit"
                   class="flex-1 border border-[#004D3C] bg-[#004D3C] py-2.5 text-sm font-bold text-white hover:bg-[#003d30] disabled:cursor-not-allowed disabled:opacity-40"
-                  :disabled="!name.trim()"
+                  :disabled="!name.trim() || isSubmitting"
                 >
-                  카테고리 추가
+                  {{ isSubmitting ? '등록 중...' : '카테고리 추가' }}
                 </button>
               </div>
             </div>

--- a/src/views/hq/HqProductManagementView.vue
+++ b/src/views/hq/HqProductManagementView.vue
@@ -4,7 +4,7 @@ import { useRouter, useRoute } from 'vue-router'
 import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
-import { getCategories, getCategory } from '@/api/category.js'
+import { deleteCategory, getCategories, getCategory, updateCategory } from '@/api/category.js'
 
 const router = useRouter()
 const route = useRoute()
@@ -25,6 +25,8 @@ watch(() => route.query.tab, (tab) => {
 })
 const selectedProduct = ref(null)
 const selectedCategory = ref(null)
+const categoryEditForm = ref(null)
+const categorySubmitting = ref(false)
 
 const productSideMenus = [
   { label: '카테고리 관리', icon: 'tags', id: 'SO-006' },
@@ -97,7 +99,10 @@ const toggleExpand = (id, event) => {
 }
 
 const closeDetail = () => { selectedProduct.value = null }
-const closeCategoryDetail = () => { selectedCategory.value = null }
+const closeCategoryDetail = () => {
+  selectedCategory.value = null
+  categoryEditForm.value = null
+}
 const productEditForm = ref(null)
 
 const statusLabelMap = {
@@ -146,6 +151,7 @@ async function loadCategories() {
 
 async function selectCategory(code) {
   try {
+    categoryError.value = ''
     const detail = await getCategory(code)
     const parent = categories.value.find((cat) => cat.id === detail.parentCode) ?? null
     selectedCategory.value = {
@@ -158,8 +164,59 @@ async function selectCategory(code) {
       lastUpdated: formatDate(detail.updatedAt),
       children: [],
     }
+    categoryEditForm.value = {
+      name: selectedCategory.value.name,
+      status: selectedCategory.value.status,
+    }
   } catch (error) {
     categoryError.value = error.message
+  }
+}
+
+const statusCodeMap = {
+  사용중: 'ACTIVE',
+  점검중: 'SUSPENDED',
+  미사용: 'INACTIVE',
+}
+
+async function handleSaveCategory() {
+  if (!selectedCategory.value || !categoryEditForm.value) return
+  if (!categoryEditForm.value.name?.trim()) {
+    categoryError.value = '카테고리명을 입력해주세요.'
+    return
+  }
+
+  try {
+    categorySubmitting.value = true
+    categoryError.value = ''
+    await updateCategory(selectedCategory.value.id, {
+      name: categoryEditForm.value.name.trim(),
+      status: statusCodeMap[categoryEditForm.value.status] ?? 'ACTIVE',
+    })
+    await loadCategories()
+    await selectCategory(selectedCategory.value.id)
+  } catch (error) {
+    categoryError.value = error.message
+  } finally {
+    categorySubmitting.value = false
+  }
+}
+
+async function handleDeleteCategory() {
+  if (!selectedCategory.value) return
+  const ok = confirm(`[${selectedCategory.value.name}] 카테고리를 삭제하시겠습니까?`)
+  if (!ok) return
+
+  try {
+    categorySubmitting.value = true
+    categoryError.value = ''
+    await deleteCategory(selectedCategory.value.id)
+    closeCategoryDetail()
+    await loadCategories()
+  } catch (error) {
+    categoryError.value = error.message
+  } finally {
+    categorySubmitting.value = false
   }
 }
 
@@ -418,7 +475,7 @@ onMounted(() => {
         </div>
 
         <!-- 카테고리 상세 패널 -->
-        <aside v-if="selectedCategory" class="w-full shrink-0 border border-gray-300 bg-white shadow-sm xl:w-80">
+        <aside v-if="selectedCategory && categoryEditForm" class="w-full shrink-0 border border-gray-300 bg-white shadow-sm xl:w-80">
           <div class="flex items-center justify-between bg-[#004D3C] px-4 py-3 text-white">
             <h3 class="inline-flex items-center gap-2 text-[11px] font-bold">
               <InfoIcon :size="14" /> 카테고리 상세
@@ -441,7 +498,7 @@ onMounted(() => {
                 카테고리명
                 <input
                   type="text"
-                  :value="selectedCategory.name"
+                  v-model="categoryEditForm.name"
                   class="mt-1 w-full border border-gray-300 bg-gray-50 px-3 py-2 text-xs text-gray-800 outline-none focus:border-[#004D3C]"
                 />
               </label>
@@ -455,10 +512,10 @@ onMounted(() => {
 
               <label class="block text-[10px] font-bold text-gray-400">
                 상태
-                <select class="mt-1 w-full border border-gray-300 bg-gray-50 px-3 py-2 text-xs text-gray-800 outline-none focus:border-[#004D3C]">
-                  <option :selected="selectedCategory.status === '사용중'">사용중</option>
-                  <option :selected="selectedCategory.status === '점검중'">점검중</option>
-                  <option :selected="selectedCategory.status === '미사용'">미사용</option>
+                <select v-model="categoryEditForm.status" class="mt-1 w-full border border-gray-300 bg-gray-50 px-3 py-2 text-xs text-gray-800 outline-none focus:border-[#004D3C]">
+                  <option>사용중</option>
+                  <option>점검중</option>
+                  <option>미사용</option>
                 </select>
               </label>
             </div>
@@ -477,8 +534,22 @@ onMounted(() => {
             </div>
 
             <div class="flex gap-2 pt-1">
-              <button type="button" class="flex-1 border border-[#004D3C] bg-[#004D3C] py-2 text-xs font-bold text-white hover:bg-[#003d30]">저장</button>
-              <button type="button" class="flex-1 border border-red-300 bg-red-50 py-2 text-xs font-bold text-red-600 hover:bg-red-100">삭제</button>
+              <button
+                type="button"
+                class="flex-1 border border-[#004D3C] bg-[#004D3C] py-2 text-xs font-bold text-white hover:bg-[#003d30] disabled:opacity-50"
+                :disabled="categorySubmitting"
+                @click="handleSaveCategory"
+              >
+                저장
+              </button>
+              <button
+                type="button"
+                class="flex-1 border border-red-300 bg-red-50 py-2 text-xs font-bold text-red-600 hover:bg-red-100 disabled:opacity-50"
+                :disabled="categorySubmitting"
+                @click="handleDeleteCategory"
+              >
+                삭제
+              </button>
             </div>
           </div>
         </aside>

--- a/src/views/hq/HqProductManagementView.vue
+++ b/src/views/hq/HqProductManagementView.vue
@@ -1,9 +1,10 @@
 <script setup>
-import { computed, h, ref, watch } from 'vue'
+import { computed, h, onMounted, ref, watch } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
+import { getCategories, getCategory } from '@/api/category.js'
 
 const router = useRouter()
 const route = useRoute()
@@ -48,59 +49,8 @@ const productMasterData = [
   { id: 'PD-O004', name: '브이넥 니트 가디건', parentCategory: '아우터', childCategory: '가디건', price: 48900, leadTime: '7일', vendor: '니트랩', status: '활성', regDate: '2024.03.25' },
 ]
 
-const categories = ref([
-  {
-    id: 'CAT-100',
-    name: '상의',
-    level: '대분류',
-    status: '사용중',
-    lastUpdated: '2024.04.01',
-    children: [
-      { id: 'CAT-101', name: '반팔', level: '소분류', parentId: 'CAT-100', parentName: '상의', status: '사용중', lastUpdated: '2024.04.01' },
-      { id: 'CAT-102', name: '긴팔', level: '소분류', parentId: 'CAT-100', parentName: '상의', status: '사용중', lastUpdated: '2024.04.01' },
-      { id: 'CAT-103', name: '셔츠', level: '소분류', parentId: 'CAT-100', parentName: '상의', status: '사용중', lastUpdated: '2024.04.01' },
-      { id: 'CAT-104', name: '니트', level: '소분류', parentId: 'CAT-100', parentName: '상의', status: '사용중', lastUpdated: '2024.04.01' },
-      { id: 'CAT-105', name: '후드티', level: '소분류', parentId: 'CAT-100', parentName: '상의', status: '사용중', lastUpdated: '2024.04.01' },
-    ],
-  },
-  {
-    id: 'CAT-200',
-    name: '바지',
-    level: '대분류',
-    status: '사용중',
-    lastUpdated: '2024.04.01',
-    children: [
-      { id: 'CAT-201', name: '청바지', level: '소분류', parentId: 'CAT-200', parentName: '바지', status: '사용중', lastUpdated: '2024.04.01' },
-      { id: 'CAT-202', name: '반바지', level: '소분류', parentId: 'CAT-200', parentName: '바지', status: '사용중', lastUpdated: '2024.04.01' },
-      { id: 'CAT-203', name: '긴바지', level: '소분류', parentId: 'CAT-200', parentName: '바지', status: '사용중', lastUpdated: '2024.04.01' },
-      { id: 'CAT-204', name: '츄리닝', level: '소분류', parentId: 'CAT-200', parentName: '바지', status: '사용중', lastUpdated: '2024.04.01' },
-    ],
-  },
-  {
-    id: 'CAT-300',
-    name: '치마',
-    level: '대분류',
-    status: '사용중',
-    lastUpdated: '2024.04.01',
-    children: [
-      { id: 'CAT-301', name: '미니 스커트', level: '소분류', parentId: 'CAT-300', parentName: '치마', status: '사용중', lastUpdated: '2024.04.01' },
-      { id: 'CAT-302', name: '롱스커트', level: '소분류', parentId: 'CAT-300', parentName: '치마', status: '사용중', lastUpdated: '2024.04.01' },
-    ],
-  },
-  {
-    id: 'CAT-400',
-    name: '아우터',
-    level: '대분류',
-    status: '사용중',
-    lastUpdated: '2024.04.01',
-    children: [
-      { id: 'CAT-401', name: '패딩', level: '소분류', parentId: 'CAT-400', parentName: '아우터', status: '사용중', lastUpdated: '2024.04.01' },
-      { id: 'CAT-402', name: '후드집업', level: '소분류', parentId: 'CAT-400', parentName: '아우터', status: '사용중', lastUpdated: '2024.04.01' },
-      { id: 'CAT-403', name: '자켓', level: '소분류', parentId: 'CAT-400', parentName: '아우터', status: '사용중', lastUpdated: '2024.04.01' },
-      { id: 'CAT-404', name: '가디건', level: '소분류', parentId: 'CAT-400', parentName: '아우터', status: '사용중', lastUpdated: '2024.04.01' },
-    ],
-  },
-])
+const categories = ref([])
+const categoryError = ref('')
 
 const expandedCategories = ref(new Set(['CAT-100']))
 
@@ -149,6 +99,69 @@ const toggleExpand = (id, event) => {
 const closeDetail = () => { selectedProduct.value = null }
 const closeCategoryDetail = () => { selectedCategory.value = null }
 const productEditForm = ref(null)
+
+const statusLabelMap = {
+  ACTIVE: '사용중',
+  SUSPENDED: '점검중',
+  INACTIVE: '미사용',
+}
+
+const levelLabelMap = {
+  ROOT: '대분류',
+  CHILD: '소분류',
+}
+
+function formatDate(dateValue) {
+  if (!dateValue) return '-'
+  const date = new Date(dateValue)
+  if (Number.isNaN(date.getTime())) return '-'
+  return date.toISOString().slice(0, 10).replace(/-/g, '.')
+}
+
+function mapCategoryNode(node, parent = null) {
+  return {
+    id: node.code,
+    name: node.name,
+    level: levelLabelMap[node.level] ?? node.level,
+    status: statusLabelMap[node.status] ?? node.status,
+    lastUpdated: formatDate(node.updatedAt),
+    parentId: parent?.code ?? null,
+    parentName: parent?.name ?? null,
+    children: (node.children ?? []).map((child) => mapCategoryNode(child, node)),
+  }
+}
+
+async function loadCategories() {
+  try {
+    categoryError.value = ''
+    const list = await getCategories()
+    categories.value = list.map((node) => mapCategoryNode(node))
+    if (categories.value.length > 0 && expandedCategories.value.size === 0) {
+      expandedCategories.value = new Set([categories.value[0].id])
+    }
+  } catch (error) {
+    categoryError.value = error.message
+  }
+}
+
+async function selectCategory(code) {
+  try {
+    const detail = await getCategory(code)
+    const parent = categories.value.find((cat) => cat.id === detail.parentCode) ?? null
+    selectedCategory.value = {
+      id: detail.code,
+      name: detail.name,
+      level: levelLabelMap[detail.level] ?? detail.level,
+      status: statusLabelMap[detail.status] ?? detail.status,
+      parentId: parent?.id ?? null,
+      parentName: parent?.name ?? null,
+      lastUpdated: formatDate(detail.updatedAt),
+      children: [],
+    }
+  } catch (error) {
+    categoryError.value = error.message
+  }
+}
 
 const syncProductEditForm = (product) => {
   if (!product) {
@@ -253,6 +266,10 @@ const iconMap = {
   tags: TagsIcon,
   package: PackageIcon,
 }
+
+onMounted(() => {
+  loadCategories()
+})
 </script>
 
 <template>
@@ -312,6 +329,9 @@ const iconMap = {
           </button>
         </div>
       </section>
+      <p v-if="categoryError" class="border border-red-200 bg-red-50 px-3 py-2 text-xs font-bold text-red-600">
+        {{ categoryError }}
+      </p>
 
       <!-- 카테고리 관리 -->
       <section v-if="activeSideMenu === '카테고리 관리'" class="flex min-h-0 flex-col gap-4 xl:flex-row">
@@ -341,7 +361,7 @@ const iconMap = {
                   <tr
                     class="cursor-pointer hover:bg-gray-50"
                     :class="selectedCategory?.id === cat.id ? 'bg-[#E6F2F0]' : ''"
-                    @click="selectedCategory = cat"
+                    @click="selectCategory(cat.id)"
                   >
                     <td class="px-3 py-3 text-center font-bold text-gray-400">{{ cat.id }}</td>
                     <td class="px-3 py-3">
@@ -372,7 +392,7 @@ const iconMap = {
                       :key="child.id"
                       class="cursor-pointer bg-gray-50/40 hover:bg-gray-100/60"
                       :class="selectedCategory?.id === child.id ? 'bg-[#E6F2F0]' : ''"
-                      @click="selectedCategory = child"
+                      @click="selectCategory(child.id)"
                     >
                       <td class="px-3 py-2.5 text-center font-bold text-gray-400">{{ child.id }}</td>
                       <td class="px-3 py-2.5">

--- a/src/views/hq/inventory/HqCompanyWideInventoryView.vue
+++ b/src/views/hq/inventory/HqCompanyWideInventoryView.vue
@@ -409,7 +409,7 @@ function handleLogout() {
                 <th class="px-3 py-3 font-black">품목 코드</th>
                 <th class="px-3 py-3 font-black">카테고리</th>
                 <th class="px-3 py-3 font-black">품목명</th>
-                <th class="px-3 py-3 text-right font-black">실제고</th>
+                <th class="px-3 py-3 text-right font-black">실재고</th>
                 <th class="px-3 py-3 text-right font-black">가용재고</th>
                 <th class="px-3 py-3 text-right font-black">안전재고</th>
                 <th class="px-3 py-3 text-center font-black">상태</th>

--- a/src/views/warehouse/WarehouseInventoryView.vue
+++ b/src/views/warehouse/WarehouseInventoryView.vue
@@ -201,7 +201,7 @@ function handleLogout() {
                   <th class="px-3 py-3 font-black">품목 코드</th>
                   <th class="px-3 py-3 font-black">카테고리</th>
                   <th class="px-3 py-3 font-black">품목명</th>
-                  <th class="px-3 py-3 text-right font-black">실제고</th>
+                  <th class="px-3 py-3 text-right font-black">실재고</th>
                   <th class="px-3 py-3 text-right font-black">가용재고</th>
                   <th class="px-3 py-3 text-right font-black">안전재고</th>
                   <th class="px-3 py-3 text-center font-black">상태</th>


### PR DESCRIPTION
## 📌 요약
- 본사 관리자 상품 관리의 카테고리 기능을 목업 기반에서 API 연동 기반으로 전환했습니다.
- 카테고리 등록/조회/수정/삭제 흐름을 화면에서 모두 처리할 수 있도록 구현했습니다.

<br><br>

## 🎯 작업 내용
- `HqProductManagementView` 카테고리 탭에 카테고리 목록/상세 조회 API 연동
- `HqCategoryAddView` 카테고리 등록 API 연동 및 성공/실패 피드백 처리
- 카테고리 상세 패널에 수정(PATCH)/삭제(DELETE) 연동 및 처리 상태/오류 메시지 반영

<br><br>

## ✔️ 참고 사항
- CORS 이슈 대응을 위해 백엔드에서 `http://localhost:5173` 허용 설정이 선행되어야 합니다.
- 카테고리 상태는 화면값(사용중/점검중/미사용)과 API enum(ACTIVE/SUSPENDED/INACTIVE) 매핑으로 처리합니다.

<br><br>

## ✔️ 관련 이슈

- Close #188 

<br><br>
