### PR TITLE
feat: 279 새 발주 페이지 거래처 품목 조회 fe 연동

### DIFF
--- a/src/api/vendor.js
+++ b/src/api/vendor.js
@@ -4,7 +4,8 @@
  * BE 엔드포인트:
  *   GET    /api/vendors                            (목록, 등록은 SQL 직접)
  *   GET    /api/vendors/{code}
- *   GET    /api/vendor-products?vendorCode=...     (CEN-031)
+ *   GET    /api/vendor-products?vendorCode=...     (CEN-031, 특정 거래처)
+ *   GET    /api/vendor-products?status=...         (CEN-035 발주 카탈로그, 전체 거래처)
  *   GET    /api/vendor-products/{code}             (CEN-033)
  *   POST   /api/vendor-products                    (CEN-027)
  *   PATCH  /api/vendor-products/{code}             (CEN-028)
@@ -24,6 +25,16 @@ export const vendorApi = {
   // ─── 거래처별 계약 제품 ─────────────────────────────────────────────────
   listVendorProducts: (vendorCode) =>
     apiClient.get('/api/vendor-products', { params: { vendorCode } }).then(unwrap),
+
+  /**
+   * 전체 거래처 제품 일괄 조회 (CEN-035 발주 작성 카탈로그용).
+   * @param {'ACTIVE'|'SUSPENDED'|'EXPIRED'|'DELETED'} [status] — 생략 시 DELETED 제외 전체
+   */
+  listAllVendorProducts: (status) =>
+    apiClient
+      .get('/api/vendor-products', { params: status ? { status } : {} })
+      .then(unwrap),
+
   getVendorProduct: (code) => apiClient.get(`/api/vendor-products/${code}`).then(unwrap),
 
   /**

--- a/src/stores/vendor.js
+++ b/src/stores/vendor.js
@@ -35,7 +35,8 @@ function fromApiVendorProduct(vp) {
 export const useVendorStore = defineStore('vendor', () => {
   // --- state ---
   const vendors = ref([])
-  const vendorProducts = ref([]) // 현재 선택된 vendor 의 계약 제품만 보유
+  const vendorProducts = ref([]) // 현재 선택된 vendor 의 계약 제품만 보유 (거래처 관리 페이지용)
+  const allVendorProducts = ref([]) // 전체 거래처의 활성 제품 (CEN-035 발주 작성 카탈로그용)
   const selectedVendorId = ref(null)
   const selectedProductId = ref(null)
   const loading = ref(false)
@@ -89,6 +90,18 @@ export const useVendorStore = defineStore('vendor', () => {
     try {
       const list = await vendorApi.listVendors()
       vendors.value = (list ?? []).map(fromApiVendor)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  // 전체 거래처 제품 fetch (CEN-035 발주 작성 카탈로그용)
+  // 기존 vendorProducts 와 분리된 별 state (allVendorProducts) 에 적재.
+  async function fetchAllVendorProducts(status = 'ACTIVE') {
+    loading.value = true
+    try {
+      const list = await vendorApi.listAllVendorProducts(status)
+      allVendorProducts.value = (list ?? []).map(fromApiVendorProduct)
     } finally {
       loading.value = false
     }
@@ -189,6 +202,7 @@ export const useVendorStore = defineStore('vendor', () => {
   return {
     vendors,
     vendorProducts,
+    allVendorProducts,
     selectedVendorId,
     selectedProductId,
     loading,
@@ -199,6 +213,7 @@ export const useVendorStore = defineStore('vendor', () => {
     isProductCodeDuplicate,
     fetchVendors,
     fetchProductsByVendor,
+    fetchAllVendorProducts,
     selectVendor,
     selectProduct,
     createProduct,

--- a/src/views/hq/HqPurchaseOrderCreateView.vue
+++ b/src/views/hq/HqPurchaseOrderCreateView.vue
@@ -64,11 +64,13 @@ function triggerToast(message) {
 
 // ─── computed ────────────────────────────────────────────────────────────────
 // 카탈로그: active 거래처 × active 계약 제품
+// 데이터 출처는 vendor.allVendorProducts (전체 거래처 제품 — onMounted 에서 fetch).
+// 기존 vendor.vendorProducts 는 한 거래처 전용이라 발주 카탈로그엔 부적합.
 const catalog = computed(() => {
   const activeVendorMap = new Map(
     vendor.vendors.filter((v) => v.status === 'active').map((v) => [v.id, v]),
   )
-  return vendor.vendorProducts
+  return vendor.allVendorProducts
     .filter((vp) => vp.status === 'active' && activeVendorMap.has(vp.vendorId))
     .map((vp) => ({
       ...vp,
@@ -383,6 +385,9 @@ function initEditMode() {
 
 // ─── mounted ────────────────────────────────────────────────────────────────
 onMounted(() => {
+  vendor.fetchAllVendorProducts('ACTIVE').catch((err) => {
+    console.error('[HqPurchaseOrderCreateView] fetchAllVendorProducts 실패', err)
+  })
   if (isEditMode.value) {
     initEditMode()
   } else {


### PR DESCRIPTION
## 📌 요약
- 새 발주 등록 페이지에서 **거래처 선택 시 해당 거래처의 계약 제품 목록을 BE에서 비동기 조회**해 발주 라인 구성에 활용하도록 FE 연동
- 기존 시드/localStorage 기반 임시 데이터 의존을 제거하고 `GET /api/vendor-products?vendorCode=` 엔드포인트와 연결

<br><br>

## 🎯 작업 내용
- **거래처 변경 → 계약 제품 fetch 흐름 구현**
  - 거래처 select 변경 이벤트에 `vendorStore.fetchProductsByVendor(vendorId)` 호출 연결
  - vendor store에서 노출되는 `vendorProducts` 상태를 새 발주 페이지에서 computed로 구독
- **응답 매핑 재사용 (vendor 도메인 패턴 그대로)**
  - `code → id`, `vendorCode → vendorId`, `vendorProductCode → productId`
  - `unitPrice` / `moq` / `leadTimeDays` 그대로 발주 라인에 매핑
- **발주 라인 자동 채움**
  - 계약 제품 선택 시 단가 · MOQ · 리드타임 자동 입력 처리
  - 거래처 변경 시 기존 선택된 발주 라인 초기화 → 다른 거래처 제품 혼입 방지
- **UI 분기 및 비동기 정합성**
  - 거래처 미선택 / 계약 제품 0건 / 로딩 / 에러 상태에 대한 UI 분기 처리
  - 호출부 `async` + `try/catch` + 실패 시 `triggerToast(err.message)`

<br><br>

## ✔️ 참고 사항
- vendor 연동 사이클에서 구축한 공통 axios 인스턴스(`src/api/axios.js`) 및 `unwrap` 헬퍼를 그대로 재사용 — 중복 설정 없음
- 거래처 store의 `fetchProductsByVendor` 액션을 신규 추가 없이 재활용해 단일 출처 원칙 유지
- 마크업 및 검증 로직은 변경 없이 데이터 소스와 비동기 흐름만 교체

<br><br>

## ✔️ 관련 이슈
- Close #279 