### PR TITLE
fix(purchase-order): 발주 목록 품목수 0 + 총합에 취소 포함 수정

### DIFF
--- a/src/stores/purchaseOrder.js
+++ b/src/stores/purchaseOrder.js
@@ -24,6 +24,9 @@ const WAREHOUSES = [
 
 function toFeOrder(beOrder) {
   if (!beOrder) return null
+  // BE ListRes 는 itemCount 만, DetailRes 는 items 배열만 보내므로 둘 중 하나로 fallback.
+  const itemCount =
+    beOrder.itemCount ?? (Array.isArray(beOrder.items) ? beOrder.items.length : 0)
   return {
     id: beOrder.code,
     warehouseId: beOrder.warehouseId ?? '',
@@ -37,6 +40,7 @@ function toFeOrder(beOrder) {
     cancelReason: beOrder.cancelReason ?? '',
     createdAt: beOrder.createdAt ?? '',
     updatedAt: beOrder.updatedAt ?? '',
+    itemCount,
     items: Array.isArray(beOrder.items) ? beOrder.items.map(toFeItem) : [],
     statusHistory: Array.isArray(beOrder.statusHistory)
       ? beOrder.statusHistory.map(toFeHistory)
@@ -173,7 +177,8 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
   })
 
   const summary = computed(() => {
-    let base = purchaseOrders.value
+    // 취소된(REJECTED) 발주는 총 발주 합계에서 제외 — 실제 처리되지 않은 금액.
+    let base = purchaseOrders.value.filter((o) => o.status !== 'REJECTED')
     if (vendorFilter.value) {
       base = base.filter((o) => o.vendorId === vendorFilter.value)
     }

--- a/src/views/hq/HqPurchaseOrderView.vue
+++ b/src/views/hq/HqPurchaseOrderView.vue
@@ -426,7 +426,7 @@ const TruckIcon = IconBase([
                   <td class="px-3 py-3 font-black text-gray-800">{{ order.vendorName }}</td>
                   <td class="px-3 py-3 font-bold text-gray-600">{{ order.warehouseName }}</td>
                   <td class="px-3 py-3 text-center font-bold text-gray-700">
-                    {{ order.items.length }}
+                    {{ order.itemCount }}
                   </td>
                   <td class="px-3 py-3 text-right font-black text-gray-800">
                     ₩{{ order.totalPrice.toLocaleString() }}


### PR DESCRIPTION
## 📌 요약
- 발주 목록 품목수가 클릭 전 0으로 표시되던 문제 수정
- 상단 총 발주 합계에 REJECTED(취소) 발주 금액이 포함되던 문제 수정

<br><br>

## 🎯 작업 내용
- **품목수 매핑 보강**
  - 원인: store의 `toFeOrder`가 BE `ListRes.itemCount`를 매핑하지 않고, view가 `order.items.length`만 참조 → list 시점엔 items가 빈 배열이라 0, 상세 fetch 후에야 정상값
  - 수정: `toFeOrder`에서 `BE itemCount ?? items.length` 로 흡수해 list/detail 양쪽 응답 모두에서 정확한 값 보관
  - view에서 `order.itemCount` 직접 사용하도록 변경
- **총 발주 합계 보정**
  - status 무관하게 `totalAmount` 합산하던 summary computed를 **REJECTED 제외**로 변경
  - 취소 발주는 실제 처리되지 않은 금액이므로 합계에서 제외하는 게 의미상 정합

<br><br>

## ✔️ 참고 사항
- list 응답과 detail 응답의 `itemCount` 표현 방식 차이를 store 매핑 단계에서 일원화 → view는 단일 필드만 참조
- 마크업 변경 없이 데이터 매핑·집계 로직만 수정

<br><br>

## ✔️ 관련 이슈
- Close #285 

<br><br>