### PR TITLE
feat(inbound): 창고 관리자 입고 BE axios 연동

### DIFF
--- a/src/api/inbound.js
+++ b/src/api/inbound.js
@@ -1,0 +1,39 @@
+/**
+ * inbound.js — BE 연동 (WHS-005/007/008 창고 관리자 입고)
+ *
+ * BE 엔드포인트:
+ *   GET    /api/warehouse/inbound?status=&warehouseId=&from=&to=    (입고 예정/완료 목록)
+ *   GET    /api/warehouse/inbound/{code}                            (상세 — items + statusHistory)
+ *   POST   /api/warehouse/inbound/{code}/confirm                    (입고 확정 SHIPPING → COMPLETED)
+ *
+ * 응답: BaseResponse<T>. unwrap() 으로 result 만 추출, 실패 시 throw.
+ *
+ * 단일 진실 원천(ADR-015) 정책 — list/detail 은 현재 `purchaseOrder` store 의 SHIPPING/COMPLETED
+ * 발주를 그대로 활용하므로 store 에서 직접 호출하지 않을 수도 있음. confirm 만 핵심 사용처.
+ * 인증 도입(ADR-011) 전 임시: warehouseId 는 query 파라미터로 받음 (FE 가 auth.user.storeId 전달).
+ */
+
+import { apiClient, unwrap } from './axios.js'
+
+const BASE = '/api/warehouse/inbound'
+
+export const inboundApi = {
+  /**
+   * 입고 목록 조회.
+   * @param {{status?: 'SHIPPING'|'COMPLETED', warehouseId?: string, from?: string, to?: string}} params
+   */
+  list: (params = {}) => {
+    const query = {}
+    if (params.status) query.status = params.status
+    if (params.warehouseId) query.warehouseId = params.warehouseId
+    if (params.from) query.from = params.from
+    if (params.to) query.to = params.to
+    return apiClient.get(BASE, { params: query }).then(unwrap)
+  },
+
+  /** 상세 조회 (items + statusHistory 포함) */
+  detail: (code) => apiClient.get(`${BASE}/${code}`).then(unwrap),
+
+  /** 입고 확정 (SHIPPING → COMPLETED, WHS-007) */
+  confirm: (code) => apiClient.post(`${BASE}/${code}/confirm`).then(unwrap),
+}

--- a/src/stores/inbound.js
+++ b/src/stores/inbound.js
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import { usePurchaseOrderStore } from './purchaseOrder.js'
+import { inboundApi } from '@/api/inbound.js'
 
 export const useInboundStore = defineStore('inbound', () => {
   const poStore = usePurchaseOrderStore()
@@ -59,14 +60,27 @@ export const useInboundStore = defineStore('inbound', () => {
   }))
 
   // --- actions ---
+  // 발주 선택 — items/statusHistory 가 비어있으면(list 시점) detail 자동 fetch.
+  // purchaseOrder store 의 selectOrder 와 같은 패턴 — 단일 진실 원천(ADR-015).
   function selectOrder(id) {
     selectedOrderId.value = id
+    if (id) {
+      const order = poStore.purchaseOrders.find((o) => o.id === id)
+      if (order && (order.items.length === 0 || order.statusHistory.length === 0)) {
+        poStore.fetchDetail(id).catch(() => {
+          // fetchDetail 안에서 이미 처리
+        })
+      }
+    }
   }
 
-  // 입고 확정 — purchaseOrder store 의 markCompleted 위임
-  // (statusHistory push 는 markCompleted 안에서 자동 처리)
+  // 입고 확정 (WHS-007) — 창고 권한군 entry-point 로 갈아끼움.
+  // BE: POST /api/warehouse/inbound/{code}/confirm → 내부적으로 PurchaseOrderService.complete
+  // (SHIPPING→COMPLETED 검증 + statusHistory append).
+  // 단일 진실 원천(ADR-015) 정합을 위해 confirm 후 poStore.fetchDetail 로 단건 갱신.
   async function confirmInbound(id) {
-    return poStore.markCompleted(id)
+    await inboundApi.confirm(id)
+    return poStore.fetchDetail(id)
   }
 
   return {

--- a/src/views/warehouse/WarehouseInboundView.vue
+++ b/src/views/warehouse/WarehouseInboundView.vue
@@ -302,7 +302,7 @@ const CheckIcon = IconBase([{ tag: 'polyline', attrs: { points: '20 6 9 17 4 12'
                   <td class="px-3 py-3 font-black text-gray-800">{{ order.vendorName }}</td>
                   <td class="px-3 py-3 font-bold text-gray-600">{{ order.warehouseName }}</td>
                   <td class="px-3 py-3 text-center font-bold text-gray-700">
-                    {{ order.items.length }}
+                    {{ order.itemCount }}
                   </td>
                   <td class="px-3 py-3 text-right font-black text-gray-800">
                     ₩{{ order.totalPrice.toLocaleString() }}


### PR DESCRIPTION
## 📌 요약
- 창고 입고 화면이 호출하던 본사 권한군 임시 엔드포인트(`POST /api/hq/.../complete`)를 창고 권한군(`POST /api/warehouse/inbound/{code}/confirm`)으로 정식 전환
- 함께 발견된 입고 화면 표시 버그 2건(품목수 0 / 상세 패널 품목 미노출) 동시 수정

<br><br>

## 🎯 작업 내용
- **권한군 정합 정리 (WHS-005 / 007 / 008)**
  - `inboundApi` 신설 — `list` / `detail` / `confirm` 3종 axios 함수 노출
  - 호출 경로 교체: `POST /api/hq/{code}/complete` → `POST /api/warehouse/inbound/{code}/confirm`
  - inbound store의 `confirmInbound`가 신규 axios 호출 + `poStore.fetchDetail` 재조회로 **단일 진실 원천(ADR-015)** 정합 유지
- **표시 버그 #1 — 좌측 목록 품목수 0 노출**
  - 원인: list 시점 `items` 가 빈 배열이라 `order.items.length` 가 항상 0
  - 수정: `order.itemCount` 사용으로 교체 (본사 발주 동일 fix 패턴 미러링)
- **표시 버그 #2 — 발주 클릭 시 우측 상세 패널 품목 미노출**
  - 원인: inbound store의 `selectOrder`가 `fetchDetail`을 자동 트리거하지 않아 `items` 가 빈 채로 유지
  - 수정: purchaseOrder store의 `selectOrder` 패턴 그대로 적용 → `items` / `statusHistory` 가 비어있으면 `poStore.fetchDetail(id)` 자동 호출

<br><br>

## ✔️ 참고 사항
- 임시로 본사 권한군 엔드포인트를 빌려 쓰던 구조 정리 — 권한 분리 정합성 확보
- 두 표시 버그 모두 본사 발주 화면에서 한 번 정립한 fix 패턴(`itemCount` 흡수 / `selectOrder`에서 detail 자동 fetch)을 입고 도메인에 미러링한 것
- 마크업 변경 없이 데이터 매핑·호출 흐름만 정리

<br><br>

## ✔️ 관련 이슈
- Close #287 

<br><br>