### PR TITLE
fix(purchase-order): 발주 안내문 시스템 표시 괄호 제거

### DIFF
--- a/src/views/hq/HqPurchaseOrderView.vue
+++ b/src/views/hq/HqPurchaseOrderView.vue
@@ -620,14 +620,14 @@ const TruckIcon = IconBase([
                 </button>
               </div>
               <p class="pt-1 text-center text-[11px] leading-relaxed text-gray-500">
-                30분 후 시스템(SYS-001) 이 자동으로 거래처 승인을 처리합니다.<br />
+                30분 후 시스템이 자동으로 거래처 승인을 처리합니다.<br />
                 그 전에 [수정] 또는 [취소] 가능합니다.
               </p>
             </template>
 
             <template v-else-if="poStore.selectedOrder.status === 'APPROVED'">
               <p class="text-center text-xs leading-relaxed text-gray-500">
-                승인 완료 · 30분 후 시스템(SYS-001) 이 자동으로 거래처 출고 처리합니다.
+                승인 완료 · 30분 후 시스템이 자동으로 거래처 출고 처리합니다.
               </p>
             </template>
 


### PR DESCRIPTION
## 📌 요약
- PENDING / APPROVED 액션 박스 안내문에서 내부 배치 식별자(`SYS-001`) 노출을 제거하고 `"시스템이 자동 처리"`로 단순화

<br><br>

## 🎯 작업 내용
- PENDING / APPROVED 상태 액션 박스 안내 문구 수정
  - 기존: `"시스템(SYS-001)이 자동 처리"`
  - 변경: `"시스템이 자동 처리"`

<br><br>

## ✔️ 참고 사항
- `SYS-001`은 BE 배치 구현 식별자(내부 디테일)로 운영자 화면에 노출될 의미가 없음
- 진행 이력(`statusHistory`)의 `byName` 표기와는 별개 — 이력 표시명은 기존 정책 유지
- 안내 문구만 수정, 로직 / 매핑 / API 변경 없음

<br><br>

## ✔️ 관련 이슈
- Close #289 