### PR TITLE
194 feat cen 021 제품 마스터 등록 조회 수정 삭제 구현

### DIFF
--- a/src/api/infrastructure.js
+++ b/src/api/infrastructure.js
@@ -1,0 +1,31 @@
+import api, { unwrap } from '@/api/axios.js'
+
+export async function getStores(params = {}) {
+  const res = await api.get('/api/hq/infrastructure/stores', { params })
+  return unwrap(res)
+}
+
+export async function createStore(payload) {
+  const res = await api.post('/api/hq/infrastructure/stores', payload)
+  return unwrap(res)
+}
+
+export async function updateStore(storeCode, payload) {
+  const res = await api.put(`/api/hq/infrastructure/stores/${storeCode}`, payload)
+  return unwrap(res)
+}
+
+export async function getWarehouses(params = {}) {
+  const res = await api.get('/api/hq/infrastructure/warehouses', { params })
+  return unwrap(res)
+}
+
+export async function createWarehouse(payload) {
+  const res = await api.post('/api/hq/infrastructure/warehouses', payload)
+  return unwrap(res)
+}
+
+export async function updateWarehouse(warehouseCode, payload) {
+  const res = await api.put(`/api/hq/infrastructure/warehouses/${warehouseCode}`, payload)
+  return unwrap(res)
+}

--- a/src/api/productMaster.js
+++ b/src/api/productMaster.js
@@ -1,0 +1,51 @@
+import api, { unwrap } from '@/api/axios.js'
+
+export async function getProducts(params = {}) {
+  const res = await api.get('/api/hq/products', { params })
+  return unwrap(res)
+}
+
+export async function getProductDetail(productCode) {
+  const res = await api.get(`/api/hq/products/${productCode}`)
+  return unwrap(res)
+}
+
+export async function createProduct(payload) {
+  const res = await api.post('/api/hq/products', payload)
+  return unwrap(res)
+}
+
+export async function updateProduct(productCode, payload) {
+  const res = await api.patch(`/api/hq/products/${productCode}`, payload)
+  return unwrap(res)
+}
+
+export async function deleteProduct(productCode) {
+  const res = await api.delete(`/api/hq/products/${productCode}`)
+  return unwrap(res)
+}
+
+export async function getProductSkus(productCode) {
+  const res = await api.get(`/api/hq/products/${productCode}/skus`)
+  return unwrap(res)
+}
+
+export async function createProductSku(productCode, payload) {
+  const res = await api.post(`/api/hq/products/${productCode}/skus`, payload)
+  return unwrap(res)
+}
+
+export async function createProductSkusBulk(productCode, payload) {
+  const res = await api.post(`/api/hq/products/${productCode}/skus/bulk`, payload)
+  return unwrap(res)
+}
+
+export async function updateProductSku(skuCode, payload) {
+  const res = await api.patch(`/api/hq/skus/${skuCode}`, payload)
+  return unwrap(res)
+}
+
+export async function deleteProductSku(skuCode) {
+  const res = await api.delete(`/api/hq/skus/${skuCode}`)
+  return unwrap(res)
+}

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -92,6 +92,18 @@ const router = createRouter({
       component: () => import('@/views/hq/HqProductCreateView.vue'),
       meta: { requiresAuth: true, role: 'hq' },
     },
+    {
+      path: '/hq/products/:productCode/skus',
+      name: 'hq-product-sku-detail',
+      component: () => import('@/views/hq/HqProductSkuDetailView.vue'),
+      meta: { requiresAuth: true, role: 'hq' },
+    },
+    {
+      path: '/hq/products/:productCode/edit',
+      name: 'hq-product-edit',
+      component: () => import('@/views/hq/HqProductCreateView.vue'),
+      meta: { requiresAuth: true, role: 'hq' },
+    },
     { path: '/hq/infrastructure', name: 'hq-infrastructure', component: HqInfrastructureManagementView, meta: { requiresAuth: true, role: 'hq' } },
     {
       path: '/hq/infrastructure/stores/:storeId',

--- a/src/views/hq/HqInfrastructureManagementView.vue
+++ b/src/views/hq/HqInfrastructureManagementView.vue
@@ -1,9 +1,17 @@
 <script setup>
-import { computed, h, ref, watch } from 'vue'
+import { computed, h, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
+import {
+  createStore,
+  createWarehouse,
+  getStores,
+  getWarehouses,
+  updateStore,
+  updateWarehouse,
+} from '@/api/infrastructure.js'
 
 const router = useRouter()
 const route = useRoute()
@@ -55,34 +63,11 @@ const infraSideMenus = [
   { label: '창고 정보 관리', icon: 'warehouse', id: 'SO-040' },
 ]
 
-const locations = ['서울', '경기', '인천', '부산', '대구']
-const names = ['스톡잇 강남점', '홍대 문구센터', '판교 테크노잡화', '여의도 IFC몰점', '성수 리빙샵', '인천 터미널점', '분당 서현점', '부산 센텀점', '광교 갤러리아점', '대전 둔산점']
-const managers = ['김사라', '박범수', '이선엽', '이후경', '정유진', '최진혁']
-const warehouses = ['인천 제1센터', '인천 제2센터', '용인 물류센터', '부산 중앙창고']
+const storeData = ref([])
+const warehouseData = ref([])
+const infraError = ref('')
 
-const storeData = Array.from({ length: 32 }).map((_, i) => {
-  const isExpiring = i % 7 === 0
-  const stockCapacity = 1200 + (i % 5) * 300
-  const remainingStock = 240 + (i * 77) % 1200
-  const remainingRate = Math.min(100, Math.round((remainingStock / stockCapacity) * 100))
-  return {
-    id: `ST-${String(i + 1).padStart(3, '0')}`,
-    name: `${names[i % names.length]}${i > 9 ? ` ${Math.floor(i / 10) + 1}관` : ''}`,
-    region: locations[i % locations.length],
-    type: i % 3 === 0 ? '직영점' : '가맹점',
-    manager: managers[i % managers.length],
-    contact: `010-4821-${String(1000 + i)}`,
-    warehouse: warehouses[i % warehouses.length],
-    endDate: isExpiring ? '2024.05.15' : '2025.12.31',
-    status: i === 15 ? '비활성' : '활성',
-    isExpiring,
-    stockCapacity,
-    remainingStock,
-    remainingRate,
-  }
-})
-
-const storeRegionOptions = computed(() => ['전체 지역', ...new Set(storeData.map((store) => store.region))])
+const storeRegionOptions = computed(() => ['전체 지역', ...new Set(storeData.value.map((store) => store.region))])
 const storeStatusOptions = ['전체', '활성', '비활성']
 
 if (!storeRegionOptions.value.includes(storeRegionFilter.value)) {
@@ -93,94 +78,10 @@ if (!storeStatusOptions.includes(storeStatusFilter.value)) {
   storeStatusFilter.value = '전체'
 }
 
-const filteredStoreData = computed(() => {
-  const keyword = storeSearchTerm.value.trim().toLowerCase()
+const filteredStoreData = computed(() => storeData.value)
 
-  return storeData.filter((store) => {
-    const matchesRegion = storeRegionFilter.value === '전체 지역' || store.region === storeRegionFilter.value
-    const matchesStatus = storeStatusFilter.value === '전체' || store.status === storeStatusFilter.value
-    const matchesKeyword = !keyword || [store.id, store.name, store.manager, store.contact, store.warehouse]
-      .join(' ')
-      .toLowerCase()
-      .includes(keyword)
-
-    return matchesRegion && matchesStatus && matchesKeyword
-  })
-})
-
-const warehouseData = [
-  {
-    id: 'WH-001',
-    name: '인천 제1센터',
-    address: '인천광역시 서구 봉수대로 241',
-    manager: '박범수',
-    contact: '032-541-1201',
-    capacity: '12,000 PLT / 6,500㎡',
-    stockQty: 124582,
-    occupancy: 82,
-    status: '활성',
-    mappedStores: ['스톡잇 강남점', '홍대 문구센터', '여의도 IFC몰점', '성수 리빙샵'],
-    recentFlows: [
-      { time: '16:45', type: '입고', item: '고속 충전기 25W', qty: '+500' },
-      { time: '15:20', type: '출고', item: 'A4 복사용지 80g', qty: '-1,200' },
-      { time: '13:10', type: '이동', item: '무선 마우스 블랙', qty: '-240' },
-    ],
-  },
-  {
-    id: 'WH-002',
-    name: '인천 제2센터',
-    address: '인천광역시 중구 서해대로 98',
-    manager: '이후경',
-    contact: '032-541-1202',
-    capacity: '8,500 PLT / 4,100㎡',
-    stockQty: 84550,
-    occupancy: 68,
-    status: '활성',
-    mappedStores: ['판교 테크노잡화', '분당 서현점', '광교 갤러리아점'],
-    recentFlows: [
-      { time: '17:05', type: '입고', item: '절전형 멀티탭 3m', qty: '+300' },
-      { time: '14:30', type: '출고', item: '기계식 키보드 청축', qty: '-80' },
-      { time: '11:10', type: '출고', item: '손세정제 리필 500ml', qty: '-420' },
-    ],
-  },
-  {
-    id: 'WH-003',
-    name: '용인 물류센터',
-    address: '경기도 용인시 처인구 남사읍 물류로 75',
-    manager: '김사라',
-    contact: '031-338-4401',
-    capacity: '15,000 PLT / 8,300㎡',
-    stockQty: 142300,
-    occupancy: 91,
-    status: '포화 임박',
-    mappedStores: ['성수 리빙샵', '인천 터미널점', '대전 둔산점', '부산 센텀점'],
-    recentFlows: [
-      { time: '16:20', type: '입고', item: '종이컵 6.5온스', qty: '+4,500' },
-      { time: '15:05', type: '출고', item: '니트릴 고무장갑', qty: '-650' },
-      { time: '09:40', type: '출고', item: '휴대용 가글 250ml', qty: '-320' },
-    ],
-  },
-  {
-    id: 'WH-004',
-    name: '부산 중앙창고',
-    address: '부산광역시 강서구 유통단지1로 55',
-    manager: '이선엽',
-    contact: '051-923-7701',
-    capacity: '6,200 PLT / 3,200㎡',
-    stockQty: 46320,
-    occupancy: 44,
-    status: '비활성',
-    mappedStores: ['부산 센텀점'],
-    recentFlows: [
-      { time: '어제', type: '점검', item: '냉동 블루베리 1kg', qty: '보류' },
-      { time: '어제', type: '출고', item: '무선 이어폰', qty: '-45' },
-      { time: '2일 전', type: '입고', item: '유리제 머그컵 350ml', qty: '+220' },
-    ],
-  },
-]
-
-const warehouseRegionOptions = computed(() => ['전체 지역', ...new Set(warehouseData.map((warehouse) => warehouse.address.split(' ')[0].replace('광역시', '').replace('특별시', '')))])
-const warehouseStatusOptions = ['전체', '활성', '비활성', '포화 임박']
+const warehouseRegionOptions = computed(() => ['전체 지역', ...new Set(warehouseData.value.map((warehouse) => warehouse.region))])
+const warehouseStatusOptions = ['전체', '활성', '비활성', '점검중']
 
 if (!warehouseRegionOptions.value.includes(warehouseRegionFilter.value)) {
   warehouseRegionFilter.value = '전체 지역'
@@ -190,21 +91,7 @@ if (!warehouseStatusOptions.includes(warehouseStatusFilter.value)) {
   warehouseStatusFilter.value = '전체'
 }
 
-const filteredWarehouseData = computed(() => {
-  const keyword = warehouseSearchTerm.value.trim().toLowerCase()
-
-  return warehouseData.filter((warehouse) => {
-    const region = warehouse.address.split(' ')[0].replace('광역시', '').replace('특별시', '')
-    const matchesRegion = warehouseRegionFilter.value === '전체 지역' || region === warehouseRegionFilter.value
-    const matchesStatus = warehouseStatusFilter.value === '전체' || warehouse.status === warehouseStatusFilter.value
-    const matchesKeyword = !keyword || [warehouse.id, warehouse.name, warehouse.manager, warehouse.contact, warehouse.address]
-      .join(' ')
-      .toLowerCase()
-      .includes(keyword)
-
-    return matchesRegion && matchesStatus && matchesKeyword
-  })
-})
+const filteredWarehouseData = computed(() => warehouseData.value)
 
 const isStoreMenu = computed(() => activeSideMenu.value === '매장 정보 관리')
 const isWarehouseMenu = computed(() => activeSideMenu.value === '창고 정보 관리')
@@ -231,7 +118,7 @@ const handleTopMenuClick = (menu) => {
 const goToStoreDetail = (store) => {
   router.push({
     name: 'hq-infrastructure-store-detail',
-    params: { storeId: store.id },
+    params: { storeId: store.code },
     query: {
       region: storeRegionFilter.value !== '전체 지역' ? storeRegionFilter.value : undefined,
       status: storeStatusFilter.value !== '전체' ? storeStatusFilter.value : undefined,
@@ -243,7 +130,7 @@ const goToStoreDetail = (store) => {
 const goToWarehouseDetail = (warehouse) => {
   router.push({
     name: 'hq-infrastructure-warehouse-detail',
-    params: { warehouseId: warehouse.id },
+    params: { warehouseId: warehouse.code },
     query: {
       menu: '창고 정보 관리',
       region: warehouseRegionFilter.value !== '전체 지역' ? warehouseRegionFilter.value : undefined,
@@ -261,6 +148,118 @@ watch(
     }
   },
 )
+
+const statusToKor = {
+  ACTIVE: '활성',
+  INACTIVE: '비활성',
+  SUSPENDED: '점검중',
+}
+const korToStatus = {
+  활성: 'ACTIVE',
+  비활성: 'INACTIVE',
+  점검중: 'SUSPENDED',
+}
+
+async function loadStores() {
+  const status = storeStatusFilter.value === '전체' ? undefined : korToStatus[storeStatusFilter.value]
+  const region = storeRegionFilter.value === '전체 지역' ? undefined : storeRegionFilter.value
+  const list = await getStores({ keyword: storeSearchTerm.value || undefined, region, status })
+  storeData.value = list.map((s) => ({
+    code: s.code,
+    id: s.code,
+    name: s.name,
+    region: s.region,
+    type: s.type === 'DIRECT' ? '직영점' : '가맹점',
+    manager: s.managerName,
+    contact: s.contact,
+    address: s.address,
+    warehouse: s.warehouseCode,
+    status: statusToKor[s.status] ?? s.status,
+    stockCapacity: 1000,
+    remainingStock: 700,
+    remainingRate: 70,
+  }))
+}
+
+async function loadWarehouses() {
+  const status = warehouseStatusFilter.value === '전체' ? undefined : korToStatus[warehouseStatusFilter.value]
+  const region = warehouseRegionFilter.value === '전체 지역' ? undefined : warehouseRegionFilter.value
+  const list = await getWarehouses({ keyword: warehouseSearchTerm.value || undefined, region, status })
+  warehouseData.value = list.map((w) => ({
+    code: w.code,
+    id: w.code,
+    name: w.name,
+    region: w.region,
+    address: w.address,
+    manager: w.managerName,
+    contact: w.contact,
+    capacity: w.capacity,
+    stockQty: w.mappedStoreCount * 1000,
+    occupancy: Math.min(95, 20 + w.mappedStoreCount * 15),
+    status: statusToKor[w.status] ?? w.status,
+  }))
+}
+
+async function reloadActiveMenuData() {
+  try {
+    infraError.value = ''
+    if (isStoreMenu.value) await loadStores()
+    if (isWarehouseMenu.value) await loadWarehouses()
+  } catch (e) {
+    infraError.value = e.message
+  }
+}
+
+watch([storeRegionFilter, storeStatusFilter, storeSearchTerm], () => {
+  if (isStoreMenu.value) reloadActiveMenuData()
+})
+watch([warehouseRegionFilter, warehouseStatusFilter, warehouseSearchTerm], () => {
+  if (isWarehouseMenu.value) reloadActiveMenuData()
+})
+watch(activeSideMenu, () => reloadActiveMenuData())
+
+async function quickCreateStore() {
+  const name = prompt('매장명을 입력하세요')
+  if (!name) return
+  try {
+    await createStore({
+      name,
+      region: '서울',
+      type: 'DIRECT',
+      managerName: '담당자',
+      contact: '010-0000-0000',
+      address: '서울시 강남구',
+      warehouseCode: warehouseData.value[0]?.code || 'WH-0001',
+      status: 'ACTIVE',
+    })
+    await loadStores()
+  } catch (e) {
+    infraError.value = e.message
+  }
+}
+
+async function quickCreateWarehouse() {
+  const name = prompt('창고명을 입력하세요')
+  if (!name) return
+  try {
+    await createWarehouse({
+      name,
+      region: '서울',
+      managerName: '담당자',
+      contact: '02-0000-0000',
+      address: '서울시 강서구',
+      capacity: '10,000 PLT / 5,000㎡',
+      status: 'ACTIVE',
+    })
+    await loadWarehouses()
+  } catch (e) {
+    infraError.value = e.message
+  }
+}
+
+onMounted(() => {
+  reloadActiveMenuData()
+})
 
 const IconBase = (paths) => ({
   props: {
@@ -383,6 +382,7 @@ const iconMap = {
               </label>
           </div>
         </section>
+        <p v-if="infraError" class="text-xs font-bold text-red-600">{{ infraError }}</p>
 
         <section v-if="activeSideMenu === '매장 정보 관리'" class="panel store-panel">
             <div class="store-head">
@@ -392,6 +392,7 @@ const iconMap = {
                 </h3>
                 <span class="text-[10px] font-bold text-gray-400">Total: {{ filteredStoreData.length }} Locations</span>
               </div>
+              <button type="button" class="primary-button" @click="quickCreateStore">매장 등록</button>
             </div>
 
             <div class="store-card-grid">
@@ -457,6 +458,7 @@ const iconMap = {
                 <h3><WarehouseIcon :size="14" /> 전사 창고 마스터 정보 (SO-041)</h3>
                 <span>Total: {{ filteredWarehouseData.length }} Warehouses</span>
               </div>
+              <button type="button" class="primary-button" @click="quickCreateWarehouse">창고 등록</button>
             </div>
 
             <div class="store-card-grid">

--- a/src/views/hq/HqProductCreateView.vue
+++ b/src/views/hq/HqProductCreateView.vue
@@ -1,11 +1,23 @@
 <script setup>
-import { computed, ref, watch } from 'vue'
-import { useRouter } from 'vue-router'
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { ArrowLeft, ChevronRight, Package } from 'lucide-vue-next'
 import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
+import { getCategories } from '@/api/category.js'
+import {
+  createProduct,
+  createProductSku,
+  createProductSkusBulk,
+  deleteProduct,
+  deleteProductSku,
+  getProductDetail,
+  getProductSkus,
+  updateProduct,
+} from '@/api/productMaster.js'
 
+const route = useRoute()
 const router = useRouter()
 const auth = useAuthStore()
 const hqMenus = roleMenus.hq
@@ -15,6 +27,9 @@ function handleLogout() {
   router.push('/login')
 }
 
+const isEditMode = computed(() => Boolean(route.params.productCode))
+const productCode = computed(() => String(route.params.productCode ?? ''))
+
 const activeTopMenu = computed(() => '상품 관리')
 const activeSideMenu = ref('제품 마스터')
 
@@ -23,26 +38,31 @@ const productSideMenus = [
   { label: '제품 마스터', icon: 'package', id: 'SO-011', path: '/hq/products' },
 ]
 
-const categoryMap = {
-  상의: ['반팔', '긴팔', '셔츠', '니트', '후드티'],
-  바지: ['청바지', '반바지', '긴바지', '츄리닝'],
-  치마: ['미니 스커트', '롱스커트'],
-  아우터: ['패딩', '후드집업', '자켓', '가디건'],
-}
+const categoryTree = ref([])
 const COLOR_OPTIONS = ['검정', '흰색', '그레이', '아이보리']
 const SIZE_OPTIONS = ['XS', 'S', 'M', 'L', 'XL']
 
 const productName = ref('')
-const parentCategory = ref('상의')
-const childCategory = ref('반팔')
+const parentCategory = ref('')
+const childCategory = ref('')
 const price = ref('')
 const status = ref('활성')
 const vendorName = ref('')
+const leadTimeDays = ref(3)
 const regDate = ref(new Date().toISOString().slice(0, 10).replaceAll('-', '.'))
 const selectedColors = ref([])
 const selectedSizes = ref([])
+const currentSkus = ref([])
+const submitError = ref('')
+const submitSuccess = ref('')
+const isSubmitting = ref(false)
 
-const childCategoryOptions = computed(() => categoryMap[parentCategory.value] ?? [])
+
+const parentCategoryOptions = computed(() => categoryTree.value.map((c) => c.name))
+const childCategoryOptions = computed(() => {
+  const parent = categoryTree.value.find((c) => c.name === parentCategory.value)
+  return parent ? parent.children.map((c) => c.name) : []
+})
 
 watch(parentCategory, () => {
   if (!childCategoryOptions.value.includes(childCategory.value)) {
@@ -57,49 +77,225 @@ const variantSummaryText = computed(() => {
   return `색상(${selectedColors.value.join(', ')}) / 사이즈(${selectedSizes.value.join(', ')})`
 })
 
-const requiredProgress = computed(() => {
-  const requiredSteps = [
-    Boolean(productName.value.trim()),
-    Boolean(parentCategory.value),
-    Boolean(childCategory.value),
-    Number(price.value) > 0,
-    Boolean(vendorName.value.trim()),
-    isVariantValid.value,
-  ]
-  return requiredSteps.filter(Boolean).length
-})
-
-const canSubmit = computed(() =>
+const canSubmitCreate = computed(() =>
   productName.value.trim() &&
   parentCategory.value &&
   childCategory.value &&
-  Number(price.value) > 0 &&
+  Number(price.value) >= 0 &&
   vendorName.value.trim() &&
   isVariantValid.value,
 )
 
-function toggleColor(color) {
-  const next = new Set(selectedColors.value)
-  if (next.has(color)) next.delete(color)
-  else next.add(color)
-  selectedColors.value = Array.from(next)
+const canSubmitEdit = computed(() =>
+  productName.value.trim() &&
+  parentCategory.value &&
+  childCategory.value &&
+  Number(price.value) >= 0 &&
+  vendorName.value.trim(),
+)
+
+const statusMap = {
+  활성: 'ACTIVE',
+  점검중: 'SUSPENDED',
+  비활성: 'INACTIVE',
 }
 
-function toggleSize(size) {
-  const next = new Set(selectedSizes.value)
-  if (next.has(size)) next.delete(size)
-  else next.add(size)
-  selectedSizes.value = Array.from(next)
+const statusLabelMap = {
+  ACTIVE: '활성',
+  SUSPENDED: '점검중',
+  INACTIVE: '비활성',
 }
 
-function handleSubmit() {
-  if (!canSubmit.value) return
-  router.push('/hq/products')
+function resolveCategoryCode() {
+  const parent = categoryTree.value.find((c) => c.name === parentCategory.value)
+  if (!parent) return null
+  const child = parent.children.find((c) => c.name === childCategory.value)
+  return child?.code || parent.code
+}
+
+function splitColorSize(optionValue) {
+  const [color, size] = String(optionValue || '').split('|')
+  return { color: color || '', size: size || '' }
+}
+
+async function loadSkus() {
+  if (!isEditMode.value) return
+  currentSkus.value = await getProductSkus(productCode.value)
+  selectedColors.value = [...new Set(currentSkus.value.map((s) => splitColorSize(s.optionValue).color).filter(Boolean))]
+  selectedSizes.value = [...new Set(currentSkus.value.map((s) => splitColorSize(s.optionValue).size).filter(Boolean))]
+}
+
+async function toggleColor(color) {
+  selectedColors.value = selectedColors.value.includes(color)
+    ? selectedColors.value.filter((c) => c !== color)
+    : [...selectedColors.value, color]
+}
+
+async function toggleSize(size) {
+  selectedSizes.value = selectedSizes.value.includes(size)
+    ? selectedSizes.value.filter((s) => s !== size)
+    : [...selectedSizes.value, size]
+}
+
+async function syncSkusBySelections() {
+  const desiredOptionValues = new Set()
+  for (const color of selectedColors.value) {
+    for (const size of selectedSizes.value) {
+      desiredOptionValues.add(`${color}|${size}`)
+    }
+  }
+
+  const currentOptionMap = new Map(currentSkus.value.map((sku) => [sku.optionValue, sku]))
+  const removeTargets = currentSkus.value.filter((sku) => !desiredOptionValues.has(sku.optionValue))
+  const addTargets = [...desiredOptionValues].filter((optionValue) => !currentOptionMap.has(optionValue))
+
+  if (removeTargets.length > 0) {
+    await Promise.all(removeTargets.map((sku) => deleteProductSku(sku.skuCode)))
+  }
+
+  if (addTargets.length > 0) {
+    await createProductSkusBulk(productCode.value, {
+      optionName: 'COLOR_SIZE',
+      optionValues: addTargets,
+      unitPrice: Number(price.value),
+      status: statusMap[status.value] ?? 'ACTIVE',
+    })
+  }
+
+  return { added: addTargets.length, removed: removeTargets.length }
+}
+
+async function loadProduct() {
+  if (!isEditMode.value) return
+  const product = await getProductDetail(productCode.value)
+
+  productName.value = product.name || ''
+  price.value = Number(product.basePrice || 0)
+  status.value = statusLabelMap[product.status] || '활성'
+  vendorName.value = product.mainVendorCode || ''
+  leadTimeDays.value = Number(product.leadTimeDays || 0)
+
+  const parent = categoryTree.value.find((c) => (c.children || []).some((child) => child.code === product.categoryCode))
+  if (parent) {
+    parentCategory.value = parent.name
+    const child = parent.children.find((c) => c.code === product.categoryCode)
+    childCategory.value = child?.name || parent.children?.[0]?.name || ''
+  } else {
+    const root = categoryTree.value.find((c) => c.code === product.categoryCode)
+    if (root) {
+      parentCategory.value = root.name
+      childCategory.value = root.children?.[0]?.name || ''
+    }
+  }
+}
+
+async function handleSubmit() {
+  const categoryCode = resolveCategoryCode()
+  if (!categoryCode) {
+    submitError.value = '카테고리 정보를 불러오지 못했습니다.'
+    return
+  }
+
+  if (!isEditMode.value && !canSubmitCreate.value) return
+  if (isEditMode.value && !canSubmitEdit.value) return
+
+  try {
+    isSubmitting.value = true
+    submitError.value = ''
+    submitSuccess.value = ''
+
+    if (!isEditMode.value) {
+      const product = await createProduct({
+        name: productName.value.trim(),
+        categoryCode,
+        basePrice: Number(price.value),
+        leadTimeDays: Number(leadTimeDays.value),
+        mainVendorCode: vendorName.value.trim(),
+        status: statusMap[status.value] ?? 'ACTIVE',
+      })
+
+      for (const color of selectedColors.value) {
+        for (const size of selectedSizes.value) {
+          await createProductSku(product.code, {
+            optionName: 'COLOR_SIZE',
+            optionValue: `${color}|${size}`,
+            unitPrice: Number(price.value),
+            status: statusMap[status.value] ?? 'ACTIVE',
+          })
+        }
+      }
+
+      submitSuccess.value = '제품 및 SKU 등록이 완료되었습니다.'
+    } else {
+      await updateProduct(productCode.value, {
+        name: productName.value.trim(),
+        categoryCode,
+        basePrice: Number(price.value),
+        leadTimeDays: Number(leadTimeDays.value),
+        mainVendorCode: vendorName.value.trim(),
+        status: statusMap[status.value] ?? 'ACTIVE',
+      })
+      const skuResult = await syncSkusBySelections()
+      await loadSkus()
+      submitSuccess.value = `제품 정보 수정 완료 (SKU 추가 ${skuResult.added}건 / 삭제 ${skuResult.removed}건)`
+    }
+
+    setTimeout(() => {
+      router.push('/hq/products?tab=products')
+    }, 500)
+  } catch (e) {
+    submitError.value = e.message
+  } finally {
+    isSubmitting.value = false
+  }
 }
 
 function handleCancel() {
-  router.push('/hq/products')
+  router.push('/hq/products?tab=products')
 }
+
+async function handleDeleteProduct() {
+  if (!isEditMode.value) return
+  const ok = confirm('해당 품목을 삭제할까요? 연결된 SKU도 함께 삭제됩니다.')
+  if (!ok) return
+  try {
+    isSubmitting.value = true
+    submitError.value = ''
+    submitSuccess.value = ''
+    await deleteProduct(productCode.value)
+    submitSuccess.value = '품목이 삭제되었습니다.'
+    setTimeout(() => {
+      router.push('/hq/products?tab=products')
+    }, 500)
+  } catch (e) {
+    submitError.value = e.message
+  } finally {
+    isSubmitting.value = false
+  }
+}
+
+
+async function loadCategories() {
+  const list = await getCategories()
+  categoryTree.value = list
+  if (!isEditMode.value && list.length > 0) {
+    parentCategory.value = list[0].name
+    childCategory.value = list[0].children?.[0]?.name ?? ''
+  }
+}
+
+onMounted(async () => {
+  try {
+    submitError.value = ''
+    await loadCategories()
+    if (isEditMode.value) {
+      await loadProduct()
+      await loadSkus()
+    }
+  } catch (e) {
+    submitError.value = e.message
+  }
+})
 </script>
 
 <template>
@@ -118,7 +314,7 @@ function handleCancel() {
           <ChevronRight :size="12" />
           <button type="button" class="hover:text-[#004D3C]" @click="handleCancel">제품 마스터</button>
           <ChevronRight :size="12" />
-          <span class="text-gray-700">신규 제품 등록</span>
+          <span class="text-gray-700">{{ isEditMode ? '제품 관리' : '신규 제품 등록' }}</span>
         </div>
         <div class="mt-3 flex items-center gap-3">
           <button
@@ -129,162 +325,142 @@ function handleCancel() {
             <ArrowLeft :size="15" />
           </button>
           <div>
-            <h1 class="text-xl font-black text-gray-950">신규 제품 등록</h1>
-            <p class="mt-0.5 text-xs font-bold text-gray-400">제품 기본 정보를 입력하고 신규 제품을 등록합니다.</p>
+            <h1 class="text-xl font-black text-gray-950">{{ isEditMode ? '제품 관리' : '신규 제품 등록' }}</h1>
+            <p class="mt-0.5 text-xs font-bold text-gray-400">{{ isEditMode ? '제품 기본 정보와 옵션(색상·사이즈)을 수정합니다.' : '제품 기본 정보를 입력하고 초기 옵션을 구성합니다.' }}</p>
           </div>
         </div>
       </section>
 
       <section class="grid gap-4 xl:grid-cols-[minmax(0,2fr)_minmax(280px,1fr)] xl:items-start">
-        <div class="border border-gray-200 bg-white shadow-sm">
-          <div class="flex items-center gap-2 border-b border-gray-100 px-5 py-3">
-            <Package :size="15" class="text-[#004D3C]" />
-            <h2 class="text-sm font-black text-gray-900">제품 정보 입력</h2>
-          </div>
-
-          <div class="border-b border-gray-100 bg-[#F7FBFA] px-5 py-3">
-            <div class="flex items-center justify-between gap-2">
-              <p class="text-[11px] font-black uppercase tracking-wide text-gray-500">입력 진행 안내</p>
-              <span class="text-[11px] font-black text-[#004D3C]">{{ requiredProgress }}/6 완료</span>
-            </div>
-            <div class="mt-2 h-1.5 overflow-hidden bg-[#DCEDE8]">
-              <div class="h-full bg-[#0E7A60] transition-all" :style="{ width: `${(requiredProgress / 6) * 100}%` }" />
-            </div>
-          </div>
-
-          <form class="space-y-6 p-5" @submit.prevent="handleSubmit">
-            <div>
-              <label class="mb-1.5 block text-[11px] font-black uppercase tracking-wide text-gray-500">
-                제품명 <span class="text-red-500">*</span>
-              </label>
-              <input
-                v-model="productName"
-                type="text"
-                placeholder="제품명을 입력하세요"
-                class="w-full border border-gray-300 bg-white px-3 py-2.5 text-sm outline-none focus:border-[#004D3C]"
-              />
+        <div class="space-y-4">
+          <div class="border border-gray-200 bg-white shadow-sm">
+            <div class="flex items-center gap-2 border-b border-gray-100 px-5 py-3">
+              <Package :size="15" class="text-[#004D3C]" />
+              <h2 class="text-sm font-black text-gray-900">제품 정보</h2>
             </div>
 
-            <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <label class="block text-[11px] font-black uppercase tracking-wide text-gray-500">
-                대분류 <span class="text-red-500">*</span>
-                <select
-                  v-model="parentCategory"
-                  class="mt-1.5 w-full border border-gray-300 bg-white px-3 py-2.5 text-sm text-gray-800 outline-none focus:border-[#004D3C]"
-                >
-                  <option v-for="parent in Object.keys(categoryMap)" :key="parent" :value="parent">{{ parent }}</option>
-                </select>
-              </label>
-              <label class="block text-[11px] font-black uppercase tracking-wide text-gray-500">
-                소분류 <span class="text-red-500">*</span>
-                <select
-                  v-model="childCategory"
-                  class="mt-1.5 w-full border border-gray-300 bg-white px-3 py-2.5 text-sm text-gray-800 outline-none focus:border-[#004D3C]"
-                >
-                  <option v-for="child in childCategoryOptions" :key="child" :value="child">{{ child }}</option>
-                </select>
-              </label>
-            </div>
-
-            <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <label class="block text-[11px] font-black uppercase tracking-wide text-gray-500">
-                단가 <span class="text-red-500">*</span>
+            <form class="space-y-6 p-5" @submit.prevent="handleSubmit">
+              <div>
+                <label class="mb-1.5 block text-[11px] font-black uppercase tracking-wide text-gray-500">
+                  제품명 <span class="text-red-500">*</span>
+                </label>
                 <input
-                  v-model.number="price"
-                  type="number"
-                  min="0"
-                  placeholder="숫자로 입력"
-                  class="mt-1.5 w-full border border-gray-300 bg-white px-3 py-2.5 text-sm outline-none focus:border-[#004D3C]"
-                />
-              </label>
-              <label class="block text-[11px] font-black uppercase tracking-wide text-gray-500">
-                상태
-                <select
-                  v-model="status"
-                  class="mt-1.5 w-full border border-gray-300 bg-white px-3 py-2.5 text-sm text-gray-800 outline-none focus:border-[#004D3C]"
-                >
-                  <option value="활성">활성</option>
-                  <option value="점검중">점검중</option>
-                  <option value="비활성">비활성</option>
-                </select>
-              </label>
-            </div>
-
-            <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <label class="block text-[11px] font-black uppercase tracking-wide text-gray-500">
-                메인 거래처 <span class="text-red-500">*</span>
-                <input
-                  v-model="vendorName"
+                  v-model="productName"
                   type="text"
-                  placeholder="거래처명을 입력하세요"
-                  class="mt-1.5 w-full border border-gray-300 bg-white px-3 py-2.5 text-sm outline-none focus:border-[#004D3C]"
+                  placeholder="제품명을 입력하세요"
+                  class="w-full border border-gray-300 bg-white px-3 py-2.5 text-sm outline-none focus:border-[#004D3C]"
                 />
-              </label>
-              <label class="block text-[11px] font-black uppercase tracking-wide text-gray-500">
-                등록일
-                <input
-                  v-model="regDate"
-                  type="text"
-                  class="mt-1.5 w-full border border-gray-300 bg-white px-3 py-2.5 text-sm outline-none focus:border-[#004D3C]"
-                />
-              </label>
-            </div>
-
-            <div class="mt-6 space-y-3 rounded-md border border-gray-300 bg-white p-5">
-              <p class="text-[11px] font-black uppercase tracking-wide text-gray-500">옵션 구성 <span class="text-red-500">*</span></p>
-              <div class="flex flex-wrap gap-2">
-                <button
-                  v-for="color in COLOR_OPTIONS"
-                  :key="color"
-                  type="button"
-                  class="border px-3 py-1.5 text-xs font-black transition"
-                  :class="selectedColors.includes(color)
-                    ? 'border-[#004D3C] bg-[#004D3C] text-white'
-                    : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-100'"
-                  @click="toggleColor(color)"
-                >
-                  {{ color }}
-                </button>
               </div>
 
-              <div class="mt-5 pt-2">
-                <p class="mb-2 text-[11px] font-black text-gray-500">공통 사이즈 선택</p>
-                <div class="flex flex-wrap gap-2">
-                <button
-                  v-for="size in SIZE_OPTIONS"
-                  :key="size"
-                  type="button"
-                  class="border px-2.5 py-1 text-xs font-black transition"
-                  :class="selectedSizes.includes(size)
-                    ? 'border-[#0E7A60] bg-[#EBF5F5] text-[#0E7A60]'
-                    : 'border-gray-300 bg-white text-gray-600 hover:bg-gray-100'"
-                  @click="toggleSize(size)"
-                >
-                  {{ size }}
-                </button>
+              <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <label class="block text-[11px] font-black uppercase tracking-wide text-gray-500">
+                  대분류 <span class="text-red-500">*</span>
+                  <select v-model="parentCategory" class="mt-1.5 w-full border border-gray-300 bg-white px-3 py-2.5 text-sm text-gray-800 outline-none focus:border-[#004D3C]">
+                    <option v-for="parent in parentCategoryOptions" :key="parent" :value="parent">{{ parent }}</option>
+                  </select>
+                </label>
+                <label class="block text-[11px] font-black uppercase tracking-wide text-gray-500">
+                  소분류 <span class="text-red-500">*</span>
+                  <select v-model="childCategory" class="mt-1.5 w-full border border-gray-300 bg-white px-3 py-2.5 text-sm text-gray-800 outline-none focus:border-[#004D3C]">
+                    <option v-for="child in childCategoryOptions" :key="child" :value="child">{{ child }}</option>
+                  </select>
+                </label>
+              </div>
+
+              <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <label class="block text-[11px] font-black uppercase tracking-wide text-gray-500">
+                  단가 <span class="text-red-500">*</span>
+                  <input v-model.number="price" type="number" min="0" class="mt-1.5 w-full border border-gray-300 bg-white px-3 py-2.5 text-sm outline-none focus:border-[#004D3C]" />
+                </label>
+                <label class="block text-[11px] font-black uppercase tracking-wide text-gray-500">
+                  상태
+                  <select v-model="status" class="mt-1.5 w-full border border-gray-300 bg-white px-3 py-2.5 text-sm text-gray-800 outline-none focus:border-[#004D3C]">
+                    <option value="활성">활성</option>
+                    <option value="점검중">점검중</option>
+                    <option value="비활성">비활성</option>
+                  </select>
+                </label>
+              </div>
+
+              <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <label class="block text-[11px] font-black uppercase tracking-wide text-gray-500">
+                  메인 거래처 <span class="text-red-500">*</span>
+                  <input v-model="vendorName" type="text" class="mt-1.5 w-full border border-gray-300 bg-white px-3 py-2.5 text-sm outline-none focus:border-[#004D3C]" />
+                </label>
+                <label class="block text-[11px] font-black uppercase tracking-wide text-gray-500">
+                  리드타임(일)
+                  <input v-model.number="leadTimeDays" type="number" min="0" class="mt-1.5 w-full border border-gray-300 bg-white px-3 py-2.5 text-sm outline-none focus:border-[#004D3C]" />
+                </label>
+              </div>
+
+              <div class="!mt-4 space-y-5 rounded-md border border-gray-300 bg-white p-5">
+                <p class="text-[11px] font-black uppercase tracking-wide text-gray-500">
+                  옵션 구성 <span v-if="!isEditMode" class="text-red-500">*</span>
+                </p>
+                <div class="space-y-2">
+                  <p class="text-[10px] font-bold text-gray-400">색상</p>
+                  <div class="flex flex-wrap gap-2">
+                    <button
+                      v-for="color in COLOR_OPTIONS"
+                      :key="color"
+                      type="button"
+                      class="border px-3 py-1.5 text-xs font-black transition"
+                      :class="selectedColors.includes(color)
+                        ? 'border-[#004D3C] bg-[#004D3C] text-white'
+                        : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-100'"
+                      @click="toggleColor(color)"
+                    >
+                      {{ color }}
+                    </button>
+                  </div>
+                </div>
+                <div class="space-y-2">
+                  <p class="text-[10px] font-bold text-gray-400">사이즈</p>
+                  <div class="flex flex-wrap gap-2">
+                    <button
+                      v-for="size in SIZE_OPTIONS"
+                      :key="size"
+                      type="button"
+                      class="border px-2.5 py-1 text-xs font-black transition"
+                      :class="selectedSizes.includes(size)
+                        ? 'border-[#0E7A60] bg-[#EBF5F5] text-[#0E7A60]'
+                        : 'border-gray-300 bg-white text-gray-600 hover:bg-gray-100'"
+                      @click="toggleSize(size)"
+                    >
+                      {{ size }}
+                    </button>
+                  </div>
                 </div>
               </div>
-            </div>
 
-            <div class="-mx-5 border-t border-gray-100 bg-white px-5 pt-4">
-              <div class="flex gap-2">
-                <button
-                  type="button"
-                  class="flex-1 border border-gray-300 bg-white py-2.5 text-sm font-black text-gray-700 hover:bg-gray-50"
-                  @click="handleCancel"
-                >
-                  취소
-                </button>
-                <button
-                  type="submit"
-                  class="flex-1 border border-[#004D3C] bg-[#004D3C] py-2.5 text-sm font-black text-white hover:bg-[#003d30] disabled:cursor-not-allowed disabled:opacity-40"
-                  :disabled="!canSubmit"
-                >
-                  신규 제품 등록
-                </button>
+              <div class="-mx-5 border-t border-gray-100 bg-white px-5 pt-4">
+                <p v-if="submitError" class="mb-2 border border-red-200 bg-red-50 px-2 py-1 text-[11px] font-bold text-red-600">{{ submitError }}</p>
+                <p v-if="submitSuccess" class="mb-2 border border-emerald-200 bg-emerald-50 px-2 py-1 text-[11px] font-bold text-emerald-700">{{ submitSuccess }}</p>
+                <div class="flex gap-2">
+                  <button
+                    v-if="isEditMode"
+                    type="button"
+                    class="flex-1 border border-red-300 bg-red-50 py-2.5 text-sm font-black text-red-600 hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-40"
+                    :disabled="isSubmitting"
+                    @click="handleDeleteProduct"
+                  >
+                    품목 삭제
+                  </button>
+                  <button type="button" class="flex-1 border border-gray-300 bg-white py-2.5 text-sm font-black text-gray-700 hover:bg-gray-50" @click="handleCancel">
+                    취소
+                  </button>
+                  <button
+                    type="submit"
+                    class="flex-1 border border-[#004D3C] bg-[#004D3C] py-2.5 text-sm font-black text-white hover:bg-[#003d30] disabled:cursor-not-allowed disabled:opacity-40"
+                    :disabled="(isEditMode ? !canSubmitEdit : !canSubmitCreate) || isSubmitting"
+                  >
+                    {{ isSubmitting ? (isEditMode ? '저장 중...' : '등록 중...') : (isEditMode ? '제품 정보 저장' : '신규 제품 등록') }}
+                  </button>
+                </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
+
         </div>
 
         <aside class="space-y-4 xl:sticky xl:top-16">
@@ -301,7 +477,7 @@ function handleCancel() {
               </div>
               <div class="flex items-center justify-between border border-gray-100 bg-gray-50 px-3 py-2">
                 <span class="font-black text-gray-500">단가</span>
-                <span class="font-black text-gray-800">{{ Number(price) > 0 ? `₩${Number(price).toLocaleString()}` : '-' }}</span>
+                <span class="font-black text-gray-800">{{ Number(price) >= 0 ? `₩${Number(price).toLocaleString()}` : '-' }}</span>
               </div>
               <div class="flex items-center justify-between border border-gray-100 bg-gray-50 px-3 py-2">
                 <span class="font-black text-gray-500">메인 거래처</span>
@@ -315,16 +491,10 @@ function handleCancel() {
                 <span class="font-black text-gray-500">옵션</span>
                 <span class="text-right font-black text-gray-800">{{ variantSummaryText }}</span>
               </div>
-            </div>
-          </section>
-
-          <section class="border border-gray-200 bg-white p-4 shadow-sm">
-            <h3 class="text-xs font-black uppercase tracking-wide text-gray-500">작성 가이드</h3>
-            <div class="mt-3 space-y-2 text-[12px] font-bold text-gray-600">
-              <p>제품명은 거래처/매장 공통으로 식별 가능한 명칭으로 입력하세요.</p>
-              <p>카테고리는 대분류와 소분류를 함께 선택해야 저장할 수 있습니다.</p>
-              <p>단가는 원 단위 숫자만 입력하고, 메인 거래처는 필수입니다.</p>
-              <p>옵션은 최소 1개 색상과 1개 사이즈를 선택하며, 선택한 사이즈는 모든 선택 색상에 공통 적용됩니다.</p>
+              <div class="flex items-center justify-between border border-gray-100 bg-gray-50 px-3 py-2">
+                <span class="font-black text-gray-500">등록일</span>
+                <span class="font-black text-gray-800">{{ regDate }}</span>
+              </div>
             </div>
           </section>
         </aside>

--- a/src/views/hq/HqProductManagementView.vue
+++ b/src/views/hq/HqProductManagementView.vue
@@ -5,6 +5,9 @@ import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
 import { deleteCategory, getCategories, getCategory, updateCategory } from '@/api/category.js'
+import {
+  getProducts,
+} from '@/api/productMaster.js'
 
 const router = useRouter()
 const route = useRoute()
@@ -23,7 +26,6 @@ const activeSideMenu = ref(tabLabelMap[route.query.tab] ?? '카테고리 관리'
 watch(() => route.query.tab, (tab) => {
   activeSideMenu.value = tabLabelMap[tab] ?? '카테고리 관리'
 })
-const selectedProduct = ref(null)
 const selectedCategory = ref(null)
 const categoryEditForm = ref(null)
 const categorySubmitting = ref(false)
@@ -33,23 +35,7 @@ const productSideMenus = [
   { label: '제품 마스터', icon: 'package', id: 'SO-011' },
 ]
 
-const productMasterData = [
-  { id: 'PD-T001', name: '코튼 베이직 반팔 티셔츠', parentCategory: '상의', childCategory: '반팔', price: 12900, leadTime: '3일', vendor: '스타일텍스', status: '활성', regDate: '2024.01.12' },
-  { id: 'PD-T002', name: '슬림핏 긴팔 티셔츠', parentCategory: '상의', childCategory: '긴팔', price: 16900, leadTime: '4일', vendor: '스타일텍스', status: '활성', regDate: '2024.01.26' },
-  { id: 'PD-T003', name: '오버핏 옥스포드 셔츠', parentCategory: '상의', childCategory: '셔츠', price: 35900, leadTime: '5일', vendor: '어반클로스', status: '활성', regDate: '2024.02.14' },
-  { id: 'PD-T004', name: '라운드넥 소프트 니트', parentCategory: '상의', childCategory: '니트', price: 39900, leadTime: '6일', vendor: '니트랩', status: '점검중', regDate: '2024.03.02' },
-  { id: 'PD-T005', name: '헤비웨이트 로고 후드티', parentCategory: '상의', childCategory: '후드티', price: 45900, leadTime: '7일', vendor: '어반클로스', status: '활성', regDate: '2024.03.15' },
-  { id: 'PD-B001', name: '스트레이트 워싱 데님', parentCategory: '바지', childCategory: '청바지', price: 42900, leadTime: '5일', vendor: '데님하우스', status: '활성', regDate: '2024.01.19' },
-  { id: 'PD-B002', name: '라이트 코튼 쇼츠', parentCategory: '바지', childCategory: '반바지', price: 29900, leadTime: '4일', vendor: '데님하우스', status: '활성', regDate: '2024.02.08' },
-  { id: 'PD-B003', name: '와이드 밴딩 팬츠', parentCategory: '바지', childCategory: '긴바지', price: 37900, leadTime: '4일', vendor: '모션웨어', status: '활성', regDate: '2024.02.27' },
-  { id: 'PD-B004', name: '데일리 조거 트레이닝 팬츠', parentCategory: '바지', childCategory: '츄리닝', price: 33900, leadTime: '3일', vendor: '모션웨어', status: '비활성', regDate: '2024.03.11' },
-  { id: 'PD-S001', name: 'A라인 데님 미니스커트', parentCategory: '치마', childCategory: '미니 스커트', price: 31900, leadTime: '5일', vendor: '스커트스튜디오', status: '활성', regDate: '2024.01.30' },
-  { id: 'PD-S002', name: '플리츠 롱스커트', parentCategory: '치마', childCategory: '롱스커트', price: 38900, leadTime: '6일', vendor: '스커트스튜디오', status: '활성', regDate: '2024.03.05' },
-  { id: 'PD-O001', name: '라이트 숏 패딩', parentCategory: '아우터', childCategory: '패딩', price: 79900, leadTime: '8일', vendor: '윈터픽', status: '활성', regDate: '2024.02.21' },
-  { id: 'PD-O002', name: '스웨트 후드 집업', parentCategory: '아우터', childCategory: '후드집업', price: 54900, leadTime: '6일', vendor: '윈터픽', status: '점검중', regDate: '2024.03.09' },
-  { id: 'PD-O003', name: '싱글 브레스트 자켓', parentCategory: '아우터', childCategory: '자켓', price: 72900, leadTime: '9일', vendor: '테일러드원', status: '활성', regDate: '2024.03.18' },
-  { id: 'PD-O004', name: '브이넥 니트 가디건', parentCategory: '아우터', childCategory: '가디건', price: 48900, leadTime: '7일', vendor: '니트랩', status: '활성', regDate: '2024.03.25' },
-]
+const productMasterData = ref([])
 
 const categories = ref([])
 const categoryError = ref('')
@@ -72,7 +58,7 @@ const childCategoryOptions = computed(() => {
 })
 const filteredProductMasterData = computed(() => {
   const keyword = productKeyword.value.trim().toLowerCase()
-  return productMasterData.filter((prod) => {
+  return productMasterData.value.filter((prod) => {
     const matchParent = selectedParentFilter.value === 'all' || prod.parentCategory === selectedParentFilter.value
     const matchChild = selectedChildFilter.value === 'all' || prod.childCategory === selectedChildFilter.value
     const matchKeyword =
@@ -98,12 +84,10 @@ const toggleExpand = (id, event) => {
   expandedCategories.value = next
 }
 
-const closeDetail = () => { selectedProduct.value = null }
 const closeCategoryDetail = () => {
   selectedCategory.value = null
   categoryEditForm.value = null
 }
-const productEditForm = ref(null)
 
 const statusLabelMap = {
   ACTIVE: '사용중',
@@ -220,49 +204,6 @@ async function handleDeleteCategory() {
   }
 }
 
-const syncProductEditForm = (product) => {
-  if (!product) {
-    productEditForm.value = null
-    return
-  }
-  productEditForm.value = {
-    name: product.name,
-    parentCategory: product.parentCategory,
-    childCategory: product.childCategory,
-    price: product.price,
-    vendor: product.vendor,
-    status: product.status,
-    regDate: product.regDate,
-  }
-}
-
-watch(selectedProduct, (product) => {
-  syncProductEditForm(product)
-})
-
-const detailChildCategoryOptions = computed(() => {
-  if (!productEditForm.value?.parentCategory) return []
-  const target = categories.value.find((cat) => cat.name === productEditForm.value.parentCategory)
-  return target ? target.children.map((child) => child.name) : []
-})
-
-function handleDetailParentChange(event) {
-  if (!productEditForm.value) return
-  const nextParent = event.target.value
-  productEditForm.value.parentCategory = nextParent
-  const target = categories.value.find((cat) => cat.name === nextParent)
-  productEditForm.value.childCategory = target?.children?.[0]?.name ?? ''
-}
-
-function saveProductDetail() {
-  if (!selectedProduct.value || !productEditForm.value) return
-  Object.assign(selectedProduct.value, productEditForm.value)
-}
-
-function resetProductDetail() {
-  syncProductEditForm(selectedProduct.value)
-}
-
 const IconBase = (paths) => ({
   props: {
     size: { type: Number, default: 16 },
@@ -314,18 +255,60 @@ const PlusCircleIcon = IconBase([
 ])
 const ChevronDownIcon = IconBase([{ tag: 'path', attrs: { d: 'm6 9 6 6 6-6' } }])
 const ChevronRightIcon = IconBase([{ tag: 'path', attrs: { d: 'm9 18 6-6-6-6' } }])
-const XIcon = IconBase([
-  { tag: 'path', attrs: { d: 'M18 6 6 18' } },
-  { tag: 'path', attrs: { d: 'm6 6 12 12' } },
-])
-
 const iconMap = {
   tags: TagsIcon,
   package: PackageIcon,
 }
 
+const productStatusMap = {
+  ACTIVE: '활성',
+  INACTIVE: '비활성',
+  SUSPENDED: '점검중',
+}
+
+function resolveCategoryNames(categoryCode) {
+  for (const parent of categories.value) {
+    if (parent.id === categoryCode) {
+      return { parentCategory: parent.name, childCategory: '-' }
+    }
+    const child = parent.children.find((c) => c.id === categoryCode)
+    if (child) {
+      return { parentCategory: parent.name, childCategory: child.name }
+    }
+  }
+  return { parentCategory: categoryCode || '-', childCategory: '-' }
+}
+
+async function loadProducts() {
+  try {
+    const list = await getProducts({
+      keyword: productKeyword.value || undefined,
+      categoryCode: selectedParentFilter.value === 'all' ? undefined : selectedParentFilter.value,
+    })
+    productMasterData.value = list.map((p) => ({
+      ...resolveCategoryNames(p.categoryCode),
+      id: p.code,
+      name: p.name,
+      price: p.basePrice,
+      leadTime: `${p.leadTimeDays}일`,
+      vendor: p.mainVendorCode,
+      status: productStatusMap[p.status] ?? p.status,
+      regDate: formatDate(p.updatedAt),
+    }))
+  } catch (e) {
+    categoryError.value = e.message
+  }
+}
+
+watch(productKeyword, () => {
+  if (activeSideMenu.value !== '카테고리 관리') loadProducts()
+})
+watch([selectedParentFilter, selectedChildFilter], () => {
+  if (activeSideMenu.value !== '카테고리 관리') loadProducts()
+})
+
 onMounted(() => {
-  loadCategories()
+  loadCategories().then(loadProducts)
 })
 </script>
 
@@ -578,6 +561,7 @@ onMounted(() => {
                   <th class="w-32 px-3 py-2 text-left font-black">메인 거래처</th>
                   <th class="w-24 px-3 py-2 text-center font-black">상태</th>
                   <th class="w-28 px-3 py-2 text-center font-black">등록일</th>
+                  <th class="w-16 px-3 py-2 text-center font-black">관리</th>
                 </tr>
               </thead>
               <tbody class="divide-y divide-gray-100">
@@ -585,8 +569,7 @@ onMounted(() => {
                   v-for="prod in filteredProductMasterData"
                   :key="prod.id"
                   class="cursor-pointer hover:bg-gray-50"
-                  :class="selectedProduct?.id === prod.id ? 'bg-[#E6F2F0]' : ''"
-                  @click="selectedProduct = prod"
+                  @click="router.push({ name: 'hq-product-sku-detail', params: { productCode: prod.id } })"
                 >
                   <td class="px-3 py-3 text-center font-bold text-gray-400">{{ prod.id }}</td>
                   <td class="px-3 py-3 font-black text-gray-800">{{ prod.name }}</td>
@@ -595,126 +578,21 @@ onMounted(() => {
                   <td class="px-3 py-3 text-gray-600">{{ prod.vendor }}</td>
                   <td class="px-3 py-3 text-center"><span class="bg-emerald-50 px-2 py-1 text-[10px] font-black text-emerald-700">{{ prod.status }}</span></td>
                   <td class="px-3 py-3 text-center font-bold text-gray-400">{{ prod.regDate }}</td>
+                  <td class="px-3 py-3 text-center" @click.stop>
+                    <button
+                      type="button"
+                      class="border border-gray-300 bg-white px-2 py-1 text-[11px] font-bold text-gray-700 hover:bg-gray-50"
+                      @click="router.push({ name: 'hq-product-edit', params: { productCode: prod.id } })"
+                    >
+                      관리
+                    </button>
+                  </td>
                 </tr>
               </tbody>
             </table>
           </div>
         </div>
 
-        <aside v-if="selectedProduct && productEditForm" class="w-full shrink-0 border border-gray-300 bg-white shadow-sm xl:w-80">
-          <div class="flex items-center justify-between bg-[#004D3C] px-4 py-3 text-white">
-            <h3 class="inline-flex items-center gap-2 text-[11px] font-black uppercase"><InfoIcon :size="14" /> 제품 상세</h3>
-            <button type="button" class="p-1 hover:bg-white/10" @click="closeDetail"><XIcon :size="16" /></button>
-          </div>
-          <div class="space-y-6 p-5">
-            <div>
-              <p class="text-[10px] font-bold uppercase text-gray-400">마스터 ID: {{ selectedProduct.id }}</p>
-              <h4 class="mt-2 text-base font-black leading-snug text-gray-900">제품 정보 수정</h4>
-              <div class="mt-3 flex flex-wrap gap-2">
-                <span class="border border-gray-200 bg-gray-100 px-2 py-1 text-[10px] font-bold text-gray-600">{{ productEditForm.parentCategory }} &gt; {{ productEditForm.childCategory }}</span>
-                <span class="border border-emerald-200 bg-emerald-50 px-2 py-1 text-[10px] font-bold text-emerald-700">{{ productEditForm.status }}</span>
-              </div>
-            </div>
-            <div class="space-y-4">
-              <label class="block text-[10px] font-bold uppercase text-gray-400">
-                제품명
-                <input
-                  v-model="productEditForm.name"
-                  type="text"
-                  class="mt-1.5 w-full border border-gray-300 bg-gray-50 px-3 py-2.5 text-xs font-bold text-gray-800 outline-none focus:border-[#004D3C]"
-                />
-              </label>
-              <div class="grid grid-cols-2 gap-3">
-                <label class="block text-[10px] font-bold uppercase text-gray-400">
-                  대분류
-                  <select
-                    :value="productEditForm.parentCategory"
-                    class="mt-1.5 w-full border border-gray-300 bg-gray-50 px-2 py-2.5 text-xs font-bold text-gray-800 outline-none focus:border-[#004D3C]"
-                    @change="handleDetailParentChange"
-                  >
-                    <option v-for="parent in parentCategoryOptions" :key="parent" :value="parent">{{ parent }}</option>
-                  </select>
-                </label>
-                <label class="block text-[10px] font-bold uppercase text-gray-400">
-                  소분류
-                  <select
-                    v-model="productEditForm.childCategory"
-                    class="mt-1.5 w-full border border-gray-300 bg-gray-50 px-2 py-2.5 text-xs font-bold text-gray-800 outline-none focus:border-[#004D3C]"
-                  >
-                    <option v-for="child in detailChildCategoryOptions" :key="child" :value="child">{{ child }}</option>
-                  </select>
-                </label>
-              </div>
-              <div class="grid grid-cols-2 gap-3">
-                <label class="block text-[10px] font-bold uppercase text-gray-400">
-                  단가
-                  <input
-                    v-model.number="productEditForm.price"
-                    type="number"
-                    min="0"
-                    class="mt-1.5 w-full border border-gray-300 bg-gray-50 px-3 py-2.5 text-xs font-bold text-gray-800 outline-none focus:border-[#004D3C]"
-                  />
-                </label>
-                <label class="block text-[10px] font-bold uppercase text-gray-400">
-                  상태
-                  <select
-                    v-model="productEditForm.status"
-                    class="mt-1.5 w-full border border-gray-300 bg-gray-50 px-2 py-2.5 text-xs font-bold text-gray-800 outline-none focus:border-[#004D3C]"
-                  >
-                    <option value="활성">활성</option>
-                    <option value="점검중">점검중</option>
-                    <option value="비활성">비활성</option>
-                  </select>
-                </label>
-              </div>
-              <div class="grid grid-cols-2 gap-3">
-                <label class="block text-[10px] font-bold uppercase text-gray-400">
-                  메인 거래처
-                  <input
-                    v-model="productEditForm.vendor"
-                    type="text"
-                    class="mt-1.5 w-full border border-gray-300 bg-gray-50 px-3 py-2.5 text-xs font-bold text-gray-800 outline-none focus:border-[#004D3C]"
-                  />
-                </label>
-                <label class="block text-[10px] font-bold uppercase text-gray-400">
-                  등록일
-                  <input
-                    v-model="productEditForm.regDate"
-                    type="text"
-                    class="mt-1.5 w-full border border-gray-300 bg-gray-50 px-3 py-2.5 text-xs font-bold text-gray-800 outline-none focus:border-[#004D3C]"
-                  />
-                </label>
-              </div>
-            </div>
-            <div class="border border-gray-200 bg-gray-50 p-4">
-              <p class="text-[10px] font-bold uppercase text-gray-400">메인 계약처</p>
-              <div class="mt-3 flex items-center justify-between gap-2 text-xs font-bold text-gray-700">
-                <span>{{ productEditForm.vendor }}</span>
-                <span class="bg-[#E6F2F0] px-2 py-1 text-[#004D3C]">메인 계약처</span>
-              </div>
-              <div class="mt-3 flex justify-between text-xs">
-                <span class="text-gray-500">계약가</span>
-                <strong class="text-[#004D3C]">₩{{ Math.round(productEditForm.price * 0.95).toLocaleString() }}</strong>
-              </div>
-            </div>
-            <div class="flex gap-2 pt-2">
-              <button
-                type="button"
-                class="flex-1 border border-[#004D3C] bg-[#004D3C] py-2 text-xs font-black text-white hover:bg-[#003d30]"
-                @click="saveProductDetail"
-              >
-                저장
-              </button>
-              <button
-                type="button"
-                class="flex-1 border border-gray-300 bg-white py-2 text-xs font-black text-gray-700 hover:bg-gray-50"
-                @click="resetProductDetail"
-              >
-                되돌리기
-              </button>
-            </div>
-          </div>
-        </aside>
       </section>
     </div>
   </AppLayout>

--- a/src/views/hq/HqProductSkuDetailView.vue
+++ b/src/views/hq/HqProductSkuDetailView.vue
@@ -1,0 +1,226 @@
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import AppLayout from '@/components/common/AppLayout.vue'
+import { roleMenus } from '@/config/roleMenus.js'
+import { useAuthStore } from '@/stores/auth.js'
+import { deleteProductSku, getProductDetail, getProductSkus, updateProductSku } from '@/api/productMaster.js'
+
+const route = useRoute()
+const router = useRouter()
+const auth = useAuthStore()
+
+const hqMenus = roleMenus.hq
+const productMenus = roleMenus.hq.find((menu) => menu.label === '상품 관리')?.children ?? []
+
+const activeTopMenu = computed(() => '상품 관리')
+const activeSideMenu = ref('제품 마스터')
+
+const productCode = computed(() => String(route.params.productCode ?? ''))
+const product = ref(null)
+const skus = ref([])
+const errorMessage = ref('')
+const successMessage = ref('')
+const editSkuCode = ref('')
+const editForm = ref({ color: '', size: '', unitPrice: 0, status: 'ACTIVE' })
+
+const statusLabel = {
+  ACTIVE: '활성',
+  SUSPENDED: '점검중',
+  INACTIVE: '비활성',
+}
+
+function splitColorSize(value) {
+  const [color, size] = String(value ?? '').split('|')
+  return { color: color || '-', size: size || '-' }
+}
+
+function openEdit(sku) {
+  const parsed = splitColorSize(sku.optionValue)
+  editSkuCode.value = sku.skuCode
+  editForm.value = {
+    color: parsed.color,
+    size: parsed.size,
+    unitPrice: sku.unitPrice,
+    status: sku.status,
+  }
+}
+
+function cancelEdit() {
+  editSkuCode.value = ''
+}
+
+async function loadSkus() {
+  skus.value = await getProductSkus(productCode.value)
+}
+
+async function saveEdit(skuCode) {
+  try {
+    errorMessage.value = ''
+    successMessage.value = ''
+    await updateProductSku(skuCode, {
+      optionName: 'COLOR_SIZE',
+      optionValue: `${editForm.value.color}|${editForm.value.size}`,
+      unitPrice: Number(editForm.value.unitPrice),
+      status: editForm.value.status,
+    })
+    await loadSkus()
+    cancelEdit()
+    successMessage.value = 'SKU가 수정되었습니다.'
+  } catch (e) {
+    errorMessage.value = e.message
+  }
+}
+
+async function removeSku(skuCode) {
+  const ok = confirm('해당 SKU를 삭제할까요?')
+  if (!ok) return
+  try {
+    errorMessage.value = ''
+    successMessage.value = ''
+    await deleteProductSku(skuCode)
+    await loadSkus()
+    successMessage.value = 'SKU가 삭제되었습니다.'
+  } catch (e) {
+    errorMessage.value = e.message
+  }
+}
+
+function handleLogout() {
+  auth.logout()
+  router.push('/login')
+}
+
+function goBack() {
+  router.push('/hq/products?tab=products')
+}
+
+async function init() {
+  try {
+    errorMessage.value = ''
+    successMessage.value = ''
+    const [productRes, ] = await Promise.all([
+      getProductDetail(productCode.value),
+    ])
+    product.value = productRes
+    await loadSkus()
+  } catch (e) {
+    errorMessage.value = e.message
+  }
+}
+
+onMounted(() => {
+  init()
+})
+</script>
+
+<template>
+  <AppLayout
+    :active-top-menu="activeTopMenu"
+    :top-menus="hqMenus"
+    :side-menus="productMenus"
+    v-model:active-side-menu="activeSideMenu"
+    show-system-card
+    @logout="handleLogout"
+  >
+    <div class="flex flex-col gap-4">
+      <section class="border border-gray-200 bg-white p-4 shadow-sm">
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p class="text-[10px] font-black uppercase tracking-[0.16em] text-gray-400">Product SKU</p>
+            <h1 class="mt-1 text-lg font-black text-gray-900">제품 SKU 상세</h1>
+            <p class="mt-2 text-sm font-bold text-gray-700">{{ product?.name || '-' }}</p>
+            <p class="mt-1 text-xs font-bold text-gray-500">{{ product?.code || productCode }} · {{ product?.categoryCode || '-' }}</p>
+            <p class="mt-1 text-xs font-bold text-gray-500">기본단가: {{ product?.basePrice?.toLocaleString?.() || '-' }} / 상태: {{ statusLabel[product?.status] || product?.status || '-' }}</p>
+          </div>
+          <div class="flex gap-2">
+            <button type="button" class="h-9 border border-gray-300 bg-white px-4 text-xs font-black text-gray-700 hover:bg-gray-50" @click="goBack">목록으로</button>
+            <button
+              type="button"
+              class="h-9 border border-gray-300 bg-white px-4 text-xs font-black text-gray-700 hover:bg-gray-50"
+              @click="router.push({ name: 'hq-product-edit', params: { productCode } })"
+            >
+              수정
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <p v-if="errorMessage" class="border border-red-200 bg-red-50 px-3 py-2 text-xs font-bold text-red-600">{{ errorMessage }}</p>
+      <p v-if="successMessage" class="border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs font-bold text-emerald-700">{{ successMessage }}</p>
+
+      <section class="overflow-hidden border border-gray-200 bg-white shadow-sm">
+        <div class="overflow-x-auto">
+          <table class="w-full min-w-[1080px] border-collapse text-xs">
+            <thead class="bg-gray-50 text-[10px] uppercase tracking-[0.12em] text-gray-500">
+              <tr>
+                <th class="w-[220px] px-4 py-3 text-left font-black">SKU 코드</th>
+                <th class="w-[120px] px-4 py-3 text-left font-black">색상</th>
+                <th class="w-[120px] px-4 py-3 text-left font-black">사이즈</th>
+                <th class="w-[140px] px-4 py-3 text-right font-black">단가</th>
+                <th class="w-[140px] px-4 py-3 text-left font-black">상태</th>
+                <th class="w-[140px] px-4 py-3 text-center font-black">최종 수정일</th>
+                <th class="w-[180px] px-4 py-3 text-center font-black">액션</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100">
+              <tr v-for="sku in skus" :key="sku.skuCode">
+                <td class="px-4 py-3 align-middle font-mono font-bold text-gray-600">{{ sku.skuCode }}</td>
+                <td class="px-4 py-3 align-middle font-bold text-gray-800">
+                  <input
+                    v-if="editSkuCode === sku.skuCode"
+                    v-model="editForm.color"
+                    class="w-full max-w-[96px] border border-gray-300 px-2 py-1.5 text-xs"
+                  />
+                  <span v-else>{{ splitColorSize(sku.optionValue).color }}</span>
+                </td>
+                <td class="px-4 py-3 align-middle font-black text-gray-900">
+                  <input
+                    v-if="editSkuCode === sku.skuCode"
+                    v-model="editForm.size"
+                    class="w-full max-w-[88px] border border-gray-300 px-2 py-1.5 text-xs"
+                  />
+                  <span v-else>{{ splitColorSize(sku.optionValue).size }}</span>
+                </td>
+                <td class="px-4 py-3 align-middle text-right font-black text-gray-900">
+                  <input
+                    v-if="editSkuCode === sku.skuCode"
+                    v-model.number="editForm.unitPrice"
+                    type="number"
+                    min="0"
+                    class="w-full max-w-[120px] border border-gray-300 px-2 py-1.5 text-right text-xs"
+                  />
+                  <span v-else>{{ Number(sku.unitPrice).toLocaleString() }}</span>
+                </td>
+                <td class="px-4 py-3 align-middle font-bold text-gray-700">
+                  <select v-if="editSkuCode === sku.skuCode" v-model="editForm.status" class="w-full max-w-[110px] border border-gray-300 px-2 py-1.5 text-xs">
+                    <option value="ACTIVE">활성</option>
+                    <option value="SUSPENDED">점검중</option>
+                    <option value="INACTIVE">비활성</option>
+                  </select>
+                  <span v-else>{{ statusLabel[sku.status] || sku.status }}</span>
+                </td>
+                <td class="px-4 py-3 text-center align-middle font-bold text-gray-500">{{ sku.updatedAt ? new Date(sku.updatedAt).toISOString().slice(0, 10) : '-' }}</td>
+                <td class="px-4 py-3 align-middle">
+                  <div class="flex items-center justify-center gap-1.5">
+                    <template v-if="editSkuCode === sku.skuCode">
+                      <button type="button" class="min-w-[44px] border border-[#004D3C] bg-[#004D3C] px-2 py-1.5 text-[11px] font-bold text-white" @click="saveEdit(sku.skuCode)">저장</button>
+                      <button type="button" class="min-w-[44px] border border-gray-300 px-2 py-1.5 text-[11px] font-bold text-gray-700" @click="cancelEdit">취소</button>
+                    </template>
+                    <template v-else>
+                      <button type="button" class="min-w-[44px] border border-gray-300 px-2 py-1.5 text-[11px] font-bold text-gray-700" @click="openEdit(sku)">수정</button>
+                      <button type="button" class="min-w-[44px] border border-red-300 bg-red-50 px-2 py-1.5 text-[11px] font-bold text-red-600" @click="removeSku(sku.skuCode)">삭제</button>
+                    </template>
+                  </div>
+                </td>
+              </tr>
+              <tr v-if="skus.length === 0">
+                <td colspan="7" class="px-3 py-6 text-center text-xs font-bold text-gray-400">등록된 SKU가 없습니다.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  </AppLayout>
+</template>

--- a/src/views/hq/dashboard/OperationStatusView.vue
+++ b/src/views/hq/dashboard/OperationStatusView.vue
@@ -2,69 +2,200 @@
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import {
-  AlertCircle,
-  BarChart3,
+  AlertTriangle,
+  CheckCircle2,
+  ChevronLeft,
+  ChevronRight,
   Clock,
-  Grid2X2,
+  ShoppingCart,
+  Warehouse,
 } from 'lucide-vue-next'
 import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
-import { dashboardSideMenus } from '@/views/hq/dashboard/dashboardMenus.js'
 
 const router = useRouter()
 const auth = useAuthStore()
 const hqMenus = roleMenus.hq
+const sideMenus = roleMenus.hq.find((menu) => menu.label === '대시보드')?.children ?? []
 
+const activeTopMenu = computed(() => '대시보드')
 const activeSideMenu = ref('운영 현황')
-
-const sideMenus = dashboardSideMenus
-
-const kpiStats = [
-  { label: '전사 총 재고 수량', value: '124,582', unit: 'EA', change: '+2.4%', status: 'up' },
-  { label: '재고 가치 총액', value: '₩4,821.5M', unit: '', change: '+0.8%', status: 'up' },
-  { label: '안전 재고 부족 매장', value: '08', unit: '곳', change: '+2', status: 'down' },
-  { label: '금일 입고 진행률', value: '82', unit: '%', change: '12/15 건', status: 'neutral' },
-  { label: '금일 출고 진행률', value: '45', unit: '%', change: '18/40 건', status: 'neutral' },
-  { label: '품절 임박 SKU', value: '14', unit: 'SKU', change: '-3', status: 'up' },
-]
-
-const chartHeights = [60, 45, 80, 95, 70, 85, 90]
-
-const alerts = [
-  { type: '재고', msg: '성수점: 아메리카노 원두 품절 임박', time: '10분 전' },
-  { type: '발주', msg: '인천센터: (주)하림 입고 지연 발생', time: '25분 전' },
-  { type: '정산', msg: '판교점: POS 재고 데이터 불일치', time: '1시간 전' },
-]
-
-const logisticsData = [
-  { id: '20240416-001', center: '인천 제1물류센터', item: 'A사 프리미엄 원두 (500g)', qty: 500, status: '승인완료', time: '16:45:10' },
-  { id: '20240416-002', center: '강남 서초점', item: '유기농 우유 1L (12입)', qty: -24, status: '출고대기', time: '16:30:22' },
-  { id: '20240416-003', center: '성수 직영점', item: '친환경 종이컵 (1000ea)', qty: 10, status: '검수중', time: '16:15:45' },
-  { id: '20240416-004', center: '판교 테크노점', item: '무라벨 생수 500ml', qty: 120, status: '승인완료', time: '15:50:12' },
-  { id: '20240416-005', center: '부산 중앙창고', item: '질소 포장 디저트 박스', qty: -1200, status: '이동중', time: '15:20:30' },
-]
 
 const dateLabel = computed(() =>
   new Intl.DateTimeFormat('ko-KR', {
-    year: 'numeric', month: '2-digit', day: '2-digit',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
   }).format(new Date()),
 )
 
-const activeTopMenu = computed(() => '대시보드')
+const kpiStats = [
+  { label: '가용 재고율', value: '84.7', unit: '%', caption: '비가용 제외', tone: 'blue' },
+  { label: '부족 재고', value: '18', unit: 'SKU', caption: '안전재고 이하', tone: 'red' },
+  { label: '순환 재고 후보', value: '126', unit: '품목', caption: '전환 검토 필요', tone: 'lime' },
+  { label: '발주 진행', value: '14', unit: '건', caption: '본사 거래처 발주', tone: 'gray' },
+]
+
+const inventoryRisks = [
+  {
+    item: '코튼 베이직 반팔 티셔츠',
+    category: '상의 > 반팔',
+    location: '이천 풀필먼트',
+    status: '부족',
+    stock: 74,
+    safety: 90,
+  },
+  {
+    item: '코튼 베이직 반팔 티셔츠',
+    category: '상의 > 반팔',
+    location: '부산 물류창고',
+    status: '품절',
+    stock: 0,
+    safety: 70,
+  },
+  {
+    item: '플리츠 롱스커트',
+    category: '치마 > 롱스커트',
+    location: '인천 제1창고',
+    status: '부족',
+    stock: 18,
+    safety: 55,
+  },
+  {
+    item: '라이트 숏 패딩',
+    category: '아우터 > 패딩',
+    location: '대전 허브창고',
+    status: '품절',
+    stock: 0,
+    safety: 30,
+  },
+  {
+    item: '오버핏 옥스포드 셔츠',
+    category: '상의 > 셔츠',
+    location: '인천 제1창고',
+    status: '안전',
+    stock: 490,
+    safety: 130,
+  },
+]
+
+const warehouseImbalances = [
+  {
+    item: '코튼 베이직 반팔 티셔츠',
+    category: '상의 > 반팔',
+    warehouses: [
+      { warehouse: '인천 제1창고', stock: 398, safety: 120, status: '안전' },
+      { warehouse: '이천 풀필먼트', stock: 74, safety: 90, status: '부족' },
+      { warehouse: '부산 물류창고', stock: 0, safety: 70, status: '품절' },
+      { warehouse: '대전 허브창고', stock: 132, safety: 80, status: '안전' },
+    ],
+  },
+  {
+    item: '플리츠 롱스커트',
+    category: '치마 > 롱스커트',
+    warehouses: [
+      { warehouse: '인천 제1창고', stock: 18, safety: 55, status: '부족' },
+      { warehouse: '이천 풀필먼트', stock: 0, safety: 45, status: '품절' },
+      { warehouse: '부산 물류창고', stock: 58, safety: 50, status: '안전' },
+      { warehouse: '대전 허브창고', stock: 32, safety: 50, status: '부족' },
+    ],
+  },
+  {
+    item: '라이트 숏 패딩',
+    category: '아우터 > 패딩',
+    warehouses: [
+      { warehouse: '인천 제1창고', stock: 116, safety: 50, status: '안전' },
+      { warehouse: '이천 풀필먼트', stock: 92, safety: 45, status: '안전' },
+      { warehouse: '부산 물류창고', stock: 14, safety: 35, status: '부족' },
+      { warehouse: '대전 허브창고', stock: 0, safety: 30, status: '품절' },
+    ],
+  },
+  {
+    item: '라이트 코튼 쇼츠',
+    category: '바지 > 반바지',
+    warehouses: [
+      { warehouse: '인천 제1창고', stock: 98, safety: 80, status: '안전' },
+      { warehouse: '이천 풀필먼트', stock: 39, safety: 65, status: '부족' },
+      { warehouse: '부산 물류창고', stock: 296, safety: 90, status: '안전' },
+      { warehouse: '대전 허브창고', stock: 64, safety: 60, status: '안전' },
+    ],
+  },
+]
+
+const currentImbalanceIndex = ref(0)
+
+const currentWarehouseImbalance = computed(() => warehouseImbalances[currentImbalanceIndex.value])
+
+const imbalancePositionLabel = computed(
+  () => `${currentImbalanceIndex.value + 1} / ${warehouseImbalances.length}`,
+)
+
+const orderStatuses = [
+  { label: '발주 요청', value: 36, color: 'bg-[#004D3C]' },
+  { label: '창고 배정', value: 28, color: 'bg-[#7fb3a8]' },
+  { label: '출고 준비', value: 18, color: 'bg-[#D6EAEA]' },
+  { label: '배송 중', value: 12, color: 'bg-sky-200' },
+]
+
+const purchaseStatuses = [
+  { label: '발주 요청', value: 14, color: 'bg-[#004D3C]' },
+  { label: '거래처 확인', value: 9, color: 'bg-[#7fb3a8]' },
+  { label: '입고 예정', value: 5, color: 'bg-[#D6EAEA]' },
+]
+
+const alerts = [
+  {
+    type: '매장 발주량 이상 감지',
+    message: '성수 쇼룸 반팔 티셔츠 발주량 평균 대비 3배 초과',
+    time: '8분 전',
+  },
+  {
+    type: '창고 발주량 이상 알림',
+    message: '이천 풀필먼트 플리츠 롱스커트 대량 발주 이상 감지',
+    time: '21분 전',
+  },
+  {
+    type: '매장 재고 부족 알림',
+    message: '홍대 플래그십 후드티 안전재고 미달 보충 필요',
+    time: '42분 전',
+  },
+  {
+    type: '창고 재고 부족 알림',
+    message: '부산 물류창고 라이트 숏 패딩 재고 부족',
+    time: '1시간 전',
+  },
+]
 
 function handleLogout() {
   auth.logout()
   router.push('/login')
 }
 
-function goToAlertCenter() {
-  router.push('/hq/dashboard/alerts')
+const goTo = (path) => router.push(path)
+
+const moveImbalance = (direction) => {
+  currentImbalanceIndex.value =
+    (currentImbalanceIndex.value + direction + warehouseImbalances.length) %
+    warehouseImbalances.length
 }
 
-function goToTransactions() {
-  router.push('/hq/dashboard/transactions')
-}
+const statusBadgeClass = (status) =>
+  ({
+    안전: 'bg-[#EBF5F5] text-[#004D3C]',
+    부족: 'bg-amber-50 text-amber-700',
+    품절: 'bg-red-50 text-red-700',
+  })[status] ?? 'bg-gray-50 text-gray-500'
+
+const alertTypeBadgeClass = (type) =>
+  ({
+    '매장 발주량 이상 감지': 'bg-amber-50 text-amber-700',
+    '창고 발주량 이상 알림': 'bg-orange-50 text-orange-700',
+    '매장 재고 부족 알림': 'bg-red-50 text-red-700',
+    '창고 재고 부족 알림': 'bg-rose-50 text-rose-700',
+  })[type] ?? 'bg-gray-50 text-gray-500'
 </script>
 
 <template>
@@ -76,143 +207,280 @@ function goToTransactions() {
     show-system-card
     @logout="handleLogout"
   >
-    <div class="flex flex-col gap-3">
-      <section class="flex flex-wrap items-center justify-between gap-3 border border-gray-300 bg-white px-3 py-2.5 shadow-sm">
-        <div class="flex items-center gap-3">
-          <h2 class="inline-flex items-center gap-2 text-[15px] font-semibold text-gray-900">
-            <Grid2X2 :size="18" stroke-width="2" />
-            {{ activeSideMenu }}
-          </h2>
-          <div class="flex gap-2">
-            <span class="border border-gray-200 bg-gray-50 px-2 py-1 text-[11px] font-medium text-gray-500">기준: {{ dateLabel }}</span>
-            <span class="inline-flex items-center gap-1 border border-emerald-200 bg-emerald-50 px-2 py-1 text-[11px] font-medium text-emerald-700">
-              <Clock :size="12" /> 실시간
+    <div class="flex flex-col gap-4">
+      <section class="border border-gray-200 bg-white p-4 shadow-sm">
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p class="text-[10px] font-black uppercase tracking-[0.18em] text-gray-400">
+              HQ Operation Dashboard
+            </p>
+            <h1 class="mt-1 text-xl font-black text-gray-950">중앙관리자 운영 현황</h1>
+            <p class="mt-1 text-xs font-bold text-gray-500">
+              전사 재고, 주문/발주, 알림을 한 화면에서 확인합니다.
+            </p>
+          </div>
+          <div class="flex items-center gap-2">
+            <span
+              class="inline-flex h-8 items-center gap-1 border border-[#D6EAEA] bg-[#EBF5F5] px-3 text-[11px] font-black text-[#004D3C]"
+            >
+              <Clock :size="13" />
+              {{ dateLabel }}
+            </span>
+            <span
+              class="inline-flex h-8 items-center gap-1 border border-emerald-200 bg-emerald-50 px-3 text-[11px] font-black text-emerald-700"
+            >
+              <CheckCircle2 :size="13" />
+              실시간 모니터링
             </span>
           </div>
         </div>
       </section>
 
-      <section class="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-6">
+      <section class="grid grid-cols-2 gap-3 lg:grid-cols-4">
         <article
           v-for="stat in kpiStats"
           :key="stat.label"
-          class="flex h-[80px] flex-col justify-between border border-gray-300 bg-white px-3 py-3 shadow-sm"
+          class="border border-gray-200 bg-white p-3 shadow-sm"
         >
-          <p class="text-[11px] font-medium leading-tight text-gray-500">{{ stat.label }}</p>
-          <div class="flex items-end justify-between gap-1">
-            <div class="min-w-0 leading-none">
-              <span class="text-[20px] font-bold tracking-tight text-gray-950">{{ stat.value }}</span>
-              <span v-if="stat.unit" class="ml-0.5 text-[11px] text-gray-400">{{ stat.unit }}</span>
+          <p class="text-[11px] font-bold text-gray-500">{{ stat.label }}</p>
+          <div class="mt-3 flex items-end justify-between gap-2">
+            <div class="min-w-0">
+              <span class="text-2xl font-black text-gray-950">{{ stat.value }}</span>
+              <span class="ml-1 text-xs font-black text-gray-400">{{ stat.unit }}</span>
             </div>
             <span
-              class="shrink-0 text-[11px] font-bold"
+              class="h-2.5 w-2.5 shrink-0"
               :class="{
-                'text-emerald-600': stat.status === 'up',
-                'text-red-600': stat.status === 'down',
-                'text-gray-400': stat.status === 'neutral',
+                'bg-[#004D3C]': stat.tone === 'green',
+                'bg-sky-400': stat.tone === 'blue',
+                'bg-red-400': stat.tone === 'red',
+                'bg-orange-300': stat.tone === 'orange',
+                'bg-lime-300': stat.tone === 'lime',
+                'bg-gray-300': stat.tone === 'gray',
               }"
-            >{{ stat.change }}</span>
+            />
+          </div>
+          <p class="mt-2 text-[11px] font-bold text-gray-400">{{ stat.caption }}</p>
+        </article>
+      </section>
+
+      <section class="grid gap-4 xl:grid-cols-[minmax(0,1.35fr)_minmax(360px,0.9fr)]">
+        <article class="border border-gray-200 bg-white shadow-sm">
+          <div class="flex items-center justify-between border-b border-gray-100 px-4 py-3">
+            <h2 class="inline-flex items-center gap-2 text-sm font-black text-gray-900">
+              <AlertTriangle :size="16" class="text-red-500" />
+              전사 재고 위험
+            </h2>
+            <button
+              type="button"
+              class="text-xs font-black text-[#004D3C] hover:underline"
+              @click="goTo('/hq/inventory/company-wide')"
+            >
+              전사 재고 조회
+            </button>
+          </div>
+          <div class="overflow-x-auto">
+            <table class="w-full min-w-[680px] text-left text-xs">
+              <thead class="bg-gray-50 text-[10px] uppercase tracking-[0.12em] text-gray-500">
+                <tr>
+                  <th class="px-4 py-3 font-black">품목</th>
+                  <th class="px-4 py-3 font-black">카테고리</th>
+                  <th class="px-4 py-3 font-black">위치</th>
+                  <th class="px-4 py-3 text-right font-black">현재/안전</th>
+                  <th class="px-4 py-3 font-black">상태</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-100">
+                <tr
+                  v-for="item in inventoryRisks"
+                  :key="`${item.item}-${item.location}`"
+                  class="hover:bg-[#EBF5F5]/60"
+                >
+                  <td class="px-4 py-3 font-black text-gray-900">{{ item.item }}</td>
+                  <td class="px-4 py-3 font-bold text-gray-500">{{ item.category }}</td>
+                  <td class="px-4 py-3 font-bold text-gray-700">{{ item.location }}</td>
+                  <td class="px-4 py-3 text-right font-black text-gray-900">
+                    {{ item.stock }} / {{ item.safety }}
+                  </td>
+                  <td class="px-4 py-3">
+                    <span
+                      class="px-2 py-1 text-[11px] font-black"
+                      :class="statusBadgeClass(item.status)"
+                      >{{ item.status }}</span
+                    >
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </article>
+
+        <article class="border border-gray-200 bg-white shadow-sm">
+          <div
+            class="flex flex-wrap items-center justify-between gap-2 border-b border-gray-100 px-4 py-3"
+          >
+            <div class="flex min-w-0 items-center gap-2">
+              <h2 class="inline-flex min-w-0 items-center gap-2 text-sm font-black text-gray-900">
+                <Warehouse :size="16" class="shrink-0" />
+                <span class="truncate">창고별 재고 불균형</span>
+              </h2>
+              <span class="shrink-0 text-[11px] font-black text-gray-400">{{
+                imbalancePositionLabel
+              }}</span>
+            </div>
+            <div class="flex items-center gap-1.5">
+              <button
+                type="button"
+                class="inline-flex h-7 w-7 items-center justify-center border border-gray-200 text-gray-500 transition hover:border-[#004D3C] hover:text-[#004D3C]"
+                aria-label="이전 불균형 품목"
+                @click="moveImbalance(-1)"
+              >
+                <ChevronLeft :size="14" />
+              </button>
+              <button
+                type="button"
+                class="inline-flex h-7 w-7 items-center justify-center border border-gray-200 text-gray-500 transition hover:border-[#004D3C] hover:text-[#004D3C]"
+                aria-label="다음 불균형 품목"
+                @click="moveImbalance(1)"
+              >
+                <ChevronRight :size="14" />
+              </button>
+              <button
+                type="button"
+                class="ml-1 text-xs font-black text-[#004D3C] hover:underline"
+                @click="goTo('/hq/inventory/warehouse-comparison')"
+              >
+                창고 비교
+              </button>
+            </div>
+          </div>
+          <div class="px-4 py-3">
+            <div class="flex items-start justify-between gap-3">
+              <div class="min-w-0">
+                <p class="truncate font-black text-gray-900">
+                  {{ currentWarehouseImbalance.item }}
+                </p>
+                <p class="mt-1 text-[11px] font-bold text-gray-400">
+                  {{ currentWarehouseImbalance.category }}
+                </p>
+              </div>
+            </div>
+            <div class="h-4" aria-hidden="true" />
+
+            <div class="grid gap-2 sm:grid-cols-2">
+              <div
+                v-for="warehouse in currentWarehouseImbalance.warehouses"
+                :key="warehouse.warehouse"
+                class="border border-gray-100 bg-gray-50 px-3 py-2"
+              >
+                <div class="flex items-center justify-between gap-2">
+                  <p class="truncate text-[11px] font-black text-gray-900">
+                    {{ warehouse.warehouse }}
+                  </p>
+                  <span
+                    class="shrink-0 px-2 py-1 text-[10px] font-black"
+                    :class="statusBadgeClass(warehouse.status)"
+                  >
+                    {{ warehouse.status }}
+                  </span>
+                </div>
+                <div class="mt-2 flex items-end justify-between gap-2">
+                  <span class="text-lg font-black text-gray-950">{{ warehouse.stock }}</span>
+                  <span class="text-[11px] font-bold text-gray-400"
+                    >/ {{ warehouse.safety }} EA</span
+                  >
+                </div>
+              </div>
+            </div>
           </div>
         </article>
       </section>
 
-      <section class="grid gap-3 xl:grid-cols-[minmax(0,3fr)_minmax(300px,1fr)]">
-        <article class="border border-gray-300 bg-white shadow-sm">
-          <div class="flex items-center justify-between border-b border-gray-200 px-3 py-2.5">
-            <h3 class="flex items-center gap-2 text-sm font-medium text-gray-800">
-              <BarChart3 :size="16" /> 전사 입출고 트렌드 분석
-            </h3>
-            <div class="flex gap-3 text-[10px] font-medium text-gray-400">
-              <span class="flex items-center gap-1"><i class="h-2 w-2 bg-[#1f4b3a]" />출고</span>
-              <span class="flex items-center gap-1"><i class="h-2 w-2 bg-gray-200" />입고</span>
+      <section class="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+        <article class="border border-gray-200 bg-white p-4 shadow-sm">
+          <div class="flex items-center justify-between gap-3">
+            <h2 class="inline-flex items-center gap-2 text-sm font-black text-gray-900">
+              <ShoppingCart :size="16" />
+              매장 발주·거래처 발주 현황
+            </h2>
+            <div class="flex gap-2">
+              <button
+                type="button"
+                class="text-xs font-black text-[#004D3C] hover:underline"
+                @click="goTo('/hq/orders')"
+              >
+                매장 주문
+              </button>
+              <button
+                type="button"
+                class="text-xs font-black text-[#004D3C] hover:underline"
+                @click="goTo('/hq/purchase-orders')"
+              >
+                거래처 발주
+              </button>
             </div>
           </div>
-          <div class="px-3 py-3">
-            <div class="flex gap-2">
-              <div class="flex h-[220px] w-8 shrink-0 flex-col justify-between pb-4 pt-2 text-right text-[10px] font-medium text-gray-400">
-                <span>100</span>
-                <span>75</span>
-                <span>50</span>
-                <span>25</span>
-                <span>0</span>
-              </div>
-              <div
-                class="flex flex-1 items-end border-b border-l border-gray-200"
-                style="height: 220px; padding: 10px 6px 16px 4px;"
-              >
-                <div
-                  v-for="(height, index) in chartHeights"
-                  :key="index"
-                  class="flex h-full flex-1 flex-col items-center justify-end gap-2"
-                >
-                  <div class="flex h-full w-full items-end justify-center gap-1">
-                    <div class="w-4.5 rounded-sm bg-[#1f4b3a]" :style="{ height: `${height}%` }" />
-                    <div class="w-4.5 rounded-sm bg-gray-200" :style="{ height: `${height * 0.7}%` }" />
+          <div class="mt-4 grid gap-4 md:grid-cols-2">
+            <div>
+              <p class="mb-3 text-[11px] font-black text-gray-500">매장 발주</p>
+              <div class="space-y-3">
+                <div v-for="status in orderStatuses" :key="status.label">
+                  <div class="flex justify-between text-xs font-black text-gray-600">
+                    <span>{{ status.label }}</span>
+                    <span>{{ status.value }}건</span>
                   </div>
-                  <span class="text-[11px] font-medium text-gray-400">{{ 10 + index }}일</span>
+                  <div class="mt-1 h-7 bg-gray-100">
+                    <div
+                      class="h-full"
+                      :class="status.color"
+                      :style="{ width: `${Math.min(status.value, 80)}%` }"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div>
+              <p class="mb-3 text-[11px] font-black text-gray-500">거래처 발주</p>
+              <div class="space-y-3">
+                <div v-for="status in purchaseStatuses" :key="status.label">
+                  <div class="flex justify-between text-xs font-black text-gray-600">
+                    <span>{{ status.label }}</span>
+                    <span>{{ status.value }}건</span>
+                  </div>
+                  <div class="mt-1 h-7 bg-gray-100">
+                    <div
+                      class="h-full"
+                      :class="status.color"
+                      :style="{ width: `${Math.min(status.value, 80)}%` }"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </article>
 
-        <article class="flex flex-col border border-gray-300 bg-white shadow-sm">
-          <div class="border-b border-gray-200 px-3 py-2.5">
-            <h3 class="flex items-center gap-2 text-sm font-medium text-gray-800">
-              <AlertCircle :size="16" class="text-red-600" /> 긴급 장애/경보
-            </h3>
+        <article class="border border-gray-200 bg-white shadow-sm">
+          <div class="border-b border-gray-100 px-4 py-3">
+            <h2 class="inline-flex items-center gap-2 text-sm font-black text-gray-900">
+              <AlertTriangle :size="16" />
+              알림 센터 요약
+            </h2>
           </div>
-          <div class="flex-1 divide-y divide-gray-100">
-            <button
-              v-for="alert in alerts"
-              :key="alert.msg"
-              type="button"
-              class="w-full px-3 py-3 text-left transition-colors hover:bg-gray-50"
-            >
-              <span class="block text-[13px] font-semibold text-gray-800">{{ alert.msg }}</span>
-              <span class="mt-1 block text-[11px] text-gray-400">{{ alert.type }} · {{ alert.time }}</span>
-            </button>
+          <div class="divide-y divide-gray-100">
+            <div v-for="alert in alerts" :key="alert.message" class="px-4 py-3">
+              <div class="flex items-center justify-between gap-2">
+                <span
+                  class="px-2 py-1 text-[11px] font-black"
+                  :class="alertTypeBadgeClass(alert.type)"
+                  >{{ alert.type }}</span
+                >
+                <span class="text-[11px] font-bold text-gray-400">{{ alert.time }}</span>
+              </div>
+              <p class="mt-2 text-xs font-black text-gray-900">{{ alert.message }}</p>
+            </div>
           </div>
-          <button type="button" class="border-t border-gray-200 py-2.5 text-[12px] font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-800" @click="goToAlertCenter">
-            알림 센터 바로가기
-          </button>
         </article>
-      </section>
-
-      <section class="border border-gray-300 bg-white shadow-sm">
-        <div class="flex items-center justify-between border-b border-gray-200 px-3 py-2.5">
-          <div class="flex items-center gap-2">
-            <h3 class="text-sm font-medium text-gray-800">최근 물류 트랜잭션</h3>
-            <span class="bg-black px-1.5 py-0.5 text-[9px] font-bold text-white">LIVE</span>
-          </div>
-          <button type="button" class="text-xs font-semibold text-[#1f4b3a] hover:underline" @click="goToTransactions">전체 트랜잭션 조회</button>
-        </div>
-        <div class="overflow-auto">
-          <table class="w-full min-w-[800px] text-[13px]">
-            <thead class="bg-gray-50 text-[11px] uppercase text-gray-500">
-              <tr>
-                <th class="px-3 py-2.5 text-left font-bold">ID</th>
-                <th class="px-3 py-2.5 text-left font-bold">물류 거점</th>
-                <th class="px-3 py-2.5 text-left font-bold">품목</th>
-                <th class="px-3 py-2.5 text-right font-bold">수량</th>
-                <th class="px-3 py-2.5 text-left font-bold">상태</th>
-                <th class="px-3 py-2.5 text-left font-bold">시각</th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-gray-100 border-t border-gray-200">
-              <tr v-for="row in logisticsData" :key="row.id" class="hover:bg-gray-50/50">
-                <td class="px-3 py-2.5 font-mono text-gray-400">{{ row.id.split('-')[1] }}</td>
-                <td class="px-3 py-2.5 font-semibold text-gray-800">{{ row.center }}</td>
-                <td class="px-3 py-2.5 text-gray-600">{{ row.item }}</td>
-                <td class="px-3 py-2.5 text-right font-bold" :class="row.qty > 0 ? 'text-emerald-600' : 'text-red-600'">
-                  {{ row.qty > 0 ? `+${row.qty.toLocaleString()}` : row.qty.toLocaleString() }}
-                </td>
-                <td class="px-3 py-2.5 text-xs font-bold text-gray-700">{{ row.status }}</td>
-                <td class="px-3 py-2.5 text-gray-400">{{ row.time }}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
       </section>
     </div>
   </AppLayout>


### PR DESCRIPTION
## 📌 요약
- 본사 관리자 제품 마스터 프론트 화면을 API 중심으로 정리하고, 제품 관리/ SKU 상세 운영 UX를 개선했습니다.
- 제품 목록, 제품 관리 페이지, SKU 상세 페이지를 실제 백엔드 데이터와 동기화했습니다.

<br><br>

## 🎯 작업 내용
- 제품 마스터 목록 API 연동 및 카테고리 표시 개선(코드값 → 대/소분류명 매핑)
- 제품 등록/관리 공용 페이지 구성 및 저장 시 SKU 선택(색상·사이즈) 반영 로직 적용
- SKU 상세 페이지 행 단위 수정/삭제(가격/상태 변경 포함) 기능 추가 및 테이블 정렬/간격 개선

<br><br>

## ✔️ 참고 사항
- 제품 목록 동선: 행 클릭은 SKU 상세, 행 끝 `관리` 버튼은 제품 관리 페이지로 분리했습니다.
- 제품 관리 페이지에서 품목 삭제 버튼을 추가하고 삭제 API와 연동했습니다.

<br><br>

## ✔️ 관련 이슈

- Close #194

<br><br>
