### PR TITLE
feat(warehouse-dashboard): 입고 진행률 BE 집계 연동

### DIFF
--- a/src/api/dashboard.js
+++ b/src/api/dashboard.js
@@ -1,0 +1,32 @@
+/**
+ * dashboard.js — BE 연동 (WHS-001 창고 관리자 대시보드)
+ *
+ * BE 엔드포인트:
+ *   GET  /api/warehouse/dashboard/inbound-progress?warehouseId=&from=&to=
+ *
+ * 응답: BaseResponse<InboundProgressRes>.
+ *   result.kpi: { scheduledCount, completedCount, totalCount, progressRate, avgProcessingHours }
+ *     - progressRate: 0~1 double
+ *     - avgProcessingHours: createdAt → COMPLETED 평균 시간. 0건이면 null
+ *     - totalCount: REJECTED 제외 전체 (입고 파이프라인 분모)
+ *   result.statusBreakdown: { PENDING, APPROVED, SHIPPING, COMPLETED, REJECTED } 5키 모두 노출
+ *
+ * 인증 도입(ADR-011) 전 임시: warehouseId 는 옵셔널 query 파라미터.
+ */
+
+import { apiClient, unwrap } from './axios.js'
+
+const BASE = '/api/warehouse/dashboard'
+
+export const dashboardApi = {
+  /**
+   * @param {{warehouseId?: string, from?: string, to?: string}} params
+   */
+  getInboundProgress: (params = {}) => {
+    const query = {}
+    if (params.warehouseId) query.warehouseId = params.warehouseId
+    if (params.from) query.from = params.from
+    if (params.to) query.to = params.to
+    return apiClient.get(`${BASE}/inbound-progress`, { params: query }).then(unwrap)
+  },
+}

--- a/src/stores/warehouseDashboard.js
+++ b/src/stores/warehouseDashboard.js
@@ -1,0 +1,93 @@
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import { dashboardApi } from '@/api/dashboard.js'
+import { inboundApi } from '@/api/inbound.js'
+
+/**
+ * WHS-001 창고 관리자 대시보드 입고 진행률 store.
+ * BE: GET /api/warehouse/dashboard/inbound-progress (집계) + GET /api/warehouse/inbound?status=SHIPPING (예정 발주 목록).
+ * 두 호출은 fetchInboundProgress 액션에서 병렬 처리.
+ *
+ * 단일 진실 원천(ADR-015) — 대시보드는 자체 BE 호출만으로 동작. purchaseOrder/inbound store 의존 금지.
+ */
+export const useWarehouseDashboardStore = defineStore('warehouseDashboard', () => {
+  const progress = ref(null) // { kpi, statusBreakdown } | null
+  const shippingOrders = ref([]) // [{ id, vendorName, warehouseName, createdAt, itemCount, totalPrice }]
+  const isLoading = ref(false)
+  const error = ref(null)
+
+  // ─── getters ───────────────────────────────────────────────────────────────
+  const kpi = computed(() => progress.value?.kpi ?? {})
+  const statusBreakdown = computed(() => progress.value?.statusBreakdown ?? {})
+
+  const progressPercent = computed(() => {
+    const r = kpi.value.progressRate
+    if (r === null || r === undefined) return null
+    return Math.round(r * 100)
+  })
+
+  const shippingCount = computed(() => statusBreakdown.value.SHIPPING ?? 0)
+  const completedCount = computed(() => statusBreakdown.value.COMPLETED ?? 0)
+  const stageTotal = computed(() => shippingCount.value + completedCount.value)
+
+  const shippingPct = computed(() => {
+    if (stageTotal.value === 0) return 0
+    return Math.round((shippingCount.value / stageTotal.value) * 100)
+  })
+  const completedPct = computed(() => {
+    if (stageTotal.value === 0) return 0
+    return 100 - shippingPct.value
+  })
+
+  // ─── actions ──────────────────────────────────────────────────────────────
+  /**
+   * @param {{warehouseId?: string, from?: string, to?: string}} params
+   */
+  async function fetchInboundProgress(params = {}) {
+    isLoading.value = true
+    error.value = null
+    try {
+      const [progressRes, listRes] = await Promise.all([
+        dashboardApi.getInboundProgress(params),
+        inboundApi.list({ ...params, status: 'SHIPPING' }),
+      ])
+      progress.value = progressRes
+      // 입고 예정 테이블 — 도착 임박 (오래된 순) 노출 위해 createdAt asc 로 재정렬
+      const mapped = listRes.map((o) => ({
+        id: o.code,
+        vendorName: o.vendorName,
+        warehouseName: o.warehouseName,
+        createdAt: o.createdAt,
+        itemCount: o.itemCount,
+        totalPrice: o.totalAmount,
+      }))
+      mapped.sort((a, b) => String(a.createdAt).localeCompare(String(b.createdAt)))
+      shippingOrders.value = mapped
+    } catch (e) {
+      error.value = e?.message ?? '대시보드 데이터를 불러오지 못했습니다.'
+      progress.value = null
+      shippingOrders.value = []
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  return {
+    // state
+    progress,
+    shippingOrders,
+    isLoading,
+    error,
+    // getters
+    kpi,
+    statusBreakdown,
+    progressPercent,
+    shippingCount,
+    completedCount,
+    stageTotal,
+    shippingPct,
+    completedPct,
+    // actions
+    fetchInboundProgress,
+  }
+})

--- a/src/views/warehouse/WarehouseDashboardView.vue
+++ b/src/views/warehouse/WarehouseDashboardView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import {
   BarChart3,
@@ -12,12 +12,12 @@ import {
 import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
-import { usePurchaseOrderStore } from '@/stores/purchaseOrder.js'
+import { useWarehouseDashboardStore } from '@/stores/warehouseDashboard.js'
 import { useWarehouseSpaceStore } from '@/stores/warehouseSpace.js'
 
 const router = useRouter()
 const auth = useAuthStore()
-const poStore = usePurchaseOrderStore()
+const dashStore = useWarehouseDashboardStore()
 
 const topMenus = roleMenus.warehouse
 const sideMenus = roleMenus.warehouse.find((menu) => menu.label === '대시보드')?.children ?? []
@@ -71,56 +71,41 @@ function monthStartStr() {
   const m = String(d.getMonth() + 1).padStart(2, '0')
   return `${d.getFullYear()}-${m}-01`
 }
-function inRange(iso) {
-  if (!iso) return false
-  const date = iso.slice(0, 10)
+
+// range key → BE from/to 파라미터. all 은 둘 다 미지정.
+const rangeParams = computed(() => {
   switch (range.value) {
     case 'today':
-      return date === todayStr()
+      return { from: todayStr(), to: todayStr() }
     case 'week':
-      return date >= weekStartStr() && date <= todayStr()
+      return { from: weekStartStr(), to: todayStr() }
     case 'month':
-      return date >= monthStartStr() && date <= todayStr()
+      return { from: monthStartStr(), to: todayStr() }
     default:
-      return true
+      return {}
   }
-}
-
-// ─── computed ──────────────────────────────────────────────────────────────
-const filteredOrders = computed(() =>
-  poStore.purchaseOrders.filter(
-    (o) => inRange(o.createdAt) && (o.status === 'SHIPPING' || o.status === 'COMPLETED'),
-  ),
-)
-
-const shippingCount = computed(
-  () => filteredOrders.value.filter((o) => o.status === 'SHIPPING').length,
-)
-const completedCount = computed(
-  () => filteredOrders.value.filter((o) => o.status === 'COMPLETED').length,
-)
-
-const progressRate = computed(() => {
-  const total = shippingCount.value + completedCount.value
-  if (total === 0) return null
-  return Math.round((completedCount.value / total) * 100)
 })
 
-const avgProcessingDays = computed(() => {
-  const completed = filteredOrders.value.filter(
-    (o) => o.status === 'COMPLETED' && Array.isArray(o.statusHistory),
-  )
-  const diffs = []
-  for (const o of completed) {
-    const shipping = o.statusHistory.find((h) => h.status === 'SHIPPING')
-    const done = o.statusHistory.find((h) => h.status === 'COMPLETED')
-    if (!shipping?.at || !done?.at) continue
-    const ms = new Date(done.at).getTime() - new Date(shipping.at).getTime()
-    if (Number.isNaN(ms) || ms < 0) continue
-    diffs.push(ms / (1000 * 60 * 60 * 24))
-  }
-  if (diffs.length === 0) return null
-  return diffs.reduce((sum, v) => sum + v, 0) / diffs.length
+onMounted(() => {
+  dashStore.fetchInboundProgress(rangeParams.value)
+})
+
+watch(range, () => {
+  dashStore.fetchInboundProgress(rangeParams.value)
+})
+
+// ─── KPI / breakdown — store getter 직접 사용 ───────────────────────────────
+const shippingCount = computed(() => dashStore.shippingCount)
+const completedCount = computed(() => dashStore.completedCount)
+const stageTotal = computed(() => dashStore.stageTotal)
+const shippingPct = computed(() => dashStore.shippingPct)
+const completedPct = computed(() => dashStore.completedPct)
+const progressRate = computed(() => dashStore.progressPercent)
+
+const totalCount = computed(() => dashStore.kpi.totalCount ?? 0)
+const avgProcessingHours = computed(() => {
+  const v = dashStore.kpi.avgProcessingHours
+  return v === null || v === undefined ? null : v
 })
 
 // KPI 카드 — 본사 대시보드 패턴 (라벨 + 값/단위 + 우상단 점 + 캡션)
@@ -131,7 +116,7 @@ const kpiStats = computed(() => [
     unit: progressRate.value !== null ? '%' : '',
     caption:
       progressRate.value !== null
-        ? `총 ${shippingCount.value + completedCount.value}건 중 ${completedCount.value}건 완료`
+        ? `총 ${totalCount.value}건 중 ${completedCount.value}건 완료`
         : '데이터 없음',
     tone: 'green',
   },
@@ -151,9 +136,9 @@ const kpiStats = computed(() => [
   },
   {
     label: '평균 처리',
-    value: avgProcessingDays.value !== null ? avgProcessingDays.value.toFixed(1) : '—',
-    unit: avgProcessingDays.value !== null ? '일' : '',
-    caption: 'SHIPPING → COMPLETED',
+    value: avgProcessingHours.value !== null ? avgProcessingHours.value.toFixed(1) : '—',
+    unit: avgProcessingHours.value !== null ? '시간' : '',
+    caption: '발주 → 입고완료',
     tone: 'gray',
   },
 ])
@@ -169,23 +154,8 @@ function dotClass(tone) {
   )
 }
 
-// 입고 예정 SHIPPING 발주 (도착 임박 — 오래된 순)
-const shippingOrders = computed(() =>
-  filteredOrders.value
-    .filter((o) => o.status === 'SHIPPING')
-    .sort((a, b) => a.createdAt.localeCompare(b.createdAt)),
-)
-
-// 단계 비율 (세그먼트 스택 막대용)
-const stageTotal = computed(() => shippingCount.value + completedCount.value)
-const shippingPct = computed(() => {
-  if (stageTotal.value === 0) return 0
-  return Math.round((shippingCount.value / stageTotal.value) * 100)
-})
-const completedPct = computed(() => {
-  if (stageTotal.value === 0) return 0
-  return 100 - shippingPct.value
-})
+// 입고 예정 SHIPPING 발주 — store 가 도착 임박(오래된 순) 으로 정렬해서 줌
+const shippingOrders = computed(() => dashStore.shippingOrders)
 
 function formatDate(iso) {
   if (!iso) return '-'
@@ -347,7 +317,7 @@ const thresholdBarClass = computed(
                     {{ formatDate(o.createdAt) }}
                   </td>
                   <td class="px-4 py-3 text-right font-black text-gray-900">
-                    {{ o.items.length }}품목 / ₩{{ o.totalPrice.toLocaleString() }}
+                    {{ o.itemCount }}품목 / ₩{{ o.totalPrice.toLocaleString() }}
                   </td>
                 </tr>
                 <tr v-if="shippingOrders.length === 0">
@@ -376,7 +346,7 @@ const thresholdBarClass = computed(
                   진행률
                 </p>
                 <p class="mt-1 text-xs font-bold text-gray-500">
-                  총 {{ stageTotal }}건 중 {{ completedCount }}건 완료
+                  총 {{ totalCount }}건 중 {{ completedCount }}건 완료
                 </p>
               </div>
               <p


### PR DESCRIPTION
## 📌 요약
- 창고 대시보드 KPI 4장 + 단계별 세그먼트 막대를 client-side 집계 → **BE 집계 엔드포인트 호출**로 전환
- 데이터 출처 일원화 + 기간 필터 단일 책임(BE) 정합 확보

<br><br>

## 🎯 작업 내용
- **데이터 소스 전환**
  - 화면이 자체적으로 발주 store를 훑어 KPI를 계산하던 방식 제거
  - `dashboardApi.getInboundProgress` 호출로 KPI / statusBreakdown 서버 집계 수신
- **병렬 호출 처리**
  - `warehouseDashboard` store에서 `dashboardApi.getInboundProgress` + `inboundApi.list({status: SHIPPING})` 두 호출을 `Promise.all`로 병렬 처리
  - 한 사이클에 KPI / breakdown / 예정 발주 목록 일괄 적재
- **기간 필터 정리**
  - 기간 토글을 BE의 `from` / `to` 파라미터로만 변환
  - 컴포넌트의 client-side 필터 로직 일괄 제거
- **KPI 정의 정합**
  - 평균 처리 시간: 발주 → 입고 완료 (시간 단위, BE 정의 그대로 사용)
  - 진행률 분모: REJECTED 제외 전체 발주 수

<br><br>

## ✔️ 참고 사항
- 데이터 출처 분산으로 인한 정합 위험 / 기간 필터 BE·FE 이중 처리 위험 제거
- 컴포넌트는 store에서 받은 값만 표출 — 추가 가공 없음
- 마크업 변경 없이 데이터 흐름만 BE 집계 기반으로 교체

<br><br>

## ✔️ 관련 이슈
- Close #292 

<br><br>