### PR TITLE
design: 매장 관리자 매장 통계 페이지 구현

### DIFF
--- a/src/config/roleMenus.js
+++ b/src/config/roleMenus.js
@@ -132,6 +132,15 @@ export const roleMenus = {
         { label: '입고 관리', path: '/store/inbound' },
       ],
     },
+    {
+      label: '통계',
+      path: '/store/stats',
+      icon: 'chart',
+      children: [
+        { label: '매장 통계', path: '/store/stats' },
+        { label: '매출 조회', path: '/store/stats/sales' },
+      ],
+    },
   ],
   warehouse: [
     {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -18,6 +18,8 @@ import StoreInventoryView from '@/views/store/StoreInventoryView.vue'
 import StoreInventorySkuDetailView from '@/views/store/StoreInventorySkuDetailView.vue'
 import StoreInboundView from '@/views/store/StoreInboundView.vue'
 import StoreAiReportView from '@/views/store/StoreAiReportView.vue'
+import StoreStatsView from '@/views/store/stats/StoreStatsView.vue'
+import StoreSalesStatsView from '@/views/store/stats/StoreSalesStatsView.vue'
 
 import WarehouseDashboardView from '@/views/warehouse/WarehouseDashboardView.vue'
 import WarehouseInventoryView from '@/views/warehouse/WarehouseInventoryView.vue'
@@ -165,6 +167,8 @@ const router = createRouter({
       meta: { requiresAuth: true, role: 'store' },
     },
     { path: '/store/inbound', name: 'store-inbound', component: StoreInboundView, meta: { requiresAuth: true, role: 'store' } },
+    { path: '/store/stats', name: 'store-stats', component: StoreStatsView, meta: { requiresAuth: true, role: 'store' } },
+    { path: '/store/stats/sales', name: 'store-stats-sales', component: StoreSalesStatsView, meta: { requiresAuth: true, role: 'store' } },
     { path: '/store/ai-report', name: 'store-ai-report', component: StoreAiReportView, meta: { requiresAuth: true, role: 'store' } },
 
     {

--- a/src/views/store/stats/StoreSalesStatsView.vue
+++ b/src/views/store/stats/StoreSalesStatsView.vue
@@ -1,0 +1,224 @@
+<script setup>
+import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import AppLayout from '@/components/common/AppLayout.vue'
+import { roleMenus } from '@/config/roleMenus.js'
+import { useAuthStore } from '@/stores/auth.js'
+import { useSalesStore } from '@/stores/sales.js'
+
+const router = useRouter()
+const auth = useAuthStore()
+const sales = useSalesStore()
+
+const storeMenus = roleMenus.store
+const statsMenus = roleMenus.store.find((menu) => menu.label === '통계')?.children ?? []
+const activeTopMenu = computed(() => '통계')
+const activeSideMenu = ref('매출 조회')
+
+const keyword = ref('')
+const category = ref('전체')
+const status = ref('전체')
+const sortBy = ref('latest')
+
+const now = new Date()
+const lastWeek = new Date(now)
+lastWeek.setDate(now.getDate() - 6)
+
+const pad = (v) => String(v).padStart(2, '0')
+const dateToInput = (d) => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+
+const startDate = ref(dateToInput(lastWeek))
+const endDate = ref(dateToInput(now))
+
+const salesRows = computed(() => {
+  const liveRows = sales.sales.flatMap((sale) => {
+    return sale.items.map((item, idx) => {
+      const hash = [...`${sale.saleId}-${item.skuId}-${idx}`].reduce((acc, ch) => acc + ch.charCodeAt(0), 0)
+      const mockStatus = hash % 13 === 0 ? '취소' : hash % 7 === 0 ? '환불' : '완료'
+      return {
+        soldAt: sale.soldAt,
+        soldDate: sale.soldAt.slice(0, 10),
+        saleId: sale.saleId,
+        productName: item.productName,
+        category: item.mainCategory,
+        subCategory: item.subCategory,
+        status: mockStatus,
+        quantity: item.quantity,
+        unitPrice: item.unitPrice,
+        amount: item.lineAmount,
+      }
+    })
+  })
+
+  if (liveRows.length > 0) return liveRows
+
+  return [
+    { soldAt: '2026-04-28T09:12:00', soldDate: '2026-04-28', saleId: 'SALE-20260428-001', productName: '오버핏 코튼 티셔츠', category: '상의', subCategory: '반팔티', status: '완료', quantity: 3, unitPrice: 24000, amount: 72000 },
+    { soldAt: '2026-04-28T11:35:00', soldDate: '2026-04-28', saleId: 'SALE-20260428-002', productName: '슬림 데님 팬츠', category: '하의', subCategory: '데님', status: '완료', quantity: 2, unitPrice: 48000, amount: 96000 },
+    { soldAt: '2026-04-27T15:40:00', soldDate: '2026-04-27', saleId: 'SALE-20260427-004', productName: '린넨 블렌드 셔츠', category: '상의', subCategory: '셔츠', status: '환불', quantity: 1, unitPrice: 52000, amount: 52000 },
+    { soldAt: '2026-04-27T18:22:00', soldDate: '2026-04-27', saleId: 'SALE-20260427-006', productName: '라운드 니트 가디건', category: '아우터', subCategory: '가디건', status: '완료', quantity: 2, unitPrice: 88000, amount: 176000 },
+    { soldAt: '2026-04-26T13:05:00', soldDate: '2026-04-26', saleId: 'SALE-20260426-003', productName: '캔버스 토트백', category: '잡화', subCategory: '가방', status: '취소', quantity: 1, unitPrice: 36000, amount: 36000 },
+    { soldAt: '2026-04-25T10:17:00', soldDate: '2026-04-25', saleId: 'SALE-20260425-007', productName: '와이드 코튼 팬츠', category: '하의', subCategory: '코튼팬츠', status: '완료', quantity: 4, unitPrice: 39000, amount: 156000 },
+    { soldAt: '2026-04-24T14:58:00', soldDate: '2026-04-24', saleId: 'SALE-20260424-005', productName: '베이직 레이어드 롱슬리브', category: '상의', subCategory: '긴팔티', status: '완료', quantity: 3, unitPrice: 27000, amount: 81000 },
+    { soldAt: '2026-04-23T16:11:00', soldDate: '2026-04-23', saleId: 'SALE-20260423-002', productName: '플리츠 롱 스커트', category: '하의', subCategory: '스커트', status: '완료', quantity: 2, unitPrice: 46000, amount: 92000 },
+  ]
+})
+
+const categoryOptions = computed(() => ['전체', ...new Set(salesRows.value.map((r) => r.category))])
+
+const filteredRows = computed(() => {
+  const start = startDate.value ? new Date(`${startDate.value}T00:00:00`) : null
+  const end = endDate.value ? new Date(`${endDate.value}T23:59:59`) : null
+  const q = keyword.value.trim().toLowerCase()
+
+  let rows = salesRows.value.filter((row) => {
+    const sold = new Date(row.soldAt)
+    const matchDate = (!start || sold >= start) && (!end || sold <= end)
+    const matchCategory = category.value === '전체' || row.category === category.value
+    const matchStatus = status.value === '전체' || row.status === status.value
+    const matchKeyword = !q || [row.saleId, row.productName].join(' ').toLowerCase().includes(q)
+    return matchDate && matchCategory && matchStatus && matchKeyword
+  })
+
+  if (sortBy.value === 'amount') {
+    rows = rows.sort((a, b) => b.amount - a.amount)
+  } else if (sortBy.value === 'quantity') {
+    rows = rows.sort((a, b) => b.quantity - a.quantity)
+  } else {
+    rows = rows.sort((a, b) => new Date(b.soldAt) - new Date(a.soldAt))
+  }
+
+  return rows
+})
+
+const totalAmount = computed(() => filteredRows.value.reduce((sum, row) => sum + row.amount, 0))
+const totalQty = computed(() => filteredRows.value.reduce((sum, row) => sum + row.quantity, 0))
+const totalCount = computed(() => filteredRows.value.length)
+
+function statusClass(v) {
+  if (v === '완료') return 'bg-emerald-50 text-emerald-700'
+  if (v === '환불') return 'bg-amber-50 text-amber-700'
+  return 'bg-red-50 text-red-700'
+}
+
+function formatDateTime(iso) {
+  const d = new Date(iso)
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+function handleLogout() {
+  auth.logout()
+  router.push('/login')
+}
+</script>
+
+<template>
+  <AppLayout
+    :active-top-menu="activeTopMenu"
+    :top-menus="storeMenus"
+    :side-menus="statsMenus"
+    v-model:active-side-menu="activeSideMenu"
+    @logout="handleLogout"
+  >
+    <div class="flex flex-col gap-4">
+      <section class="border border-gray-300 bg-white p-4 shadow-sm">
+        <p class="text-[10px] font-black uppercase tracking-[0.18em] text-gray-400">Sales Table</p>
+        <h1 class="mt-1 text-lg font-black text-gray-900">매출 조회</h1>
+        <p class="mt-1 text-xs font-bold text-gray-500">기간/카테고리/상태/키워드로 매출을 필터링해 표로 조회합니다.</p>
+      </section>
+
+      <section class="grid gap-3 border border-gray-300 bg-white p-4 shadow-sm md:grid-cols-2 xl:grid-cols-6">
+        <label class="flex flex-col gap-1">
+          <span class="text-[11px] font-bold text-gray-500">시작일</span>
+          <input v-model="startDate" type="date" class="h-9 border border-gray-300 px-2 text-xs font-bold" />
+        </label>
+        <label class="flex flex-col gap-1">
+          <span class="text-[11px] font-bold text-gray-500">종료일</span>
+          <input v-model="endDate" type="date" class="h-9 border border-gray-300 px-2 text-xs font-bold" />
+        </label>
+        <label class="flex flex-col gap-1">
+          <span class="text-[11px] font-bold text-gray-500">카테고리</span>
+          <select v-model="category" class="h-9 border border-gray-300 px-2 text-xs font-bold">
+            <option v-for="opt in categoryOptions" :key="opt" :value="opt">{{ opt }}</option>
+          </select>
+        </label>
+        <label class="flex flex-col gap-1">
+          <span class="text-[11px] font-bold text-gray-500">상태</span>
+          <select v-model="status" class="h-9 border border-gray-300 px-2 text-xs font-bold">
+            <option value="전체">전체</option>
+            <option value="완료">완료</option>
+            <option value="환불">환불</option>
+            <option value="취소">취소</option>
+          </select>
+        </label>
+        <label class="flex flex-col gap-1 xl:col-span-2">
+          <span class="text-[11px] font-bold text-gray-500">키워드</span>
+          <input v-model="keyword" type="search" placeholder="판매번호, 상품명" class="h-9 border border-gray-300 px-2 text-xs font-bold" />
+        </label>
+      </section>
+
+      <section class="grid gap-3 md:grid-cols-3">
+        <article class="border border-gray-300 bg-white p-3 shadow-sm">
+          <p class="text-[10px] font-black uppercase tracking-[0.12em] text-gray-400">총 매출액</p>
+          <p class="mt-2 text-2xl font-black text-gray-900">₩{{ totalAmount.toLocaleString() }}</p>
+        </article>
+        <article class="border border-gray-300 bg-white p-3 shadow-sm">
+          <p class="text-[10px] font-black uppercase tracking-[0.12em] text-gray-400">총 판매 수량</p>
+          <p class="mt-2 text-2xl font-black text-gray-900">{{ totalQty.toLocaleString() }}</p>
+        </article>
+        <article class="border border-gray-300 bg-white p-3 shadow-sm">
+          <p class="text-[10px] font-black uppercase tracking-[0.12em] text-gray-400">총 거래 건수</p>
+          <p class="mt-2 text-2xl font-black text-gray-900">{{ totalCount.toLocaleString() }}</p>
+        </article>
+      </section>
+
+      <section class="border border-gray-300 bg-white shadow-sm">
+        <div class="flex items-center justify-between border-b border-gray-200 px-4 py-3">
+          <h2 class="text-sm font-black text-gray-900">매출 조회 결과</h2>
+          <label class="flex items-center gap-2 text-[11px] font-bold text-gray-500">
+            정렬
+            <select v-model="sortBy" class="h-8 border border-gray-300 px-2 text-xs font-bold text-gray-700">
+              <option value="latest">최신순</option>
+              <option value="amount">매출순</option>
+              <option value="quantity">수량순</option>
+            </select>
+          </label>
+        </div>
+
+        <div class="overflow-x-auto">
+          <table class="w-full min-w-[1020px] border-collapse text-xs">
+            <thead class="bg-gray-50 text-[10px] uppercase tracking-[0.12em] text-gray-500">
+              <tr>
+                <th class="px-3 py-3 text-left font-black">일시</th>
+                <th class="px-3 py-3 text-left font-black">판매번호</th>
+                <th class="px-3 py-3 text-left font-black">상품명</th>
+                <th class="px-3 py-3 text-left font-black">카테고리</th>
+                <th class="px-3 py-3 text-center font-black">상태</th>
+                <th class="px-3 py-3 text-right font-black">수량</th>
+                <th class="px-3 py-3 text-right font-black">단가</th>
+                <th class="px-3 py-3 text-right font-black">금액</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100">
+              <tr v-for="row in filteredRows" :key="`${row.saleId}-${row.productName}-${row.soldAt}`">
+                <td class="px-3 py-3 font-bold text-gray-600">{{ formatDateTime(row.soldAt) }}</td>
+                <td class="px-3 py-3 font-mono font-bold text-gray-700">{{ row.saleId }}</td>
+                <td class="px-3 py-3 font-bold text-gray-900">{{ row.productName }}</td>
+                <td class="px-3 py-3 font-bold text-gray-600">{{ row.category }} > {{ row.subCategory }}</td>
+                <td class="px-3 py-3 text-center">
+                  <span class="px-2 py-1 text-[11px] font-black" :class="statusClass(row.status)">{{ row.status }}</span>
+                </td>
+                <td class="px-3 py-3 text-right font-black text-gray-700">{{ row.quantity }}</td>
+                <td class="px-3 py-3 text-right font-black text-gray-700">₩{{ row.unitPrice.toLocaleString() }}</td>
+                <td class="px-3 py-3 text-right font-black text-gray-900">₩{{ row.amount.toLocaleString() }}</td>
+              </tr>
+              <tr v-if="filteredRows.length === 0">
+                <td colspan="8" class="px-4 py-12 text-center text-gray-400">조건에 맞는 매출 데이터가 없습니다.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  </AppLayout>
+</template>

--- a/src/views/store/stats/StoreStatsView.vue
+++ b/src/views/store/stats/StoreStatsView.vue
@@ -1,0 +1,231 @@
+<script setup>
+import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import AppLayout from '@/components/common/AppLayout.vue'
+import LineChart from '@/components/common/charts/LineChart.vue'
+import { roleMenus } from '@/config/roleMenus.js'
+import { useAuthStore } from '@/stores/auth.js'
+
+const router = useRouter()
+const auth = useAuthStore()
+
+const storeMenus = roleMenus.store
+const statsMenus = roleMenus.store.find((menu) => menu.label === '통계')?.children ?? []
+const activeTopMenu = computed(() => '통계')
+const activeSideMenu = ref('매장 통계')
+
+const kpi = [
+  { label: '오늘 매출', value: '₩4,821,500', delta: '+12.3%', tone: 'up' },
+  { label: '주간 매출', value: '₩29,484,000', delta: '+6.8%', tone: 'up' },
+  { label: '객단가', value: '₩38,900', delta: '-2.1%', tone: 'down' },
+  { label: '판매 건수', value: '124건', delta: '+9건', tone: 'up' },
+  { label: '재고 부족 SKU', value: '7개', delta: '주의 필요', tone: 'warn' },
+  { label: '발주 진행 건수', value: '5건', delta: '승인대기 2건', tone: 'neutral' },
+]
+
+const trend = [58, 72, 66, 81, 75, 92, 88]
+const trendLabels = ['월', '화', '수', '목', '금', '토', '일']
+
+const salesTrendChartData = computed(() => ({
+  labels: trendLabels,
+  datasets: [
+    {
+      label: '일 매출',
+      data: trend,
+      borderColor: '#0E7A60',
+      backgroundColor: 'rgba(14, 122, 96, 0.14)',
+      borderWidth: 2.5,
+      pointRadius: 3,
+      pointHoverRadius: 5,
+      pointBackgroundColor: '#fff',
+      pointBorderColor: '#0E7A60',
+      pointBorderWidth: 2,
+      tension: 0.35,
+      fill: true,
+    },
+  ],
+}))
+
+const salesTrendChartOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: { display: false },
+    tooltip: {
+      backgroundColor: 'rgba(17, 24, 39, 0.95)',
+      titleColor: '#6ee7b7',
+      titleFont: { size: 11, weight: 'bold' },
+      bodyColor: '#fff',
+      padding: 10,
+      cornerRadius: 6,
+      displayColors: false,
+      callbacks: {
+        title: (items) => items[0].label,
+        label: (ctx) => `${ctx.parsed.y}`,
+      },
+    },
+  },
+  scales: {
+    x: { grid: { display: false }, ticks: { font: { size: 11 }, color: '#9ca3af' } },
+    y: {
+      display: true,
+      grid: { color: '#f3f4f6' },
+      ticks: { font: { size: 10 }, color: '#9ca3af' },
+      border: { display: false },
+    },
+  },
+  interaction: { mode: 'index', intersect: false },
+}
+
+const categoryMix = [
+  { name: '상의', percent: 38, color: '#0E7A60' },
+  { name: '하의', percent: 27, color: '#3A9D85' },
+  { name: '아우터', percent: 19, color: '#77BEAD' },
+  { name: '잡화', percent: 16, color: '#B8DDD4' },
+]
+
+const topSkus = [
+  { sku: 'SKU-0132', name: '오버핏 코튼 티셔츠', qty: 48, amount: 1152000 },
+  { sku: 'SKU-0084', name: '슬림 데님 팬츠', qty: 37, amount: 1776000 },
+  { sku: 'SKU-0201', name: '린넨 블렌드 셔츠', qty: 32, amount: 1536000 },
+  { sku: 'SKU-0314', name: '라운드 니트 가디건', qty: 24, amount: 2112000 },
+  { sku: 'SKU-0160', name: '캔버스 토트백', qty: 21, amount: 756000 },
+]
+
+const riskSkus = [
+  { sku: 'SKU-0084-BLK-28', name: '슬림 데님 팬츠 / 28', stock: 2, safe: 10, risk: '높음' },
+  { sku: 'SKU-0132-WHT-XS', name: '오버핏 코튼 티셔츠 / XS', stock: 5, safe: 15, risk: '중간' },
+  { sku: 'SKU-0314-GRY-M', name: '라운드 니트 가디건 / M', stock: 8, safe: 20, risk: '중간' },
+  { sku: 'SKU-0201-IVR-L', name: '린넨 블렌드 셔츠 / L', stock: 11, safe: 18, risk: '관심' },
+]
+
+function toneClass(tone) {
+  if (tone === 'up') return 'text-emerald-600'
+  if (tone === 'down') return 'text-red-500'
+  if (tone === 'warn') return 'text-amber-600'
+  return 'text-gray-500'
+}
+
+function riskClass(risk) {
+  if (risk === '높음') return 'bg-red-50 text-red-600'
+  if (risk === '중간') return 'bg-amber-50 text-amber-600'
+  return 'bg-slate-100 text-slate-600'
+}
+
+function handleLogout() {
+  auth.logout()
+  router.push('/login')
+}
+</script>
+
+<template>
+  <AppLayout
+    :active-top-menu="activeTopMenu"
+    :top-menus="storeMenus"
+    :side-menus="statsMenus"
+    v-model:active-side-menu="activeSideMenu"
+    @logout="handleLogout"
+  >
+    <div class="flex flex-col gap-4">
+      <section class="border border-gray-300 bg-white p-4 shadow-sm">
+        <p class="text-[10px] font-black uppercase tracking-[0.18em] text-gray-400">Store Statistics</p>
+        <h1 class="mt-1 text-lg font-black text-gray-900">매장 통계</h1>
+        <p class="mt-1 text-xs font-bold text-gray-500">매장 운영에 필요한 핵심 지표를 한 페이지에서 확인합니다.</p>
+      </section>
+
+      <section class="grid gap-3 md:grid-cols-3 xl:grid-cols-6">
+        <article v-for="item in kpi" :key="item.label" class="border border-gray-300 bg-white px-3 py-3 shadow-sm">
+          <p class="text-[11px] font-bold text-gray-500">{{ item.label }}</p>
+          <p class="mt-2 text-xl font-black text-gray-900">{{ item.value }}</p>
+          <p class="mt-1 text-[11px] font-bold" :class="toneClass(item.tone)">{{ item.delta }}</p>
+        </article>
+      </section>
+
+      <section class="grid gap-3 xl:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+        <article class="border border-gray-300 bg-white shadow-sm">
+          <div class="border-b border-gray-200 px-4 py-3">
+            <h2 class="text-sm font-black text-gray-900">최근 7일 매출 추이</h2>
+          </div>
+          <div class="px-4 pb-4 pt-3">
+            <div class="h-[140px]">
+              <LineChart :data="salesTrendChartData" :options="salesTrendChartOptions" :height="140" />
+            </div>
+          </div>
+        </article>
+
+        <article class="border border-gray-300 bg-white shadow-sm">
+          <div class="border-b border-gray-200 px-4 py-3">
+            <h2 class="text-sm font-black text-gray-900">카테고리별 매출 비중</h2>
+          </div>
+          <div class="space-y-3 px-4 py-4">
+            <div v-for="row in categoryMix" :key="row.name" class="space-y-1">
+              <div class="flex items-center justify-between text-xs">
+                <span class="font-bold text-gray-700">{{ row.name }}</span>
+                <span class="font-black text-gray-900">{{ row.percent }}%</span>
+              </div>
+              <div class="h-2 overflow-hidden bg-gray-100">
+                <div class="h-full" :style="{ width: `${row.percent}%`, backgroundColor: row.color }" />
+              </div>
+            </div>
+          </div>
+        </article>
+      </section>
+
+      <section class="grid gap-3 xl:grid-cols-2">
+        <article class="border border-gray-300 bg-white shadow-sm">
+          <div class="border-b border-gray-200 px-4 py-3">
+            <h2 class="text-sm font-black text-gray-900">판매 TOP SKU</h2>
+          </div>
+          <div class="overflow-x-auto">
+            <table class="w-full min-w-[520px] text-xs">
+              <thead class="bg-gray-50 text-[10px] uppercase text-gray-500">
+                <tr>
+                  <th class="px-3 py-3 text-left font-black">SKU</th>
+                  <th class="px-3 py-3 text-left font-black">상품명</th>
+                  <th class="px-3 py-3 text-right font-black">판매수량</th>
+                  <th class="px-3 py-3 text-right font-black">매출</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-100">
+                <tr v-for="row in topSkus" :key="row.sku">
+                  <td class="px-3 py-3 font-mono font-bold text-gray-500">{{ row.sku }}</td>
+                  <td class="px-3 py-3 font-bold text-gray-800">{{ row.name }}</td>
+                  <td class="px-3 py-3 text-right font-black text-gray-700">{{ row.qty }}</td>
+                  <td class="px-3 py-3 text-right font-black text-gray-900">₩{{ row.amount.toLocaleString() }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </article>
+
+        <article class="border border-gray-300 bg-white shadow-sm">
+          <div class="border-b border-gray-200 px-4 py-3">
+            <h2 class="text-sm font-black text-gray-900">재고 리스크 SKU</h2>
+          </div>
+          <div class="overflow-x-auto">
+            <table class="w-full min-w-[520px] text-xs">
+              <thead class="bg-gray-50 text-[10px] uppercase text-gray-500">
+                <tr>
+                  <th class="px-3 py-3 text-left font-black">SKU</th>
+                  <th class="px-3 py-3 text-left font-black">상품명</th>
+                  <th class="px-3 py-3 text-right font-black">재고/안전</th>
+                  <th class="px-3 py-3 text-center font-black">위험도</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-100">
+                <tr v-for="row in riskSkus" :key="row.sku">
+                  <td class="px-3 py-3 font-mono font-bold text-gray-500">{{ row.sku }}</td>
+                  <td class="px-3 py-3 font-bold text-gray-800">{{ row.name }}</td>
+                  <td class="px-3 py-3 text-right font-black text-gray-700">{{ row.stock }} / {{ row.safe }}</td>
+                  <td class="px-3 py-3 text-center">
+                    <span class="px-2 py-1 text-[11px] font-black" :class="riskClass(row.risk)">{{ row.risk }}</span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </article>
+      </section>
+    </div>
+  </AppLayout>
+</template>


### PR DESCRIPTION
## 📌 요약
- 매장 관리자 전용 `통계 > 매장 통계` 페이지를 신규 구현하고, 한 페이지에서 핵심 운영 지표를 빠르게 확인할 수 있도록 대시보드 UI를 구성했습니다.
- 최근 7일 매출 추이 그래프를 본사 KPI 대시보드 톤에 맞춰 리디자인하여, 좌측 Y축 수치와 요일별 포인트를 포함한 가독성 높은 형태로 개선했습니다.

<br><br>

## 🎯 작업 내용
- 매장 관리자 좌측 메뉴에 `통계` 상위 메뉴 및 `매장 통계` 하위 메뉴를 추가하고 `/store/stats` 라우팅을 연결했습니다.
- `StoreStatsView`를 추가해 KPI 카드, 최근 7일 매출 추이, 카테고리별 매출 비중, 판매 TOP SKU, 재고 리스크 SKU 섹션을 구성했습니다.
- 최근 7일 매출 추이 차트를 `LineChart` 기반으로 정리하고, Y축/포인트/툴팁 스타일을 조정해 시인성과 일관성을 높였습니다.

<br><br>

## ✔️ 참고 사항
- 이번 범위는 프론트 화면 구현 중심이며, 통계 수치는 목업 데이터 기반으로 구성했습니다.
- 기존 매장 관리자 메뉴(대시보드/재고/판매/발주/입고) 및 `통계 > 매출 조회` 동선에는 영향이 없습니다.

<br><br>

## ✔️ 관련 이슈

- Close #294

<br><br>
