### PR TITLE
fix(vendor): 거래처 화면 우측 패널을 마스터 기반 계약 표로 재설계

### DIFF
--- a/src/api/vendor.js
+++ b/src/api/vendor.js
@@ -4,6 +4,7 @@
  * BE 엔드포인트:
  *   GET    /api/vendors                            (목록, 등록은 SQL 직접)
  *   GET    /api/vendors/{code}
+ *   GET    /api/vendors/{code}/contracts            (E 안 — ProductMaster 매칭 + VendorProduct join)
  *   GET    /api/vendor-products?vendorCode=...     (CEN-031, 특정 거래처)
  *   GET    /api/vendor-products?status=...         (CEN-035 발주 카탈로그, 전체 거래처)
  *   GET    /api/vendor-products/{code}             (CEN-033)
@@ -22,6 +23,15 @@ export const vendorApi = {
   listVendors: () => apiClient.get('/api/vendors').then(unwrap),
   getVendor: (code) => apiClient.get(`/api/vendors/${code}`).then(unwrap),
 
+  /**
+   * 거래처 계약 표 (E 안) — mainVendorCode 매칭 ProductMaster 행 + VendorProduct join.
+   * 응답: ContractRow[] = { productCode, productName, categoryCode, basePrice,
+   *   vendorProductCode|null, contractUnitPrice|null, moq|null, leadTimeDays|null,
+   *   contractStart|null, contractEnd|null, status|null, contracted: boolean }
+   */
+  getContracts: (vendorCode) =>
+    apiClient.get(`/api/vendors/${vendorCode}/contracts`).then(unwrap),
+
   // ─── 거래처별 계약 제품 ─────────────────────────────────────────────────
   listVendorProducts: (vendorCode) =>
     apiClient.get('/api/vendor-products', { params: { vendorCode } }).then(unwrap),
@@ -38,15 +48,15 @@ export const vendorApi = {
   getVendorProduct: (code) => apiClient.get(`/api/vendor-products/${code}`).then(unwrap),
 
   /**
-   * 등록 (CEN-027)
-   * @param {{vendorCode, productCode, productName, unitPrice, moq, leadTimeDays, contractStart, contractEnd}} req
+   * 등록 (CEN-027). productName 은 BE 가 ProductMaster.name 자동 복사 — 요청에 포함하지 마라.
+   * @param {{vendorCode, productCode, unitPrice, moq, leadTimeDays, contractStart, contractEnd}} req
    */
   createVendorProduct: (req) => apiClient.post('/api/vendor-products', req).then(unwrap),
 
   /**
-   * 수정 (CEN-028)
+   * 수정 (CEN-028). productName 폐기 — ProductMaster 가 진실 원천이라 VendorProduct 측 변경 액션 없음.
    * @param {string} code
-   * @param {{productName, unitPrice, moq, leadTimeDays, contractStart, contractEnd}} req
+   * @param {{unitPrice, moq, leadTimeDays, contractStart, contractEnd}} req
    */
   updateVendorProduct: (code, req) =>
     apiClient.patch(`/api/vendor-products/${code}`, req).then(unwrap),

--- a/src/stores/vendor.js
+++ b/src/stores/vendor.js
@@ -37,9 +37,12 @@ export const useVendorStore = defineStore('vendor', () => {
   const vendors = ref([])
   const vendorProducts = ref([]) // 현재 선택된 vendor 의 계약 제품만 보유 (거래처 관리 페이지용)
   const allVendorProducts = ref([]) // 전체 거래처의 활성 제품 (CEN-035 발주 작성 카탈로그용)
+  const contracts = ref([]) // E 안 — ContractRow[] (ProductMaster 매칭 + VendorProduct join)
   const selectedVendorId = ref(null)
   const selectedProductId = ref(null)
   const loading = ref(false)
+  const contractsLoading = ref(false)
+  const contractsError = ref(null)
 
   // --- getters ---
   const currentVendorProducts = computed(() => {
@@ -122,75 +125,73 @@ export const useVendorStore = defineStore('vendor', () => {
     }
   }
 
-  // 거래처 선택 + 그 거래처의 제품 자동 fetch
+  // 거래처 계약 표 fetch (E 안 — ContractRow[])
+  async function fetchContracts(vendorCode) {
+    if (!vendorCode) {
+      contracts.value = []
+      return
+    }
+    contractsLoading.value = true
+    contractsError.value = null
+    try {
+      const list = await vendorApi.getContracts(vendorCode)
+      contracts.value = list ?? []
+    } catch (e) {
+      contractsError.value = e?.message ?? '계약 표 조회 실패'
+      contracts.value = []
+    } finally {
+      contractsLoading.value = false
+    }
+  }
+
+  // 거래처 선택 + 그 거래처의 계약 표 자동 fetch (E 안)
   async function selectVendor(id) {
     selectedVendorId.value = id
     selectedProductId.value = null
-    await fetchProductsByVendor(id)
+    await fetchContracts(id)
   }
 
   function selectProduct(id) {
     selectedProductId.value = id
   }
 
-  // 계약 제품 등록 (CEN-027)
+  // 계약 등록 (E 안). productName 은 BE 가 ProductMaster.name 자동 복사 — 요청에 포함 안 함.
   async function createProduct(data) {
-    const created = await vendorApi.createVendorProduct({
+    await vendorApi.createVendorProduct({
       vendorCode: selectedVendorId.value,
       productCode: data.productCode,
-      productName: data.productName,
       unitPrice: Number(data.unitPrice),
       moq: data.moq != null ? Number(data.moq) : null,
       leadTimeDays: data.leadTimeDays != null ? Number(data.leadTimeDays) : null,
       contractStart: data.contractStart || null,
       contractEnd: data.contractEnd || null,
     })
-    const mapped = fromApiVendorProduct(created)
-    vendorProducts.value = [...vendorProducts.value, mapped]
-    return mapped
+    await fetchContracts(selectedVendorId.value)
   }
 
-  // 계약 제품 수정 (CEN-028) — id 는 BE 의 code 와 동일
+  // 계약 수정 (CEN-028) — id 는 BE 의 vendorProductCode (VP-XXX-NNN). productName 폐기.
   async function updateProduct(id, data) {
-    const updated = await vendorApi.updateVendorProduct(id, {
-      productName: data.productName,
+    await vendorApi.updateVendorProduct(id, {
       unitPrice: Number(data.unitPrice),
       moq: data.moq != null ? Number(data.moq) : null,
       leadTimeDays: data.leadTimeDays != null ? Number(data.leadTimeDays) : null,
       contractStart: data.contractStart || null,
       contractEnd: data.contractEnd || null,
     })
-    const mapped = fromApiVendorProduct(updated)
-    const idx = vendorProducts.value.findIndex((vp) => vp.id === id)
-    if (idx !== -1) {
-      const next = [...vendorProducts.value]
-      next[idx] = mapped
-      vendorProducts.value = next
-    }
-    return mapped
+    await fetchContracts(selectedVendorId.value)
   }
 
-  // 계약 제품 상태 변경 (CEN-029): active ↔ suspended
+  // 계약 상태 변경 (CEN-029): ACTIVE / SUSPENDED / EXPIRED
   async function updateStatus(id, newStatus) {
     const beStatus = String(newStatus).toUpperCase()
-    const updated = await vendorApi.updateVendorProductStatus(id, beStatus)
-    const mapped = fromApiVendorProduct(updated)
-    const idx = vendorProducts.value.findIndex((vp) => vp.id === id)
-    if (idx !== -1) {
-      const next = [...vendorProducts.value]
-      next[idx] = mapped
-      vendorProducts.value = next
-    }
-    return mapped
+    await vendorApi.updateVendorProductStatus(id, beStatus)
+    await fetchContracts(selectedVendorId.value)
   }
 
-  // 계약 제품 삭제 (CEN-030, SOFT DELETE) — 로컬 배열에서 제거
+  // 계약 삭제 (CEN-030, SOFT DELETE) — fetchContracts 후 contracted=false 로 돌아감
   async function deleteProduct(id) {
     await vendorApi.deleteVendorProduct(id)
-    vendorProducts.value = vendorProducts.value.filter((vp) => vp.id !== id)
-    if (selectedProductId.value === id) {
-      selectedProductId.value = null
-    }
+    await fetchContracts(selectedVendorId.value)
     return true
   }
 
@@ -203,9 +204,12 @@ export const useVendorStore = defineStore('vendor', () => {
     vendors,
     vendorProducts,
     allVendorProducts,
+    contracts,
     selectedVendorId,
     selectedProductId,
     loading,
+    contractsLoading,
+    contractsError,
     currentVendorProducts,
     selectedProductDetail,
     selectedVendor,
@@ -214,6 +218,7 @@ export const useVendorStore = defineStore('vendor', () => {
     fetchVendors,
     fetchProductsByVendor,
     fetchAllVendorProducts,
+    fetchContracts,
     selectVendor,
     selectProduct,
     createProduct,

--- a/src/views/hq/HqVendorManagementView.vue
+++ b/src/views/hq/HqVendorManagementView.vue
@@ -43,15 +43,23 @@ function handleSelectProduct(id) {
   vendor.selectProduct(id)
 }
 
+// --- E 안 — 선택된 ContractRow ---
+// vendor.contracts 의 행 하나를 선택. 미정(contracted=false) 또는 활성(contracted=true) 모두 selectedRow 에 저장.
+const selectedProductCode = ref(null)
+const selectedRow = computed(() => {
+  if (!selectedProductCode.value) return null
+  return vendor.contracts.find((r) => r.productCode === selectedProductCode.value) ?? null
+})
+
+function handleSelectRow(productCode) {
+  selectedProductCode.value = productCode
+}
+
 // --- 모달 상태 (등록/수정) ---
 const showModal = ref(false)
 const modalMode = ref('create') // 'create' | 'edit'
 
-// 등록 모달은 status 키 없음 (CEN-027: 신규 등록은 항상 active로 store default 적용).
-// 수정 모달은 openEditModal 에서 detail.status 를 별도 주입한다.
 const initialFormData = () => ({
-  productCode: '',
-  productName: '',
   unitPrice: '',
   moq: '',
   leadTimeDays: '',
@@ -62,8 +70,6 @@ const initialFormData = () => ({
 const formData = ref(initialFormData())
 
 const initialFormErrors = () => ({
-  productCode: '',
-  productName: '',
   unitPrice: '',
   moq: '',
   leadTimeDays: '',
@@ -76,20 +82,6 @@ const formErrors = ref(initialFormErrors())
 function validateForm() {
   const errors = initialFormErrors()
   const fd = formData.value
-
-  if (!fd.productCode) {
-    errors.productCode = '필수 입력 항목입니다'
-  } else if (
-    vendor.isProductCodeDuplicate(
-      vendor.selectedVendorId,
-      fd.productCode,
-      modalMode.value === 'edit' ? vendor.selectedProductId : null,
-    )
-  ) {
-    errors.productCode = '이미 등록된 제품 코드입니다'
-  }
-
-  if (!fd.productName) errors.productName = '필수 입력 항목입니다'
 
   if (fd.unitPrice === '' || fd.unitPrice === null) {
     errors.unitPrice = '필수 입력 항목입니다'
@@ -121,29 +113,30 @@ function validateForm() {
   return Object.values(errors).every((msg) => !msg)
 }
 
+// 미정 행에서 [계약 등록]
 function openCreateModal() {
+  if (!selectedRow.value) return
   modalMode.value = 'create'
   formData.value = initialFormData()
   formErrors.value = initialFormErrors()
   showModal.value = true
 }
 
+// 활성 행에서 [수정]
 function openEditModal() {
-  const detail = vendor.selectedProductDetail
-  if (!detail) return
-  if (detail.status === 'expired') {
+  const row = selectedRow.value
+  if (!row || !row.contracted) return
+  if (row.status === 'EXPIRED') {
     alert('만료된 계약은 수정할 수 없습니다.')
     return
   }
   modalMode.value = 'edit'
   formData.value = {
-    productCode: detail.productCode,
-    productName: detail.productName,
-    unitPrice: String(detail.unitPrice),
-    moq: String(detail.moq),
-    leadTimeDays: String(detail.leadTimeDays),
-    contractStart: detail.contractStart,
-    contractEnd: detail.contractEnd,
+    unitPrice: String(row.contractUnitPrice ?? ''),
+    moq: String(row.moq ?? ''),
+    leadTimeDays: String(row.leadTimeDays ?? ''),
+    contractStart: row.contractStart ?? '',
+    contractEnd: row.contractEnd ?? '',
   }
   formErrors.value = initialFormErrors()
   showModal.value = true
@@ -169,16 +162,27 @@ function triggerToast(message) {
 
 async function handleSubmitForm() {
   if (!validateForm()) return
+  const row = selectedRow.value
+  if (!row) return
 
   try {
     if (modalMode.value === 'create') {
-      await vendor.createProduct(formData.value)
+      // productCode 는 selectedRow 에서, productName 은 BE 가 ProductMaster.name 자동 복사
+      await vendor.createProduct({
+        productCode: row.productCode,
+        unitPrice: formData.value.unitPrice,
+        moq: formData.value.moq,
+        leadTimeDays: formData.value.leadTimeDays,
+        contractStart: formData.value.contractStart,
+        contractEnd: formData.value.contractEnd,
+      })
       closeModal()
-      triggerToast('계약 제품이 등록되었습니다')
+      triggerToast('계약이 등록되었습니다')
     } else {
-      await vendor.updateProduct(vendor.selectedProductId, formData.value)
+      // 수정은 vendorProductCode 로 PATCH
+      await vendor.updateProduct(row.vendorProductCode, formData.value)
       closeModal()
-      triggerToast('계약 제품 정보가 수정되었습니다')
+      triggerToast('계약 정보가 수정되었습니다')
     }
   } catch (err) {
     triggerToast(err?.message ?? '요청 처리 중 오류가 발생했습니다')
@@ -192,13 +196,13 @@ const showStatusConfirm = ref(false)
 const pendingStatusChange = ref(null) // { productId, productName, newStatus, label }
 
 function handleToggleStatus() {
-  const detail = vendor.selectedProductDetail
-  if (!detail || detail.status === 'expired') return
-  const newStatus = detail.status === 'active' ? 'suspended' : 'active'
-  const label = newStatus === 'active' ? '활성' : '정지'
+  const row = selectedRow.value
+  if (!row || !row.contracted || row.status === 'EXPIRED') return
+  const newStatus = row.status === 'ACTIVE' ? 'SUSPENDED' : 'ACTIVE'
+  const label = newStatus === 'ACTIVE' ? '활성' : '정지'
   pendingStatusChange.value = {
-    productId: detail.id,
-    productName: detail.productName,
+    vendorProductCode: row.vendorProductCode,
+    productName: row.productName,
     newStatus,
     label,
   }
@@ -209,7 +213,7 @@ async function confirmStatusChange() {
   const change = pendingStatusChange.value
   if (!change) return
   try {
-    await vendor.updateStatus(change.productId, change.newStatus)
+    await vendor.updateStatus(change.vendorProductCode, change.newStatus)
     triggerToast(`계약이 "${change.label}" 상태로 변경되었습니다`)
   } catch (err) {
     triggerToast(err?.message ?? '상태 변경에 실패했습니다')
@@ -225,27 +229,29 @@ function cancelStatusChange() {
 
 // --- 삭제 ---
 async function handleDeleteProduct() {
-  const detail = vendor.selectedProductDetail
-  if (!detail) return
-  if (!confirm(`[${detail.productName}] 계약을 삭제하시겠습니까?\n이 작업은 되돌릴 수 없습니다.`)) return
+  const row = selectedRow.value
+  if (!row || !row.contracted) return
+  if (!confirm(`[${row.productName}] 계약을 삭제하시겠습니까?\n이 작업은 되돌릴 수 없습니다.`)) return
   try {
-    await vendor.deleteProduct(detail.id)
-    triggerToast('계약 제품이 삭제되었습니다')
+    await vendor.deleteProduct(row.vendorProductCode)
+    triggerToast('계약이 삭제되었습니다')
   } catch (err) {
     triggerToast(err?.message ?? '삭제에 실패했습니다')
   }
 }
 
-// --- 상태 뱃지 헬퍼 ---
+// --- 상태 뱃지 헬퍼 (ContractRow.status 는 BE enum 대문자 또는 null=미정) ---
 function statusLabel(status) {
-  const map = { active: '활성', suspended: '정지', expired: '만료' }
+  if (!status) return '미정'
+  const map = { ACTIVE: '활성', SUSPENDED: '정지', EXPIRED: '만료', DELETED: '삭제' }
   return map[status] ?? status
 }
 
 function statusClass(status) {
-  if (status === 'active') return 'bg-emerald-50 text-emerald-700'
-  if (status === 'suspended') return 'bg-amber-50 text-amber-700'
-  if (status === 'expired') return 'bg-gray-100 text-gray-400'
+  if (!status) return 'bg-sky-50 text-sky-700' // 미정
+  if (status === 'ACTIVE') return 'bg-emerald-50 text-emerald-700'
+  if (status === 'SUSPENDED') return 'bg-amber-50 text-amber-700'
+  if (status === 'EXPIRED') return 'bg-gray-100 text-gray-400'
   return 'bg-gray-100 text-gray-400'
 }
 
@@ -464,15 +470,12 @@ const InfoIcon = IconBase([
             <span v-if="vendor.selectedVendor"> {{ vendor.selectedVendor.name }} — 계약 제품 </span>
             <span v-else>계약 제품 목록</span>
           </h2>
-          <button
+          <span
             v-if="vendor.selectedVendorId"
-            type="button"
-            class="inline-flex items-center gap-1 border border-white/30 px-2 py-1 text-[10px] font-black text-white hover:bg-white/10"
-            @click="openCreateModal"
+            class="text-[10px] font-bold text-white/60"
           >
-            <PlusIcon :size="12" />
-            계약 제품 추가
-          </button>
+            제품 마스터 자동 노출
+          </span>
         </div>
 
         <!-- 거래처 미선택 상태 -->
@@ -489,53 +492,58 @@ const InfoIcon = IconBase([
           </div>
         </div>
 
-        <!-- 계약 제품 테이블 -->
+        <!-- 계약 제품 테이블 (E 안 — ContractRow[]) -->
         <template v-else>
           <div class="overflow-auto flex-1">
-            <table class="w-full min-w-[560px] table-fixed border-collapse text-xs">
+            <table class="w-full min-w-[640px] table-fixed border-collapse text-xs">
               <thead
                 class="sticky top-0 z-10 bg-gray-100 text-[10px] uppercase tracking-wider text-gray-500"
               >
                 <tr>
-                  <th class="w-24 px-3 py-2 text-left font-black">제품 코드</th>
                   <th class="px-3 py-2 text-left font-black">제품명</th>
-                  <th class="w-24 px-3 py-2 text-right font-black">단가</th>
-                  <th class="w-16 px-3 py-2 text-right font-black">MOQ</th>
+                  <th class="w-20 px-3 py-2 text-left font-black">카테고리</th>
+                  <th class="w-24 px-3 py-2 text-right font-black">계약단가</th>
+                  <th class="w-14 px-3 py-2 text-right font-black">MOQ</th>
                   <th class="w-16 px-3 py-2 text-right font-black">납기(일)</th>
                   <th class="w-20 px-3 py-2 text-center font-black">상태</th>
                 </tr>
               </thead>
               <tbody class="divide-y divide-gray-100">
-                <tr v-if="vendor.currentVendorProducts.length === 0">
+                <tr v-if="vendor.contracts.length === 0">
                   <td colspan="6" class="py-12 text-center text-[11px] text-gray-400">
-                    등록된 계약 제품이 없습니다.
+                    이 거래처에 매핑된 제품 마스터가 없습니다.<br />
+                    제품 마스터 페이지에서 메인 거래처를 이 거래처로 지정해 등록하세요.
                   </td>
                 </tr>
 
                 <tr
-                  v-for="vp in vendor.currentVendorProducts"
-                  :key="vp.id"
+                  v-for="row in vendor.contracts"
+                  :key="row.productCode"
                   class="cursor-pointer transition-colors hover:bg-gray-50"
-                  :class="vendor.selectedProductId === vp.id ? 'bg-[#E6F2F0]' : ''"
-                  @click="handleSelectProduct(vp.id)"
+                  :class="selectedProductCode === row.productCode ? 'bg-[#E6F2F0]' : ''"
+                  @click="handleSelectRow(row.productCode)"
                 >
-                  <td class="px-3 py-2.5 font-bold text-gray-400">{{ vp.productCode }}</td>
                   <td class="truncate px-3 py-2.5 font-black text-gray-800">
-                    {{ vp.productName }}
+                    {{ row.productName }}
                   </td>
-                  <td class="px-3 py-2.5 text-right font-black text-gray-700">
-                    {{ formatPrice(vp.unitPrice) }}
+                  <td class="truncate px-3 py-2.5 font-bold text-gray-500">
+                    {{ row.categoryCode }}
                   </td>
-                  <td class="px-3 py-2.5 text-right font-bold text-gray-600">{{ vp.moq }}</td>
+                  <td class="px-3 py-2.5 text-right font-black text-gray-800">
+                    {{ row.contracted ? formatPrice(row.contractUnitPrice) : '—' }}
+                  </td>
                   <td class="px-3 py-2.5 text-right font-bold text-gray-600">
-                    {{ vp.leadTimeDays }}
+                    {{ row.contracted ? row.moq : '—' }}
+                  </td>
+                  <td class="px-3 py-2.5 text-right font-bold text-gray-600">
+                    {{ row.contracted ? row.leadTimeDays : '—' }}
                   </td>
                   <td class="px-3 py-2.5 text-center">
                     <span
                       class="inline-flex px-2 py-0.5 text-[10px] font-black"
-                      :class="statusClass(vp.status)"
+                      :class="statusClass(row.status)"
                     >
-                      {{ statusLabel(vp.status) }}
+                      {{ statusLabel(row.status) }}
                     </span>
                   </td>
                 </tr>
@@ -547,7 +555,9 @@ const InfoIcon = IconBase([
           <div
             class="border-t border-gray-200 bg-gray-50 px-3 py-2 text-[10px] font-bold text-gray-500"
           >
-            총 {{ vendor.currentVendorProducts.length }}건의 계약 제품
+            총 {{ vendor.contracts.length }}개 제품 ·
+            계약 {{ vendor.contracts.filter((r) => r.contracted).length }}건 ·
+            미정 {{ vendor.contracts.filter((r) => !r.contracted).length }}건
           </div>
         </template>
       </div>
@@ -568,16 +578,16 @@ const InfoIcon = IconBase([
           </h2>
         </div>
 
-        <!-- 제품 미선택 상태 -->
+        <!-- 행 미선택 상태 -->
         <div
-          v-if="!vendor.selectedProductDetail"
+          v-if="!selectedRow"
           class="flex flex-1 flex-col items-center justify-center gap-3 text-center text-gray-400"
         >
           <PackageIcon :size="36" class="opacity-20" />
           <div>
             <p class="text-sm font-black">제품을 선택해주세요</p>
             <p class="mt-1 text-xs">
-              계약 제품 목록에서 행을 선택하면<br />상세 조건이 표시됩니다.
+              제품 목록에서 행을 선택하면<br />상세 조건이 표시됩니다.
             </p>
           </div>
         </div>
@@ -585,71 +595,85 @@ const InfoIcon = IconBase([
         <!-- 상세 정보 -->
         <template v-else>
           <div class="flex flex-1 flex-col gap-4 overflow-y-auto p-4">
-            <!-- 제품 기본 정보 -->
+            <!-- 제품 기본 정보 (ProductMaster) -->
             <section class="space-y-2">
               <p class="text-[9px] font-black uppercase tracking-wider text-gray-400">제품 정보</p>
               <p class="text-sm font-black leading-snug text-gray-900">
-                {{ vendor.selectedProductDetail.productName }}
+                {{ selectedRow.productName }}
               </p>
               <div class="flex flex-wrap gap-1.5">
                 <span
                   class="border border-gray-200 bg-gray-100 px-2 py-0.5 text-[10px] font-bold text-gray-600"
                 >
-                  {{ vendor.selectedProductDetail.productCode }}
+                  {{ selectedRow.productCode }}
+                </span>
+                <span
+                  class="border border-gray-200 bg-gray-100 px-2 py-0.5 text-[10px] font-bold text-gray-600"
+                >
+                  {{ selectedRow.categoryCode }}
                 </span>
                 <span
                   class="px-2 py-0.5 text-[10px] font-black"
-                  :class="statusClass(vendor.selectedProductDetail.status)"
+                  :class="statusClass(selectedRow.status)"
                 >
-                  {{ statusLabel(vendor.selectedProductDetail.status) }}
+                  {{ statusLabel(selectedRow.status) }}
                 </span>
               </div>
+              <p class="text-[10px] font-bold text-gray-500">
+                기본단가 {{ formatPrice(selectedRow.basePrice) }}
+              </p>
             </section>
 
-            <!-- 계약 조건 -->
-            <section class="space-y-2.5">
-              <p class="text-[9px] font-black uppercase tracking-wider text-gray-400">계약 조건</p>
-
-              <div class="grid grid-cols-2 gap-2">
-                <div class="border border-gray-100 bg-gray-50 p-2.5">
-                  <p class="text-[9px] font-bold uppercase text-gray-400">계약 단가</p>
-                  <strong class="mt-1 block text-sm font-black text-[#004D3C]">
-                    {{ formatPrice(vendor.selectedProductDetail.unitPrice) }}
-                  </strong>
-                </div>
-                <div class="border border-gray-100 bg-gray-50 p-2.5">
-                  <p class="text-[9px] font-bold uppercase text-gray-400">최소 주문량 (MOQ)</p>
-                  <strong class="mt-1 block text-sm font-black text-gray-800">
-                    {{ vendor.selectedProductDetail.moq }} EA
-                  </strong>
-                </div>
-                <div class="border border-gray-100 bg-gray-50 p-2.5">
-                  <p class="text-[9px] font-bold uppercase text-gray-400">납기일수</p>
-                  <strong class="mt-1 block text-sm font-black text-gray-800">
-                    {{ vendor.selectedProductDetail.leadTimeDays }}일
-                  </strong>
-                </div>
-              </div>
+            <!-- 미정 안내 -->
+            <section
+              v-if="!selectedRow.contracted"
+              class="border border-sky-200 bg-sky-50 p-3 text-[11px] font-bold text-sky-700"
+            >
+              아직 계약 정보가 없는 제품입니다. 아래 [계약 등록] 으로 단가/MOQ/계약기간을 채우세요.
             </section>
 
-            <!-- 계약 기간 -->
-            <section class="space-y-2">
-              <p class="text-[9px] font-black uppercase tracking-wider text-gray-400">계약 기간</p>
-              <div class="space-y-1.5 text-xs font-bold text-gray-700">
-                <div class="flex justify-between">
-                  <span class="text-gray-400">시작일</span>
-                  <span>{{ vendor.selectedProductDetail.contractStart }}</span>
+            <!-- 계약 조건 (활성/일시중단/만료만) -->
+            <template v-if="selectedRow.contracted">
+              <section class="space-y-2.5">
+                <p class="text-[9px] font-black uppercase tracking-wider text-gray-400">계약 조건</p>
+                <div class="grid grid-cols-2 gap-2">
+                  <div class="border border-gray-100 bg-gray-50 p-2.5">
+                    <p class="text-[9px] font-bold uppercase text-gray-400">계약 단가</p>
+                    <strong class="mt-1 block text-sm font-black text-[#004D3C]">
+                      {{ formatPrice(selectedRow.contractUnitPrice) }}
+                    </strong>
+                  </div>
+                  <div class="border border-gray-100 bg-gray-50 p-2.5">
+                    <p class="text-[9px] font-bold uppercase text-gray-400">최소 주문량 (MOQ)</p>
+                    <strong class="mt-1 block text-sm font-black text-gray-800">
+                      {{ selectedRow.moq }} EA
+                    </strong>
+                  </div>
+                  <div class="border border-gray-100 bg-gray-50 p-2.5">
+                    <p class="text-[9px] font-bold uppercase text-gray-400">납기일수</p>
+                    <strong class="mt-1 block text-sm font-black text-gray-800">
+                      {{ selectedRow.leadTimeDays }}일
+                    </strong>
+                  </div>
                 </div>
-                <div class="flex justify-between">
-                  <span class="text-gray-400">종료일</span>
-                  <span
-                    :class="vendor.selectedProductDetail.status === 'expired' ? 'text-red-600' : ''"
-                  >
-                    {{ vendor.selectedProductDetail.contractEnd }}
-                  </span>
+              </section>
+
+              <section class="space-y-2">
+                <p class="text-[9px] font-black uppercase tracking-wider text-gray-400">계약 기간</p>
+                <div class="space-y-1.5 text-xs font-bold text-gray-700">
+                  <div class="flex justify-between">
+                    <span class="text-gray-400">시작일</span>
+                    <span>{{ selectedRow.contractStart }}</span>
+                  </div>
+                  <div class="flex justify-between">
+                    <span class="text-gray-400">종료일</span>
+                    <span :class="selectedRow.status === 'EXPIRED' ? 'text-red-600' : ''">
+                      {{ selectedRow.contractEnd }}
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </section>
+              </section>
+            </template>
 
             <!-- 거래처 담당자 정보 -->
             <section v-if="vendor.selectedVendor" class="space-y-2 border-t border-gray-100 pt-3">
@@ -664,48 +688,64 @@ const InfoIcon = IconBase([
             </section>
           </div>
 
-          <!-- 액션 버튼 영역 -->
+          <!-- 액션 버튼 영역 — 미정/활성 분기 -->
           <div class="flex flex-col gap-2 border-t border-gray-200 p-3">
+            <!-- 미정 행: 계약 등록 -->
             <button
+              v-if="!selectedRow.contracted"
+              type="button"
+              class="inline-flex w-full items-center justify-center gap-1.5 border border-[#004D3C] bg-[#004D3C] px-3 py-2 text-[11px] font-black text-white transition-colors hover:bg-[#1f4b3a]"
+              @click="openCreateModal"
+            >
+              <PlusIcon :size="13" />
+              계약 등록
+            </button>
+
+            <!-- 활성 행: 수정 -->
+            <button
+              v-if="selectedRow.contracted"
               type="button"
               class="inline-flex w-full items-center justify-center gap-1.5 border px-3 py-2 text-[11px] font-black transition-colors"
               :class="
-                vendor.selectedProductDetail.status === 'expired'
+                selectedRow.status === 'EXPIRED'
                   ? 'cursor-not-allowed border-gray-200 bg-gray-50 text-gray-300'
                   : 'border-[#004D3C] bg-[#004D3C] text-white hover:bg-[#1f4b3a]'
               "
-              :disabled="vendor.selectedProductDetail.status === 'expired'"
+              :disabled="selectedRow.status === 'EXPIRED'"
               @click="openEditModal"
             >
               <PencilIcon :size="13" />
-              {{ vendor.selectedProductDetail.status === 'expired' ? '만료됨 (수정 불가)' : '수정' }}
+              {{ selectedRow.status === 'EXPIRED' ? '만료됨 (수정 불가)' : '수정' }}
             </button>
 
+            <!-- 활성 행: 상태 변경 -->
             <button
+              v-if="selectedRow.contracted"
               type="button"
               class="inline-flex w-full items-center justify-center gap-1.5 border px-3 py-2 text-[11px] font-black transition-colors"
               :class="
-                vendor.selectedProductDetail.status === 'active'
+                selectedRow.status === 'ACTIVE'
                   ? 'border-amber-300 bg-amber-50 text-amber-700 hover:bg-amber-100'
-                  : vendor.selectedProductDetail.status === 'expired'
+                  : selectedRow.status === 'EXPIRED'
                     ? 'cursor-not-allowed border-gray-200 bg-gray-50 text-gray-300'
                     : 'border-emerald-300 bg-emerald-50 text-emerald-700 hover:bg-emerald-100'
               "
-              :disabled="vendor.selectedProductDetail.status === 'expired'"
+              :disabled="selectedRow.status === 'EXPIRED'"
               @click="handleToggleStatus"
             >
-              <ToggleRightIcon v-if="vendor.selectedProductDetail.status === 'active'" :size="13" />
+              <ToggleRightIcon v-if="selectedRow.status === 'ACTIVE'" :size="13" />
               <ToggleLeftIcon v-else :size="13" />
               {{
-                vendor.selectedProductDetail.status === 'active'
+                selectedRow.status === 'ACTIVE'
                   ? '계약 정지'
-                  : vendor.selectedProductDetail.status === 'suspended'
+                  : selectedRow.status === 'SUSPENDED'
                     ? '계약 활성화'
                     : '만료됨 (변경 불가)'
               }}
             </button>
 
             <button
+              v-if="selectedRow.contracted"
               type="button"
               class="inline-flex w-full items-center justify-center gap-1.5 border border-red-300 bg-red-50 px-3 py-2 text-[11px] font-black text-red-700 hover:bg-red-100"
               @click="handleDeleteProduct"
@@ -730,7 +770,7 @@ const InfoIcon = IconBase([
         <!-- 모달 헤더 -->
         <div class="flex items-center justify-between bg-[#004D3C] px-4 py-3 text-white">
           <h3 class="text-[11px] font-black uppercase tracking-wider">
-            {{ modalMode === 'create' ? '계약 제품 추가' : '계약 제품 수정' }}
+            {{ modalMode === 'create' ? '계약 등록' : '계약 수정' }}
           </h3>
           <button type="button" class="p-1 hover:bg-white/10" @click="closeModal">
             <XIcon :size="16" />
@@ -739,41 +779,14 @@ const InfoIcon = IconBase([
 
         <!-- 모달 본문 -->
         <div class="p-4 space-y-3">
-          <label class="flex flex-col gap-1">
-            <span class="text-[10px] font-black uppercase text-gray-400">제품 코드</span>
-            <input
-              v-model="formData.productCode"
-              type="text"
-              placeholder="ITM-XXXX"
-              class="border bg-gray-50 px-3 py-2 text-xs outline-none focus:bg-white"
-              :class="
-                formErrors.productCode
-                  ? 'border-red-400 focus:border-red-500'
-                  : 'border-gray-300 focus:border-[#004D3C]'
-              "
-            />
-            <p v-if="formErrors.productCode" class="mt-1 text-[10px] font-bold text-red-600">
-              {{ formErrors.productCode }}
+          <!-- 제품 정보 read-only (ProductMaster 가 진실 원천) -->
+          <div v-if="selectedRow" class="border border-gray-100 bg-gray-50 p-3">
+            <p class="text-[9px] font-black uppercase tracking-wider text-gray-400">제품</p>
+            <p class="mt-1 text-sm font-black text-gray-900">{{ selectedRow.productName }}</p>
+            <p class="mt-0.5 text-[10px] font-bold text-gray-500">
+              {{ selectedRow.productCode }} · {{ selectedRow.categoryCode }} · 기본단가 {{ formatPrice(selectedRow.basePrice) }}
             </p>
-          </label>
-
-          <label class="flex flex-col gap-1">
-            <span class="text-[10px] font-black uppercase text-gray-400">제품명</span>
-            <input
-              v-model="formData.productName"
-              type="text"
-              placeholder="제품명을 입력하세요"
-              class="border bg-gray-50 px-3 py-2 text-xs outline-none focus:bg-white"
-              :class="
-                formErrors.productName
-                  ? 'border-red-400 focus:border-red-500'
-                  : 'border-gray-300 focus:border-[#004D3C]'
-              "
-            />
-            <p v-if="formErrors.productName" class="mt-1 text-[10px] font-bold text-red-600">
-              {{ formErrors.productName }}
-            </p>
-          </label>
+          </div>
 
           <div class="grid grid-cols-3 gap-3">
             <label class="flex flex-col gap-1">


### PR DESCRIPTION
## 📌 요약
- 거래처 화면 우측 패널을 `mainVendorCode` 매칭 ProductMaster 표로 재정의
- `productCode` 자유 입력 폐기, 마스터 행 클릭 기반 [계약 등록] / [수정] 흐름으로 단순화

<br><br>

## 🎯 작업 내용
- **우측 패널 재정의**
  - 별도 [신규 등록] 액션 제거 → 마스터 제품이 행으로 자동 등장
  - 행 클릭 시 미정 / 활성 분기에 따라 [계약 등록] 또는 [수정] 노출
- **입력 폼 단순화**
  - `productCode` 자유 입력 / `productName` 입력 폐기
  - 선택 행의 마스터 정보는 read-only 헤더로 노출
  - 단가 / MOQ / 계약 기간만 입력 폼으로 유지 (계약 디테일에 집중)
- **표 컬럼 정리**
  - 제품명 / 카테고리 / 계약단가 / MOQ / 납기 / 상태 6열로 축소
  - 기본단가는 우측 디테일에 참고값으로 노출 → 가로 폭 부담 완화
- **데이터 단일 출처화**
  - `getContracts` axios + `fetchContracts` store 액션 신규
  - mutation 후 재조회로 정합 유지

<br><br>

## ✔️ 참고 사항
- 마스터에 거래처가 이미 결정되므로 등록 단계 인지 부담 / 중복 등록 여지 제거
- 마크업 재정의 외 검증 로직 변경 없음 — BE 검증 강화는 별도 PR

<br><br>

## ✔️ 관련 이슈
- Close #299 

<br><br>