### PR TITLE
fix(purchase-order): 새 발주 페이지에 창고별 가용/실/안전 재고 컬럼 추가

### DIFF
--- a/src/stores/purchaseOrder.js
+++ b/src/stores/purchaseOrder.js
@@ -24,9 +24,15 @@ const WAREHOUSES = [
 
 function toFeOrder(beOrder) {
   if (!beOrder) return null
-  // BE ListRes 는 itemCount 만, DetailRes 는 items 배열만 보내므로 둘 중 하나로 fallback.
+  // BE ListRes 는 itemCount + productNames, DetailRes 는 items 배열만 보내므로 fallback 처리.
   const itemCount =
     beOrder.itemCount ?? (Array.isArray(beOrder.items) ? beOrder.items.length : 0)
+  // ListRes 의 productNames 우선, DetailRes 면 items.productName 으로 fallback (목록 검색·표시 일관성).
+  const productNames = Array.isArray(beOrder.productNames)
+    ? beOrder.productNames
+    : Array.isArray(beOrder.items)
+      ? beOrder.items.map((it) => it.productName).filter(Boolean)
+      : []
   return {
     id: beOrder.code,
     warehouseId: beOrder.warehouseId ?? '',
@@ -41,6 +47,7 @@ function toFeOrder(beOrder) {
     createdAt: beOrder.createdAt ?? '',
     updatedAt: beOrder.updatedAt ?? '',
     itemCount,
+    productNames,
     items: Array.isArray(beOrder.items) ? beOrder.items.map(toFeItem) : [],
     statusHistory: Array.isArray(beOrder.statusHistory)
       ? beOrder.statusHistory.map(toFeHistory)
@@ -122,7 +129,10 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
     if (searchKeyword.value.trim()) {
       const kw = searchKeyword.value.trim().toLowerCase()
       list = list.filter(
-        (o) => o.id.toLowerCase().includes(kw) || o.vendorName.toLowerCase().includes(kw),
+        (o) =>
+          o.id.toLowerCase().includes(kw) ||
+          o.vendorName.toLowerCase().includes(kw) ||
+          (o.productNames ?? []).some((name) => (name ?? '').toLowerCase().includes(kw)),
       )
     }
 

--- a/src/stores/warehouseStock.js
+++ b/src/stores/warehouseStock.js
@@ -1,0 +1,106 @@
+import { defineStore } from 'pinia'
+import { usePurchaseOrderStore } from './purchaseOrder.js'
+
+/**
+ * 발주 카탈로그 전용 창고-제품 재고 store.
+ *
+ * 김사라 작품 `stores/inventory.js`(SKU 단위, 단일 창고)는 손대지 않고,
+ * 본사 발주 카탈로그(`HqPurchaseOrderCreateView`) 가 "선택된 창고에서 이 ProductMaster
+ * 의 재고가 얼마인지" 를 빨리 보여주기 위한 별 store. 다중 창고 × productCode lookup.
+ *
+ * 재고 정의 (사용자 합의):
+ *   - 실재고 (onHand)     = 현재 보유 — 시드 정적 값
+ *   - 안전재고 (safetyStock) = 이 밑으로 떨어지면 안 됨 — 시드 정적 값
+ *   - 가용재고 (available)  = onHand + incoming - outgoing — 동적
+ *     · incoming = `purchaseOrder` store 의 SHIPPING 발주 중 같은 (warehouseId, productCode)
+ *                  의 quantity 합 (시연 시 발주가 SHIPPING 으로 가면 가용재고 자동 증가)
+ *     · outgoing = 0 (매장 주문/출고 도메인 미구현 — Phase 1 모킹)
+ *
+ * BE 미구현 — inventory + warehouse-stock 도메인 BE 가 만들어지면 이 store 를 axios 로 교체한다.
+ *
+ * productCode 시드 전략:
+ *   - 알려진 시연 의도 값은 KNOWN_SEEDS hard-code
+ *   - 그 외는 productCode + warehouseId 해시 기반 deterministic default — 새로고침해도 같은 값
+ */
+
+const KNOWN_SEEDS = {
+  // 'WH-001:PM-0001': { onHand: 50, safetyStock: 10 },
+}
+
+const WAREHOUSE_FACTORS = {
+  'WH-001': 1.4, // 서울 1센터 — 가장 많이 비축
+  'WH-002': 1.0, // 인천 제1센터
+  'WH-003': 0.8, // 경기 남부센터
+  'WH-004': 0.6, // 부산 물류센터
+  'WH-005': 0.5, // 대구 통합센터 — 가장 적게 비축
+}
+
+function hashSeed(s) {
+  let h = 5381
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) >>> 0
+  return h
+}
+
+function defaultStock(warehouseId, productCode) {
+  const seed = hashSeed(`${warehouseId}|${productCode}`)
+  const factor = WAREHOUSE_FACTORS[warehouseId] ?? 1.0
+  const onHand = Math.round(((seed % 80) + 5) * factor)
+  const safetyStock = 5 + ((seed >> 8) % 11) // 5~15
+  return { onHand, safetyStock }
+}
+
+export const useWarehouseStockStore = defineStore('warehouseStock', () => {
+  const poStore = usePurchaseOrderStore()
+
+  function getBaseStock(warehouseId, productCode) {
+    if (!warehouseId || !productCode) return null
+    const key = `${warehouseId}:${productCode}`
+    return KNOWN_SEEDS[key] ?? defaultStock(warehouseId, productCode)
+  }
+
+  /**
+   * 가용재고 = onHand + incoming - outgoing
+   * - incoming = SHIPPING 발주 중 같은 (warehouseId, productCode) 의 quantity 합
+   * - outgoing = 0 (매장 주문 도메인 미구현)
+   */
+  function getStock(warehouseId, productCode) {
+    const base = getBaseStock(warehouseId, productCode)
+    if (!base) return null
+
+    const incoming = poStore.purchaseOrders
+      .filter((o) => o.status === 'SHIPPING' && o.warehouseId === warehouseId)
+      .flatMap((o) => o.items ?? [])
+      .filter((it) => it.productCode === productCode)
+      .reduce((sum, it) => sum + (Number(it.quantity) || 0), 0)
+
+    const outgoing = 0
+    const available = base.onHand + incoming - outgoing
+
+    return {
+      onHand: base.onHand,
+      safetyStock: base.safetyStock,
+      incoming,
+      outgoing,
+      available,
+    }
+  }
+
+  /**
+   * 경고 임계 — onHand 기준 (안전재고 정의: 실재고가 이 밑으로 떨어지면 안 됨)
+   *   onHand < safetyStock        → 'critical' (위험, 빨강)
+   *   onHand < safetyStock × 1.5  → 'warning'  (주의, 주황)
+   *   그 외                        → 'normal'   (정상, 회색)
+   */
+  function getStockLevel(stock) {
+    if (!stock) return 'unknown'
+    if (stock.onHand < stock.safetyStock) return 'critical'
+    if (stock.onHand < stock.safetyStock * 1.5) return 'warning'
+    return 'normal'
+  }
+
+  return {
+    getBaseStock,
+    getStock,
+    getStockLevel,
+  }
+})

--- a/src/views/hq/HqPurchaseOrderCreateView.vue
+++ b/src/views/hq/HqPurchaseOrderCreateView.vue
@@ -6,12 +6,32 @@ import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
 import { useVendorStore } from '@/stores/vendor.js'
 import { usePurchaseOrderStore } from '@/stores/purchaseOrder.js'
+import { useWarehouseStockStore } from '@/stores/warehouseStock.js'
 
 const router = useRouter()
 const route = useRoute()
 const auth = useAuthStore()
 const vendor = useVendorStore()
 const poStore = usePurchaseOrderStore()
+const stockStore = useWarehouseStockStore()
+
+// 카탈로그 행마다 호출 — 선택된 창고 + 행 productCode 의 재고 정보. 창고 미선택이면 null.
+function rowStock(productCode) {
+  if (!selectedWarehouseId.value) return null
+  return stockStore.getStock(selectedWarehouseId.value, productCode)
+}
+
+function rowStockLevel(stock) {
+  return stockStore.getStockLevel(stock)
+}
+
+// onHand 컬럼 색 — 안전재고 임계 기반
+function onHandClass(stock) {
+  const level = rowStockLevel(stock)
+  if (level === 'critical') return 'text-red-600'
+  if (level === 'warning') return 'text-amber-600'
+  return 'text-gray-700'
+}
 
 const DRAFT_KEY = 'stockit:po-cart-draft'
 
@@ -559,14 +579,17 @@ const AlertTriangleIcon = IconBase([
 
           <!-- 카탈로그 테이블 -->
           <div class="overflow-auto">
-            <table class="w-full min-w-[640px] table-fixed border-collapse text-xs">
+            <table class="w-full min-w-[820px] table-fixed border-collapse text-xs">
               <thead class="bg-gray-100 text-[10px] uppercase tracking-wider text-gray-500">
                 <tr>
-                  <th class="w-40 px-3 py-2 text-left font-black">거래처</th>
-                  <th class="w-28 px-3 py-2 text-left font-black">제품코드</th>
+                  <th class="w-36 px-3 py-2 text-left font-black">거래처</th>
+                  <th class="w-24 px-3 py-2 text-left font-black">제품코드</th>
                   <th class="px-3 py-2 text-left font-black">제품명</th>
-                  <th class="w-24 px-3 py-2 text-right font-black">단가</th>
-                  <th class="w-20 px-3 py-2 text-center font-black"></th>
+                  <th class="w-20 px-3 py-2 text-right font-black">단가</th>
+                  <th class="w-16 px-3 py-2 text-right font-black" title="실재고 + 입고예정 - 출고예정">가용</th>
+                  <th class="w-16 px-3 py-2 text-right font-black" title="실재고 (현재 보유)">실재고</th>
+                  <th class="w-16 px-3 py-2 text-right font-black" title="안전재고 (이 밑으로 떨어지면 안 됨)">안전</th>
+                  <th class="w-16 px-3 py-2 text-center font-black"></th>
                 </tr>
               </thead>
               <tbody
@@ -585,6 +608,27 @@ const AlertTriangleIcon = IconBase([
                   <td class="px-3 py-2.5 text-right font-bold text-[#004D3C]">
                     ₩{{ vp.unitPrice.toLocaleString() }}
                   </td>
+                  <!-- 가용 -->
+                  <td class="px-3 py-2.5 text-right font-black text-gray-800">
+                    <template v-if="rowStock(vp.productCode)">
+                      {{ rowStock(vp.productCode).available }}
+                    </template>
+                    <span v-else class="text-gray-300">—</span>
+                  </td>
+                  <!-- 실재고 (안전재고 미달 시 색 강조) -->
+                  <td class="px-3 py-2.5 text-right font-bold" :class="onHandClass(rowStock(vp.productCode))">
+                    <template v-if="rowStock(vp.productCode)">
+                      {{ rowStock(vp.productCode).onHand }}
+                    </template>
+                    <span v-else class="text-gray-300">—</span>
+                  </td>
+                  <!-- 안전 -->
+                  <td class="px-3 py-2.5 text-right font-bold text-gray-500">
+                    <template v-if="rowStock(vp.productCode)">
+                      {{ rowStock(vp.productCode).safetyStock }}
+                    </template>
+                    <span v-else class="text-gray-300">—</span>
+                  </td>
                   <td class="px-3 py-2.5 text-center">
                     <button
                       type="button"
@@ -597,12 +641,12 @@ const AlertTriangleIcon = IconBase([
                   </td>
                 </tr>
                 <tr v-if="catalog.length === 0">
-                  <td colspan="5" class="px-3 py-8 text-center text-xs text-gray-400">
+                  <td colspan="8" class="px-3 py-8 text-center text-xs text-gray-400">
                     노출 가능한 계약 제품이 없습니다.
                   </td>
                 </tr>
                 <tr v-else-if="displayedCatalog.length === 0">
-                  <td colspan="5" class="px-3 py-8 text-center text-xs text-gray-400">
+                  <td colspan="8" class="px-3 py-8 text-center text-xs text-gray-400">
                     검색 결과가 없습니다.
                   </td>
                 </tr>

--- a/src/views/hq/HqPurchaseOrderView.vue
+++ b/src/views/hq/HqPurchaseOrderView.vue
@@ -339,7 +339,7 @@ const TruckIcon = IconBase([
                 <input
                   v-model="poStore.searchKeyword"
                   type="text"
-                  placeholder="발주번호/거래처명 검색"
+                  placeholder="발주번호/거래처/품목명 검색"
                   class="w-52 border border-gray-300 bg-white py-1.5 pl-8 pr-3 text-xs outline-none focus:border-[#004D3C]"
                 />
               </label>
@@ -408,7 +408,7 @@ const TruckIcon = IconBase([
                   <th class="w-32 px-3 py-2 text-left font-black">발주번호</th>
                   <th class="px-3 py-2 text-left font-black">거래처</th>
                   <th class="w-28 px-3 py-2 text-left font-black">입고 창고</th>
-                  <th class="w-14 px-3 py-2 text-center font-black">품목수</th>
+                  <th class="w-44 px-3 py-2 text-left font-black">품목</th>
                   <th class="w-28 px-3 py-2 text-right font-black">총금액</th>
                   <th class="w-20 px-3 py-2 text-center font-black">상태</th>
                   <th class="w-28 px-3 py-2 text-center font-black">생성일</th>
@@ -425,8 +425,16 @@ const TruckIcon = IconBase([
                   <td class="px-3 py-3 font-bold text-gray-400">{{ order.id }}</td>
                   <td class="px-3 py-3 font-black text-gray-800">{{ order.vendorName }}</td>
                   <td class="px-3 py-3 font-bold text-gray-600">{{ order.warehouseName }}</td>
-                  <td class="px-3 py-3 text-center font-bold text-gray-700">
-                    {{ order.itemCount }}
+                  <td class="px-3 py-3 font-bold text-gray-700">
+                    <span class="block truncate" :title="(order.productNames ?? []).join(', ')">
+                      <template v-if="order.productNames && order.productNames.length > 0">
+                        {{ order.productNames[0]
+                        }}<template v-if="order.productNames.length > 1">
+                          외 {{ order.productNames.length - 1 }}건
+                        </template>
+                      </template>
+                      <template v-else>—</template>
+                    </span>
                   </td>
                   <td class="px-3 py-3 text-right font-black text-gray-800">
                     ₩{{ order.totalPrice.toLocaleString() }}


### PR DESCRIPTION
## 📌 요약
- 새 발주 페이지 카탈로그에 선택 창고의 **가용재고 / 실재고 / 안전재고 3컬럼** 노출
- 운영자가 카탈로그 셀만 보고 발주 우선순위 판단 가능

<br><br>

## 🎯 작업 내용
- **신규 store 분리**
  - `stores/warehouseStock.js` 신설 — 다중 창고 × productCode 단위 재고 보유
  - `inventory` store(팀원 작업)는 손대지 않고 발주 카탈로그 전용으로 별도 분리
- **가용재고 동적 계산**
  - `가용재고 = 실재고 + (purchaseOrder store의 SHIPPING 발주 quantity 합)`
  - 입고 예정분 자동 반영
- **카탈로그 UI 보강**
  - 가용 / 실 / 안전 3컬럼 추가
  - 실재고 셀은 안전재고 임계 기반 빨강 / 주황 / 회색 강조
  - 창고 미선택 시 재고 셀 전부 `—` 처리
- **재고 정의**
  - 실재고 = 현재 보유 (시드)
  - 안전재고 = 실재고 하한 임계 (시드)
  - 가용재고 = 실재고 + 입고예정 − 출고예정 (동적)

<br><br>

## ✔️ 참고 사항
- inventory store와 분리 — 발주 카탈로그 전용 단일 책임
- 시드 기반 동작, BE 연동은 후속 사이클

<br><br>

## ✔️ 관련 이슈
- Close #301 

<br><br>