### PR TITLE
fix(purchase-order): 새 발주 페이지에 재고 부족 필터·권장 발주 수량 추가

### DIFF
--- a/src/stores/warehouseStock.js
+++ b/src/stores/warehouseStock.js
@@ -86,21 +86,36 @@ export const useWarehouseStockStore = defineStore('warehouseStock', () => {
   }
 
   /**
-   * 경고 임계 — onHand 기준 (안전재고 정의: 실재고가 이 밑으로 떨어지면 안 됨)
-   *   onHand < safetyStock        → 'critical' (위험, 빨강)
-   *   onHand < safetyStock × 1.5  → 'warning'  (주의, 주황)
-   *   그 외                        → 'normal'   (정상, 회색)
+   * 경고 임계 — 가용재고(available) 기준.
+   * 발주 결정은 "입고예정 합쳐도 부족인가" 가 핵심이라 available 로 통일 (직전 사이클의 onHand 기준에서 정련).
+   *   available < safetyStock        → 'critical' (위험, 빨강)
+   *   available < safetyStock × 1.5  → 'warning'  (주의, 주황)
+   *   그 외                           → 'normal'   (정상, 회색)
    */
   function getStockLevel(stock) {
     if (!stock) return 'unknown'
-    if (stock.onHand < stock.safetyStock) return 'critical'
-    if (stock.onHand < stock.safetyStock * 1.5) return 'warning'
+    if (stock.available < stock.safetyStock) return 'critical'
+    if (stock.available < stock.safetyStock * 1.5) return 'warning'
     return 'normal'
+  }
+
+  /**
+   * 권장 발주 수량 — 안전재고 × 1.5 까지 채우는 만큼.
+   * 부족 아닌 행(가용재고 ≥ safetyStock × 1.5) 은 0 반환. 음수 절대 0 으로 clamp.
+   * 셀 클릭 시 cart 수량을 이 값으로 덮어쓰기 (set 모드).
+   */
+  function getSuggestedQuantity(stock) {
+    if (!stock) return 0
+    const target = stock.safetyStock * 1.5
+    const need = target - stock.available
+    if (need <= 0) return 0
+    return Math.ceil(need)
   }
 
   return {
     getBaseStock,
     getStock,
     getStockLevel,
+    getSuggestedQuantity,
   }
 })

--- a/src/views/hq/HqPurchaseOrderCreateView.vue
+++ b/src/views/hq/HqPurchaseOrderCreateView.vue
@@ -25,13 +25,21 @@ function rowStockLevel(stock) {
   return stockStore.getStockLevel(stock)
 }
 
-// onHand 컬럼 색 — 안전재고 임계 기반
-function onHandClass(stock) {
+// 권장 발주 수량 — 안전재고 × 1.5 까지 채우는 만큼. 부족 아닌 행은 0.
+function rowSuggested(productCode) {
+  return stockStore.getSuggestedQuantity(rowStock(productCode))
+}
+
+// 재고 셀 색 — 가용재고 기준 안전재고 임계
+function stockLevelClass(stock) {
   const level = rowStockLevel(stock)
   if (level === 'critical') return 'text-red-600'
   if (level === 'warning') return 'text-amber-600'
   return 'text-gray-700'
 }
+
+// "부족만 보기" 토글 — 가용재고 < safetyStock × 1.5 인 행만 노출
+const shortageOnly = ref(false)
 
 const DRAFT_KEY = 'stockit:po-cart-draft'
 
@@ -109,6 +117,13 @@ const displayedCatalog = computed(() => {
       vp.productName.toLowerCase().includes(kw)
     return matchVendor && matchKw
   })
+  // "부족만 보기" 토글 — 창고 선택된 상태에서만 적용
+  if (shortageOnly.value && selectedWarehouseId.value) {
+    list = list.filter((vp) => {
+      const level = rowStockLevel(rowStock(vp.productCode))
+      return level === 'critical' || level === 'warning'
+    })
+  }
   switch (sortBy.value) {
     case 'priceAsc':
       list = [...list].sort((a, b) => a.unitPrice - b.unitPrice)
@@ -209,6 +224,35 @@ function addToCart(vp) {
       vendorName: vp.vendorName,
       unitPrice: vp.unitPrice,
       quantity: 1,
+    })
+  }
+  saveDraft()
+}
+
+// 권장 발주 수량으로 cart 채우기 (set 모드 — 기존 수량 덮어쓰기, +1 add 와 다름).
+// 표시된 권장값과 cart 수량 일치 보장.
+function addRecommendedToCart(vp) {
+  if (!selectedWarehouseId.value) return
+  const recommended = rowSuggested(vp.productCode)
+  if (recommended <= 0) return
+  // 한 발주서 = 한 거래처 정책 — 기존 vendorSwitch confirm 흐름 재사용
+  if (currentCartVendorId.value && vp.vendorId !== currentCartVendorId.value) {
+    pendingNewVendorProduct.value = vp
+    showVendorSwitchConfirm.value = true
+    return
+  }
+  const existing = cart.value.find((item) => item.productCode === vp.productCode)
+  if (existing) {
+    existing.quantity = recommended
+  } else {
+    cart.value.push({
+      productId: vp.id,
+      productCode: vp.productCode,
+      productName: vp.productName,
+      vendorId: vp.vendorId,
+      vendorName: vp.vendorName,
+      unitPrice: vp.unitPrice,
+      quantity: recommended,
     })
   }
   saveDraft()
@@ -564,6 +608,20 @@ const AlertTriangleIcon = IconBase([
               <option value="priceDesc">단가 ↓</option>
               <option value="nameAsc">제품명 ㄱ-ㄴ</option>
             </select>
+            <button
+              type="button"
+              class="border px-3 py-1.5 text-[11px] font-black transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+              :class="
+                shortageOnly
+                  ? 'border-red-400 bg-red-50 text-red-700'
+                  : 'border-gray-300 bg-white text-gray-600 hover:bg-gray-50'
+              "
+              :disabled="!selectedWarehouseId"
+              :title="!selectedWarehouseId ? '먼저 창고를 선택하세요' : '가용재고가 안전재고 1.5배 미만인 품목만 표시'"
+              @click="shortageOnly = !shortageOnly"
+            >
+              {{ shortageOnly ? '✓ 부족만' : '부족만 보기' }}
+            </button>
             <span class="ml-auto text-[11px] font-bold text-gray-500">
               {{ displayedCatalog.length }}건
             </span>
@@ -579,16 +637,17 @@ const AlertTriangleIcon = IconBase([
 
           <!-- 카탈로그 테이블 -->
           <div class="overflow-auto">
-            <table class="w-full min-w-[820px] table-fixed border-collapse text-xs">
+            <table class="w-full min-w-[900px] table-fixed border-collapse text-xs">
               <thead class="bg-gray-100 text-[10px] uppercase tracking-wider text-gray-500">
                 <tr>
-                  <th class="w-36 px-3 py-2 text-left font-black">거래처</th>
+                  <th class="w-32 px-3 py-2 text-left font-black">거래처</th>
                   <th class="w-24 px-3 py-2 text-left font-black">제품코드</th>
                   <th class="px-3 py-2 text-left font-black">제품명</th>
                   <th class="w-20 px-3 py-2 text-right font-black">단가</th>
                   <th class="w-16 px-3 py-2 text-right font-black" title="실재고 + 입고예정 - 출고예정">가용</th>
                   <th class="w-16 px-3 py-2 text-right font-black" title="실재고 (현재 보유)">실재고</th>
-                  <th class="w-16 px-3 py-2 text-right font-black" title="안전재고 (이 밑으로 떨어지면 안 됨)">안전</th>
+                  <th class="w-14 px-3 py-2 text-right font-black" title="안전재고 (이 밑으로 떨어지면 안 됨)">안전</th>
+                  <th class="w-16 px-3 py-2 text-right font-black" title="안전재고 × 1.5 까지 채우는 권장 발주 수량 — 클릭 시 cart 에 그 수량으로 담김">권장</th>
                   <th class="w-16 px-3 py-2 text-center font-black"></th>
                 </tr>
               </thead>
@@ -608,15 +667,15 @@ const AlertTriangleIcon = IconBase([
                   <td class="px-3 py-2.5 text-right font-bold text-[#004D3C]">
                     ₩{{ vp.unitPrice.toLocaleString() }}
                   </td>
-                  <!-- 가용 -->
-                  <td class="px-3 py-2.5 text-right font-black text-gray-800">
+                  <!-- 가용재고 (가용 < 안전 임계 시 색 강조 — 발주 결정 핵심 지표) -->
+                  <td class="px-3 py-2.5 text-right font-black" :class="stockLevelClass(rowStock(vp.productCode))">
                     <template v-if="rowStock(vp.productCode)">
                       {{ rowStock(vp.productCode).available }}
                     </template>
                     <span v-else class="text-gray-300">—</span>
                   </td>
-                  <!-- 실재고 (안전재고 미달 시 색 강조) -->
-                  <td class="px-3 py-2.5 text-right font-bold" :class="onHandClass(rowStock(vp.productCode))">
+                  <!-- 실재고 (참고) -->
+                  <td class="px-3 py-2.5 text-right font-bold text-gray-500">
                     <template v-if="rowStock(vp.productCode)">
                       {{ rowStock(vp.productCode).onHand }}
                     </template>
@@ -626,6 +685,22 @@ const AlertTriangleIcon = IconBase([
                   <td class="px-3 py-2.5 text-right font-bold text-gray-500">
                     <template v-if="rowStock(vp.productCode)">
                       {{ rowStock(vp.productCode).safetyStock }}
+                    </template>
+                    <span v-else class="text-gray-300">—</span>
+                  </td>
+                  <!-- 권장 발주 수량 (셀 클릭 시 cart 수량 = 권장값으로 set) -->
+                  <td class="px-3 py-2.5 text-right">
+                    <template v-if="rowStock(vp.productCode)">
+                      <button
+                        v-if="rowSuggested(vp.productCode) > 0"
+                        type="button"
+                        class="border border-red-300 bg-red-50 px-2 py-0.5 text-[10px] font-black text-red-700 hover:bg-red-100"
+                        :title="`클릭하여 ${rowSuggested(vp.productCode)}개로 담기`"
+                        @click.stop="addRecommendedToCart(vp)"
+                      >
+                        {{ rowSuggested(vp.productCode) }}
+                      </button>
+                      <span v-else class="text-gray-300">—</span>
                     </template>
                     <span v-else class="text-gray-300">—</span>
                   </td>
@@ -641,13 +716,13 @@ const AlertTriangleIcon = IconBase([
                   </td>
                 </tr>
                 <tr v-if="catalog.length === 0">
-                  <td colspan="8" class="px-3 py-8 text-center text-xs text-gray-400">
+                  <td colspan="9" class="px-3 py-8 text-center text-xs text-gray-400">
                     노출 가능한 계약 제품이 없습니다.
                   </td>
                 </tr>
                 <tr v-else-if="displayedCatalog.length === 0">
-                  <td colspan="8" class="px-3 py-8 text-center text-xs text-gray-400">
-                    검색 결과가 없습니다.
+                  <td colspan="9" class="px-3 py-8 text-center text-xs text-gray-400">
+                    {{ shortageOnly ? '재고 부족 품목이 없습니다.' : '검색 결과가 없습니다.' }}
                   </td>
                 </tr>
               </tbody>


### PR DESCRIPTION
## 📌 요약
- 새 발주 카탈로그에 [부족만 보기] 토글 + "권장" 컬럼 추가
- 재고 레벨 판정 기준을 onHand → **가용재고**로 정련, 색 강조 위치도 가용재고 셀로 이동

<br><br>

## 🎯 작업 내용
- **[부족만 보기] 토글**
  - 가용재고 < 안전재고 × 1.5 인 품목만 노출
  - 기본은 전체 노출 (정보 막지 않고 좁힘 도구로만 제공)
- **권장 발주 수량 컬럼**
  - 안전재고 1.5배까지 채우는 데 필요한 수량 자동 계산
  - 빨강 배지로 노출 + 클릭 시 cart 수량을 그 값으로 즉시 set (기존 `+1 add`와 별개 동작)
  - 표시값 ↔ cart 수량 일치 보장
- **재고 레벨 판정 기준 정련**
  - onHand → **가용재고** 기준 (입고예정 포함이 발주 결정의 핵심)
  - 색 강조 위치를 실재고 셀 → 가용재고 셀로 이동

<br><br>

## ✔️ 참고 사항
- 카탈로그 데이터 구조 변경 없이 표시·필터 로직만 정련
- 권장 배지 클릭은 cart 수량 set 동작이라 +1 add 버튼과 충돌 없음

<br><br>

## ✔️ 관련 이슈
- Close #303 

<br><br> 