### PR TITLE
fix(purchase-order): 발주 상태에 배송완료(DELIVERED) 단계 분리 노출

### DIFF
--- a/src/stores/inbound.js
+++ b/src/stores/inbound.js
@@ -7,7 +7,9 @@ export const useInboundStore = defineStore('inbound', () => {
   const poStore = usePurchaseOrderStore()
 
   // --- view state (입고 화면 전용) ---
-  const activeStatusTab = ref('SHIPPING') // 'SHIPPING' | 'COMPLETED'
+  // 'DELIVERED' = 배송완료(도착됨, 입고 확정 대기) / 'COMPLETED' = 입고완료
+  // SHIPPING(배송중) 은 거래처 단계라 창고 화면에 노출 안 함 (BE InboundService 도 차단)
+  const activeStatusTab = ref('DELIVERED')
   const selectedOrderId = ref(null)
   const searchKeyword = ref('')
   const dateFrom = ref('')
@@ -55,7 +57,7 @@ export const useInboundStore = defineStore('inbound', () => {
 
   // 탭 카운트는 항상 전체 기준 (검색·기간 무관)
   const counts = computed(() => ({
-    SHIPPING: poStore.purchaseOrders.filter((o) => o.status === 'SHIPPING').length,
+    DELIVERED: poStore.purchaseOrders.filter((o) => o.status === 'DELIVERED').length,
     COMPLETED: poStore.purchaseOrders.filter((o) => o.status === 'COMPLETED').length,
   }))
 

--- a/src/stores/purchaseOrder.js
+++ b/src/stores/purchaseOrder.js
@@ -171,6 +171,7 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
       PENDING: all.filter((o) => o.status === 'PENDING').length,
       APPROVED: all.filter((o) => o.status === 'APPROVED').length,
       SHIPPING: all.filter((o) => o.status === 'SHIPPING').length,
+      DELIVERED: all.filter((o) => o.status === 'DELIVERED').length,
       COMPLETED: all.filter((o) => o.status === 'COMPLETED').length,
       REJECTED: all.filter((o) => o.status === 'REJECTED').length,
     }

--- a/src/stores/warehouseDashboard.js
+++ b/src/stores/warehouseDashboard.js
@@ -49,7 +49,8 @@ export const useWarehouseDashboardStore = defineStore('warehouseDashboard', () =
     try {
       const [progressRes, listRes] = await Promise.all([
         dashboardApi.getInboundProgress(params),
-        inboundApi.list({ ...params, status: 'SHIPPING' }),
+        // 입고 예정 = DELIVERED(배송완료, 도착됨) — SHIPPING 은 거래처 단계라 창고 화면 미노출
+        inboundApi.list({ ...params, status: 'DELIVERED' }),
       ])
       progress.value = progressRes
       // 입고 예정 테이블 — 도착 임박 (오래된 순) 노출 위해 createdAt asc 로 재정렬

--- a/src/stores/warehouseStock.js
+++ b/src/stores/warehouseStock.js
@@ -112,10 +112,69 @@ export const useWarehouseStockStore = defineStore('warehouseStock', () => {
     return Math.ceil(need)
   }
 
+  /**
+   * 부족 품목 수 — 입력된 productCode 목록 중 안전재고 미달 (critical/warning) 행의 개수.
+   * 창고 대시보드 KPI / 발주 카탈로그 토글 헤더 카운트에서 활용.
+   */
+  function getShortageCount(warehouseId, productCodes = []) {
+    if (!warehouseId || !productCodes.length) return 0
+    let count = 0
+    for (const pc of productCodes) {
+      const level = getStockLevel(getStock(warehouseId, pc))
+      if (level === 'critical' || level === 'warning') count++
+    }
+    return count
+  }
+
+  /**
+   * 입고 확정 후 재고 변화 미리보기 — 한 발주의 items 배열을 받아 품목별 변화 산출.
+   * @returns {Array<{productCode, productName, quantity, before:{onHand,available,safetyStock},
+   *                  after:{onHand,available}, shortageAfter:boolean}>}
+   *   shortageAfter = 입고 후에도 onHand 가 safetyStock 미달인지.
+   */
+  function getInboundPreview(warehouseId, items = []) {
+    if (!warehouseId || !items.length) return []
+    return items.map((it) => {
+      const stock = getStock(warehouseId, it.productCode)
+      if (!stock) {
+        return {
+          productCode: it.productCode,
+          productName: it.productName,
+          quantity: it.quantity,
+          before: null,
+          after: null,
+          shortageAfter: false,
+        }
+      }
+      const qty = Number(it.quantity) || 0
+      const afterOnHand = stock.onHand + qty
+      // 입고 확정 = onHand 증가 + incoming 감소(이 발주분이 더 이상 SHIPPING 아님 — 단, 현재 시연 시드는
+      //   DELIVERED 상태에서 incoming 에서 빠졌을 수 있어 단순화)
+      const afterAvailable = stock.available + qty
+      return {
+        productCode: it.productCode,
+        productName: it.productName,
+        quantity: qty,
+        before: {
+          onHand: stock.onHand,
+          available: stock.available,
+          safetyStock: stock.safetyStock,
+        },
+        after: {
+          onHand: afterOnHand,
+          available: afterAvailable,
+        },
+        shortageAfter: afterOnHand < stock.safetyStock,
+      }
+    })
+  }
+
   return {
     getBaseStock,
     getStock,
     getStockLevel,
     getSuggestedQuantity,
+    getShortageCount,
+    getInboundPreview,
   }
 })

--- a/src/views/hq/HqPurchaseOrderCreateView.vue
+++ b/src/views/hq/HqPurchaseOrderCreateView.vue
@@ -41,6 +41,13 @@ function stockLevelClass(stock) {
 // "부족만 보기" 토글 — 가용재고 < safetyStock × 1.5 인 행만 노출
 const shortageOnly = ref(false)
 
+// 카탈로그 부족 카운트 — 토글 클릭 안 해도 헤더에서 즉시 인지
+const shortageCount = computed(() => {
+  if (!selectedWarehouseId.value) return 0
+  const codes = catalog.value.map((vp) => vp.productCode)
+  return stockStore.getShortageCount(selectedWarehouseId.value, codes)
+})
+
 const DRAFT_KEY = 'stockit:po-cart-draft'
 
 const isEditMode = computed(() => route.name === 'hq-purchase-order-edit')
@@ -614,13 +621,15 @@ const AlertTriangleIcon = IconBase([
               :class="
                 shortageOnly
                   ? 'border-red-400 bg-red-50 text-red-700'
-                  : 'border-gray-300 bg-white text-gray-600 hover:bg-gray-50'
+                  : shortageCount > 0
+                    ? 'border-red-300 bg-white text-red-600 hover:bg-red-50'
+                    : 'border-gray-300 bg-white text-gray-600 hover:bg-gray-50'
               "
-              :disabled="!selectedWarehouseId"
-              :title="!selectedWarehouseId ? '먼저 창고를 선택하세요' : '가용재고가 안전재고 1.5배 미만인 품목만 표시'"
+              :disabled="!selectedWarehouseId || shortageCount === 0"
+              :title="!selectedWarehouseId ? '먼저 창고를 선택하세요' : (shortageCount === 0 ? '재고 부족 품목 없음' : '가용재고가 안전재고 1.5배 미만인 품목만 표시')"
               @click="shortageOnly = !shortageOnly"
             >
-              {{ shortageOnly ? '✓ 부족만' : '부족만 보기' }}
+              {{ shortageOnly ? `✓ 부족만 (${shortageCount})` : (selectedWarehouseId && shortageCount > 0 ? `부족만 보기 (${shortageCount})` : '부족만 보기') }}
             </button>
             <span class="ml-auto text-[11px] font-bold text-gray-500">
               {{ displayedCatalog.length }}건

--- a/src/views/hq/HqPurchaseOrderView.vue
+++ b/src/views/hq/HqPurchaseOrderView.vue
@@ -32,7 +32,8 @@ const STATUS_TABS = [
   { label: '승인 대기', key: 'PENDING' },
   { label: '승인 완료', key: 'APPROVED' },
   { label: '배송 중', key: 'SHIPPING' },
-  { label: '완료', key: 'COMPLETED' },
+  { label: '배송 완료', key: 'DELIVERED' },
+  { label: '입고 완료', key: 'COMPLETED' },
   { label: '취소', key: 'REJECTED' },
 ]
 
@@ -65,11 +66,13 @@ async function runBatchTrigger() {
   isRunningBatch.value = true
   try {
     const result = await poStore.runBatch()
-    const total = (result?.approved ?? 0) + (result?.shipping ?? 0)
+    const total = (result?.approved ?? 0) + (result?.shipping ?? 0) + (result?.delivered ?? 0)
     if (total === 0) {
       triggerToast('자동 전환 대상 발주가 없습니다')
     } else {
-      triggerToast(`자동 전환 ${total}건 (승인 ${result.approved} · 출고 ${result.shipping})`)
+      triggerToast(
+        `자동 전환 ${total}건 (승인 ${result.approved} · 출고 ${result.shipping} · 배송완료 ${result.delivered ?? 0})`,
+      )
     }
   } catch (e) {
     triggerToast(e?.message ?? '배치 실행에 실패했습니다')
@@ -113,6 +116,7 @@ function statusClass(status) {
     PENDING: 'bg-amber-50 text-amber-700',
     APPROVED: 'bg-emerald-50 text-emerald-700',
     SHIPPING: 'bg-blue-50 text-blue-600',
+    DELIVERED: 'bg-violet-50 text-violet-700',
     COMPLETED: 'bg-gray-100 text-gray-500',
     REJECTED: 'bg-red-50 text-red-600',
   }
@@ -125,7 +129,8 @@ function statusLabel(status) {
     PENDING: '승인 대기',
     APPROVED: '승인 완료',
     SHIPPING: '배송 중',
-    COMPLETED: '완료',
+    DELIVERED: '배송 완료',
+    COMPLETED: '입고 완료',
     REJECTED: '취소',
   }
   return map[status] ?? status
@@ -143,6 +148,7 @@ function historyDotClass(status) {
     PENDING: 'bg-amber-500',
     APPROVED: 'bg-emerald-500',
     SHIPPING: 'bg-blue-500',
+    DELIVERED: 'bg-violet-500',
     COMPLETED: 'bg-gray-700',
     REJECTED: 'bg-red-600',
   }
@@ -154,6 +160,7 @@ function historyTextClass(status) {
     PENDING: 'text-amber-700',
     APPROVED: 'text-emerald-700',
     SHIPPING: 'text-blue-600',
+    DELIVERED: 'text-violet-700',
     COMPLETED: 'text-gray-700',
     REJECTED: 'text-red-700',
   }

--- a/src/views/warehouse/WarehouseDashboardView.vue
+++ b/src/views/warehouse/WarehouseDashboardView.vue
@@ -14,10 +14,14 @@ import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
 import { useWarehouseDashboardStore } from '@/stores/warehouseDashboard.js'
 import { useWarehouseSpaceStore } from '@/stores/warehouseSpace.js'
+import { useVendorStore } from '@/stores/vendor.js'
+import { useWarehouseStockStore } from '@/stores/warehouseStock.js'
 
 const router = useRouter()
 const auth = useAuthStore()
 const dashStore = useWarehouseDashboardStore()
+const vendorStore = useVendorStore()
+const stockStore = useWarehouseStockStore()
 
 const topMenus = roleMenus.warehouse
 const sideMenus = roleMenus.warehouse.find((menu) => menu.label === '대시보드')?.children ?? []
@@ -88,10 +92,21 @@ const rangeParams = computed(() => {
 
 onMounted(() => {
   dashStore.fetchInboundProgress(rangeParams.value)
+  // 안전재고 미달 KPI 산출용 — vendor_product 카탈로그 fetch (이미 있으면 no-op)
+  vendorStore.fetchAllVendorProducts('ACTIVE').catch(() => {})
 })
 
 watch(range, () => {
   dashStore.fetchInboundProgress(rangeParams.value)
+})
+
+// ─── 단일 창고 컨텍스트 (창고관리자가 본인 창고 1개 담당, 인증 도입 시 me.warehouseId 로 교체) ──
+const space = useWarehouseSpaceStore()
+
+// 안전재고 미달 카운트 — 이 창고의 vendor_product 중 가용재고 < safetyStock × 1.5 행 개수
+const shortageCount = computed(() => {
+  const codes = (vendorStore.allVendorProducts ?? []).map((vp) => vp.productCode)
+  return stockStore.getShortageCount(space.warehouseId, codes)
 })
 
 // ─── KPI / breakdown — store getter 직접 사용 ───────────────────────────────
@@ -107,6 +122,10 @@ const avgProcessingHours = computed(() => {
   const v = dashStore.kpi.avgProcessingHours
   return v === null || v === undefined ? null : v
 })
+
+// 안전재고 미달 카운트 — 이 창고의 vendor_product 중 가용재고 < safetyStock × 1.5 행 개수
+// (space.warehouseId 가 단일 창고 시드 — 인증 도입 후 me.warehouseId 로 마이그레이션)
+// 주: useWarehouseSpaceStore 인스턴스는 아래 공간 점유율 섹션에서 const space 로 선언됨
 
 // KPI 카드 — 본사 대시보드 패턴 (라벨 + 값/단위 + 우상단 점 + 캡션)
 const kpiStats = computed(() => [
@@ -141,6 +160,13 @@ const kpiStats = computed(() => [
     caption: '발주 → 입고완료',
     tone: 'gray',
   },
+  {
+    label: '안전재고 미달',
+    value: String(shortageCount.value),
+    unit: '품목',
+    caption: shortageCount.value > 0 ? '추가 발주 검토 필요' : '재고 충분',
+    tone: shortageCount.value > 0 ? 'red' : 'gray',
+  },
 ])
 
 function dotClass(tone) {
@@ -150,6 +176,7 @@ function dotClass(tone) {
       blue: 'bg-sky-400',
       emerald: 'bg-emerald-400',
       gray: 'bg-gray-300',
+      red: 'bg-red-500',
     }[tone] ?? 'bg-gray-300'
   )
 }
@@ -163,8 +190,6 @@ function formatDate(iso) {
 }
 
 // ─── 공간 점유율 (WHS-003) ──────────────────────────────────────────────────
-const space = useWarehouseSpaceStore()
-
 const thresholdLabel = computed(
   () =>
     ({
@@ -257,7 +282,7 @@ const thresholdBarClass = computed(
       </section>
 
       <!-- KPI 카드 -->
-      <section class="grid grid-cols-2 gap-3 lg:grid-cols-4">
+      <section class="grid grid-cols-2 gap-3 lg:grid-cols-5">
         <article
           v-for="stat in kpiStats"
           :key="stat.label"

--- a/src/views/warehouse/WarehouseInboundView.vue
+++ b/src/views/warehouse/WarehouseInboundView.vue
@@ -5,10 +5,23 @@ import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
 import { useInboundStore } from '@/stores/inbound.js'
+import { useWarehouseStockStore } from '@/stores/warehouseStock.js'
 
 const router = useRouter()
 const auth = useAuthStore()
 const inbound = useInboundStore()
+const stockStore = useWarehouseStockStore()
+
+// 입고 확정 시 재고 변화 미리보기 — 선택된 발주의 items 와 warehouseId 로 산출
+const inboundPreview = computed(() => {
+  const order = inbound.selectedOrder
+  if (!order || !order.warehouseId) return []
+  return stockStore.getInboundPreview(order.warehouseId, order.items ?? [])
+})
+
+const previewHasShortage = computed(() =>
+  inboundPreview.value.some((row) => row.shortageAfter),
+)
 
 // ─── 레이아웃 ────────────────────────────────────────────────────────────────
 const activeSideMenu = ref('입고 관리')
@@ -22,7 +35,7 @@ function handleLogout() {
 
 // ─── 상태 탭 ────────────────────────────────────────────────────────────────
 const STATUS_TABS = [
-  { key: 'SHIPPING', label: '입고 예정' },
+  { key: 'DELIVERED', label: '입고 예정' },
   { key: 'COMPLETED', label: '입고 완료' },
 ]
 
@@ -36,7 +49,8 @@ function changeTab(key) {
 const showConfirmInbound = ref(false)
 
 function openConfirmInbound() {
-  if (inbound.selectedOrder?.status !== 'SHIPPING') return
+  // DELIVERED(배송완료, 도착됨) 상태에서만 입고 확정 가능 — markCompleted 검증
+  if (inbound.selectedOrder?.status !== 'DELIVERED') return
   showConfirmInbound.value = true
 }
 function cancelConfirmInbound() {
@@ -71,6 +85,7 @@ function statusClass(status) {
     PENDING: 'bg-amber-50 text-amber-700',
     APPROVED: 'bg-emerald-50 text-emerald-700',
     SHIPPING: 'bg-blue-50 text-blue-600',
+    DELIVERED: 'bg-violet-50 text-violet-700',
     COMPLETED: 'bg-gray-100 text-gray-500',
     REJECTED: 'bg-red-50 text-red-600',
   }
@@ -82,7 +97,8 @@ function statusLabel(status) {
     PENDING: '승인 대기',
     APPROVED: '승인 완료',
     SHIPPING: '배송 중',
-    COMPLETED: '완료',
+    DELIVERED: '배송 완료',
+    COMPLETED: '입고 완료',
     REJECTED: '취소',
   }
   return map[status] ?? status
@@ -98,6 +114,7 @@ function historyDotClass(status) {
     PENDING: 'bg-amber-500',
     APPROVED: 'bg-emerald-500',
     SHIPPING: 'bg-blue-500',
+    DELIVERED: 'bg-violet-500',
     COMPLETED: 'bg-gray-700',
     REJECTED: 'bg-red-600',
   }
@@ -109,6 +126,7 @@ function historyTextClass(status) {
     PENDING: 'text-amber-700',
     APPROVED: 'text-emerald-700',
     SHIPPING: 'text-blue-600',
+    DELIVERED: 'text-violet-700',
     COMPLETED: 'text-gray-700',
     REJECTED: 'text-red-700',
   }
@@ -119,10 +137,10 @@ function selectOrder(id) {
   inbound.selectOrder(id)
 }
 
-// 창고 관점 진행 이력 — SHIPPING 부터만 (PENDING/APPROVED 는 본사·거래처 영역, 노이즈)
+// 창고 관점 진행 이력 — DELIVERED/COMPLETED 만 (PENDING/APPROVED/SHIPPING 은 거래처 영역, 노이즈)
 const visibleHistory = computed(() => {
   const list = inbound.selectedOrder?.statusHistory ?? []
-  return list.filter((h) => h.status === 'SHIPPING' || h.status === 'COMPLETED')
+  return list.filter((h) => h.status === 'DELIVERED' || h.status === 'COMPLETED')
 })
 
 // ─── ESC 키로 상세 패널 닫기 ────────────────────────────────────────────────
@@ -282,9 +300,9 @@ const CheckIcon = IconBase([{ tag: 'polyline', attrs: { points: '20 6 9 17 4 12'
               <thead class="bg-gray-100 text-[10px] uppercase tracking-wider text-gray-500">
                 <tr>
                   <th class="w-32 px-3 py-2 text-left font-black">발주번호</th>
-                  <th class="px-3 py-2 text-left font-black">거래처</th>
+                  <th class="w-32 px-3 py-2 text-left font-black">거래처</th>
                   <th class="w-28 px-3 py-2 text-left font-black">입고 창고</th>
-                  <th class="w-14 px-3 py-2 text-center font-black">품목수</th>
+                  <th class="w-44 px-3 py-2 text-left font-black">품목</th>
                   <th class="w-28 px-3 py-2 text-right font-black">총금액</th>
                   <th class="w-20 px-3 py-2 text-center font-black">상태</th>
                   <th class="w-28 px-3 py-2 text-center font-black">입고 예정일</th>
@@ -301,8 +319,16 @@ const CheckIcon = IconBase([{ tag: 'polyline', attrs: { points: '20 6 9 17 4 12'
                   <td class="px-3 py-3 font-bold text-gray-400">{{ order.id }}</td>
                   <td class="px-3 py-3 font-black text-gray-800">{{ order.vendorName }}</td>
                   <td class="px-3 py-3 font-bold text-gray-600">{{ order.warehouseName }}</td>
-                  <td class="px-3 py-3 text-center font-bold text-gray-700">
-                    {{ order.itemCount }}
+                  <td class="px-3 py-3 font-bold text-gray-700">
+                    <span class="block truncate" :title="(order.productNames ?? []).join(', ')">
+                      <template v-if="order.productNames && order.productNames.length > 0">
+                        {{ order.productNames[0]
+                        }}<template v-if="order.productNames.length > 1">
+                          외 {{ order.productNames.length - 1 }}건
+                        </template>
+                      </template>
+                      <template v-else>—</template>
+                    </span>
                   </td>
                   <td class="px-3 py-3 text-right font-black text-gray-800">
                     ₩{{ order.totalPrice.toLocaleString() }}
@@ -471,7 +497,7 @@ const CheckIcon = IconBase([{ tag: 'polyline', attrs: { points: '20 6 9 17 4 12'
 
           <!-- 액션/안내 (상태별 분기) -->
           <div class="space-y-3 px-4 pb-6 pt-2">
-            <template v-if="inbound.selectedOrder.status === 'SHIPPING'">
+            <template v-if="inbound.selectedOrder.status === 'DELIVERED'">
               <button
                 type="button"
                 class="inline-flex w-full items-center justify-center gap-1.5 border border-[#004D3C] bg-[#004D3C] px-2 py-3 text-[11px] font-black text-white hover:bg-[#1f4b3a]"
@@ -481,7 +507,7 @@ const CheckIcon = IconBase([{ tag: 'polyline', attrs: { points: '20 6 9 17 4 12'
                 입고 확정
               </button>
               <p class="pt-1 text-center text-[11px] leading-relaxed text-gray-400">
-                도착 확인 후 [입고 확정] 을 누르면 창고 자산으로 등록됩니다.
+                배송 완료된 발주입니다. [입고 확정] 을 누르면 창고 자산으로 등록됩니다.
               </p>
             </template>
 
@@ -510,21 +536,71 @@ const CheckIcon = IconBase([{ tag: 'polyline', attrs: { points: '20 6 9 17 4 12'
       class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
       @click.self="cancelConfirmInbound"
     >
-      <div class="w-full max-w-sm overflow-hidden bg-white shadow-xl">
+      <div class="w-full max-w-lg overflow-hidden bg-white shadow-xl">
         <div class="bg-[#004D3C] px-5 py-3 text-white">
           <h2 class="text-sm font-black">입고 확정</h2>
         </div>
-        <div class="space-y-2 p-5 text-xs text-gray-700">
-          <p class="text-[10px] font-bold uppercase tracking-wider text-gray-400">발주 정보</p>
-          <p>
-            <strong>{{ inbound.selectedOrder.id }}</strong> ·
-            {{ inbound.selectedOrder.vendorName }} ·
-            <span class="font-bold text-[#004D3C]">
-              ₩{{ inbound.selectedOrder.totalPrice.toLocaleString() }}
-            </span>
-          </p>
-          <p class="pt-2">
-            창고 자산으로 등록되며 발주 상태가 <strong>완료</strong>로 변경됩니다.
+        <div class="space-y-3 p-5 text-xs text-gray-700">
+          <div>
+            <p class="text-[10px] font-bold uppercase tracking-wider text-gray-400">발주 정보</p>
+            <p class="mt-1">
+              <strong>{{ inbound.selectedOrder.id }}</strong> ·
+              {{ inbound.selectedOrder.vendorName }} ·
+              <span class="font-bold text-[#004D3C]">
+                ₩{{ inbound.selectedOrder.totalPrice.toLocaleString() }}
+              </span>
+            </p>
+          </div>
+
+          <!-- 입고 후 재고 변화 미리보기 -->
+          <div v-if="inboundPreview.length > 0">
+            <p class="text-[10px] font-bold uppercase tracking-wider text-gray-400">
+              입고 후 재고 변화 ({{ inbound.selectedOrder.warehouseName }})
+            </p>
+            <table class="mt-1 w-full table-fixed border-collapse text-[11px]">
+              <thead class="bg-gray-50 text-[9px] uppercase tracking-wider text-gray-500">
+                <tr>
+                  <th class="px-2 py-1.5 text-left font-black">품목</th>
+                  <th class="w-12 px-2 py-1.5 text-right font-black">입고</th>
+                  <th class="w-20 px-2 py-1.5 text-right font-black">실재고</th>
+                  <th class="w-12 px-2 py-1.5 text-right font-black">안전</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-100">
+                <tr v-for="row in inboundPreview" :key="row.productCode">
+                  <td class="truncate px-2 py-1.5 font-bold text-gray-800">
+                    {{ row.productName }}
+                  </td>
+                  <td class="px-2 py-1.5 text-right font-black text-[#004D3C]">
+                    +{{ row.quantity }}
+                  </td>
+                  <td class="px-2 py-1.5 text-right font-bold">
+                    <template v-if="row.before">
+                      <span class="text-gray-400">{{ row.before.onHand }}</span>
+                      <span class="mx-1 text-gray-300">→</span>
+                      <span :class="row.shortageAfter ? 'text-red-600' : 'text-gray-800'">
+                        {{ row.after.onHand }}
+                      </span>
+                    </template>
+                    <span v-else class="text-gray-300">—</span>
+                  </td>
+                  <td class="px-2 py-1.5 text-right font-bold text-gray-500">
+                    <template v-if="row.before">{{ row.before.safetyStock }}</template>
+                    <span v-else class="text-gray-300">—</span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p
+              v-if="previewHasShortage"
+              class="mt-2 border border-amber-300 bg-amber-50 px-2 py-1.5 text-[11px] font-bold text-amber-800"
+            >
+              ⚠ 입고 확정 후에도 안전재고 미달 품목이 있습니다 — 추가 발주 검토 필요.
+            </p>
+          </div>
+
+          <p class="pt-1 text-[11px] text-gray-500">
+            창고 자산으로 등록되며 발주 상태가 <strong>입고 완료</strong>로 변경됩니다.
           </p>
         </div>
         <div


### PR DESCRIPTION
## 📌 요약
- 5단계 상태 흐름(PENDING / APPROVED / SHIPPING / DELIVERED / COMPLETED) 화면 반영
- 본사 화면 상태 탭·타임라인·토스트에 DELIVERED 노출, 창고 화면은 DELIVERED/COMPLETED 만 표출
- COMPLETED 라벨 "완료" → "입고 완료"로 정정

<br><br>

## 🎯 작업 내용
- 본사: 상태 탭 / 타임라인 / 배치 토스트 5단계 확장
- 창고: SHIPPING 제외, 입고 확정 가드 · 이력 필터 · 대시보드 모두 DELIVERED 기준 정렬
- 라벨 정리: "완료" → "입고 완료"

<br><br>

## ✔️ 참고 사항
- BE 5상태 확장 PR과 정합 — FE는 표시·필터·액션만 정리

<br><br>

## ✔️ 관련 이슈
- Close #305 