### PR TITLE
refactor: 순환 재고 관리 품목 -> SKU 단위 전환 및 소재/필터 UX 개선

### DIFF
--- a/src/views/hq/circular-inventory/HqCircularInventoryCandidateView.vue
+++ b/src/views/hq/circular-inventory/HqCircularInventoryCandidateView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
@@ -13,10 +13,24 @@ const circularInventoryMenus = roleMenus.hq.find(menu => menu.label === '순환 
 const activeTopMenu = computed(() => '순환 재고 관리')
 const activeSideMenu = ref('순환 재고 후보 조회')
 const hasRefreshed = ref(false)
-const candidates = ref([])
-const selectedCandidateIds = ref([])
+const candidateSkus = ref([])
+const selectedSkuCodes = ref([])
+const selectedCategory = ref('')
+const selectedWarehouse = ref('')
+const searchTerm = ref('')
 
-const circularCandidateData = [
+const PAGE_SIZE = 20
+const currentPage = ref(1)
+const sortKey = ref('convertibleStock')
+const sortDirection = ref('desc')
+
+const conditionItems = [
+  '최근 24개월 이상 판매 이력이 없는 SKU',
+  '목표 판매 기준 대비 실적이 낮은 SKU',
+  '극단 사이즈 재고 또는 특정 컬러 재고에 편중된 SKU',
+]
+
+const baseCandidates = [
   {
     id: 'CIR-001',
     itemCode: 'SPA-TOP-004',
@@ -24,8 +38,6 @@ const circularCandidateData = [
     itemName: '라운드넥 소프트 니트',
     warehouseName: '이천 풀필먼트',
     convertibleStock: 86,
-    fabricWeight: '43.0kg',
-    matchedReasons: ['2년 이상 미판매', '판매율 5% 미만'],
   },
   {
     id: 'CIR-002',
@@ -34,8 +46,6 @@ const circularCandidateData = [
     itemName: '와이드 밴딩 팬츠 XXXL',
     warehouseName: '대전 허브창고',
     convertibleStock: 24,
-    fabricWeight: '18.6kg',
-    matchedReasons: ['극단 사이즈 잔여', '판매율 5% 미만'],
   },
   {
     id: 'CIR-003',
@@ -44,8 +54,6 @@ const circularCandidateData = [
     itemName: '브이넥 니트 가디건 라임',
     warehouseName: '부산 물류창고',
     convertibleStock: 37,
-    fabricWeight: '29.6kg',
-    matchedReasons: ['특정 컬러 편중', '2년 이상 미판매'],
   },
   {
     id: 'CIR-004',
@@ -54,8 +62,6 @@ const circularCandidateData = [
     itemName: '플리츠 롱스커트 XS',
     warehouseName: '인천 제1창고',
     convertibleStock: 19,
-    fabricWeight: '12.4kg',
-    matchedReasons: ['극단 사이즈 잔여'],
   },
   {
     id: 'CIR-005',
@@ -64,34 +70,168 @@ const circularCandidateData = [
     itemName: '슬림핏 긴팔 티셔츠 머스타드',
     warehouseName: '이천 풀필먼트',
     convertibleStock: 52,
-    fabricWeight: '20.8kg',
-    matchedReasons: ['특정 컬러 편중', '판매율 5% 미만'],
   },
 ]
 
-const isAllSelected = computed(() =>
-  candidates.value.length > 0
-  && candidates.value.every(candidate => selectedCandidateIds.value.includes(candidate.id)),
+const colorOptions = ['검정', '흰색', '그레이', '아이보리']
+const colorCodeMap = { 검정: 'BLK', 흰색: 'WHT', 그레이: 'GRY', 아이보리: 'IVR' }
+const sizeOptions = ['XS', 'S', 'M', 'L', 'XL']
+
+const buildCandidateSkus = () =>
+  baseCandidates.flatMap((candidate, cIndex) => {
+    const seed = `${candidate.itemCode}-${candidate.warehouseName}`
+      .split('')
+      .reduce((sum, char) => sum + char.charCodeAt(0), 0)
+
+    return colorOptions.flatMap((color, colorIndex) =>
+      sizeOptions.map((size, sizeIndex) => {
+        const actualStock = 12 + ((seed + colorIndex * 17 + sizeIndex * 9) % 55)
+        const availableStock = Math.max(actualStock - ((seed + colorIndex * 5 + sizeIndex * 3) % 11), 0)
+        const convertibleStock = Math.max(
+          1,
+          Math.min(availableStock, 1 + ((seed + colorIndex * 13 + sizeIndex * 7 + cIndex) % 18)),
+        )
+        const updatedDay = String(28 - ((cIndex + colorIndex + sizeIndex) % 12)).padStart(2, '0')
+        const updatedHour = String(9 + ((sizeIndex + colorIndex) % 9)).padStart(2, '0')
+
+        return {
+          id: `${candidate.id}-${color}-${size}`,
+          skuCode: `${candidate.itemCode}-${colorCodeMap[color]}-${size}`,
+          itemCode: candidate.itemCode,
+          category: candidate.category,
+          itemName: candidate.itemName,
+          warehouseName: candidate.warehouseName,
+          color,
+          size,
+          availableStock,
+          convertibleStock,
+          updatedAt: `2026.04.${updatedDay} ${updatedHour}:20`,
+        }
+      }),
+    )
+  })
+
+const categoryOptions = computed(() =>
+  [...new Set(candidateSkus.value.map(row => row.category))].sort((a, b) => a.localeCompare(b, 'ko')),
 )
 
-const canConvertInventory = computed(() => selectedCandidateIds.value.length > 0)
+const warehouseOptions = computed(() =>
+  [...new Set(candidateSkus.value.map(row => row.warehouseName))].sort((a, b) => a.localeCompare(b, 'ko')),
+)
+
+const filteredSkus = computed(() => {
+  const keyword = searchTerm.value.trim().toLowerCase()
+
+  return candidateSkus.value.filter((row) => {
+    const matchesCategory = !selectedCategory.value || row.category === selectedCategory.value
+    const matchesWarehouse = !selectedWarehouse.value || row.warehouseName === selectedWarehouse.value
+    const matchesKeyword = !keyword
+      || [row.skuCode, row.itemCode, row.itemName].join(' ').toLowerCase().includes(keyword)
+
+    return matchesCategory && matchesWarehouse && matchesKeyword
+  })
+})
+
+const sortedSkus = computed(() => {
+  const rows = [...filteredSkus.value]
+  const direction = sortDirection.value === 'asc' ? 1 : -1
+
+  const getComparable = (row) => {
+    switch (sortKey.value) {
+      case 'skuCode':
+        return row.skuCode
+      case 'availableStock':
+        return row.availableStock
+      case 'convertibleStock':
+        return row.convertibleStock
+      case 'updatedAt':
+        return row.updatedAt
+      default:
+        return row.convertibleStock
+    }
+  }
+
+  rows.sort((a, b) => {
+    const aValue = getComparable(a)
+    const bValue = getComparable(b)
+
+    if (typeof aValue === 'string' && typeof bValue === 'string') {
+      return aValue.localeCompare(bValue, 'ko') * direction
+    }
+
+    return (aValue - bValue) * direction
+  })
+
+  return rows
+})
+
+const totalPages = computed(() => Math.max(1, Math.ceil(sortedSkus.value.length / PAGE_SIZE)))
+
+const paginatedSkus = computed(() => {
+  const start = (currentPage.value - 1) * PAGE_SIZE
+  return sortedSkus.value.slice(start, start + PAGE_SIZE)
+})
+
+const canConvertInventory = computed(() => selectedSkuCodes.value.length > 0)
+
+const isAllCurrentPageSelected = computed(() =>
+  paginatedSkus.value.length > 0
+  && paginatedSkus.value.every(row => selectedSkuCodes.value.includes(row.skuCode)),
+)
+
+const rangeStart = computed(() => (sortedSkus.value.length === 0 ? 0 : (currentPage.value - 1) * PAGE_SIZE + 1))
+const rangeEnd = computed(() => Math.min(currentPage.value * PAGE_SIZE, sortedSkus.value.length))
+
+watch(totalPages, (pageCount) => {
+  if (currentPage.value > pageCount) currentPage.value = pageCount
+})
+
+watch([selectedCategory, selectedWarehouse, searchTerm], () => {
+  currentPage.value = 1
+})
 
 const refreshCandidates = () => {
   hasRefreshed.value = true
-  candidates.value = circularCandidateData
-  selectedCandidateIds.value = []
+  candidateSkus.value = buildCandidateSkus()
+  selectedSkuCodes.value = []
+  currentPage.value = 1
+  sortKey.value = 'convertibleStock'
+  sortDirection.value = 'desc'
 }
 
-const toggleCandidate = (candidateId) => {
-  selectedCandidateIds.value = selectedCandidateIds.value.includes(candidateId)
-    ? selectedCandidateIds.value.filter(id => id !== candidateId)
-    : [...selectedCandidateIds.value, candidateId]
+const toggleSort = (key) => {
+  if (sortKey.value === key) {
+    sortDirection.value = sortDirection.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    sortKey.value = key
+    sortDirection.value = 'asc'
+  }
+
+  currentPage.value = 1
 }
 
-const toggleAllCandidates = () => {
-  selectedCandidateIds.value = isAllSelected.value
-    ? []
-    : candidates.value.map(candidate => candidate.id)
+const sortIcon = (key) => {
+  if (sortKey.value !== key) return '↕'
+  return sortDirection.value === 'asc' ? '▲' : '▼'
+}
+
+const toggleSku = (skuCode) => {
+  selectedSkuCodes.value = selectedSkuCodes.value.includes(skuCode)
+    ? selectedSkuCodes.value.filter(code => code !== skuCode)
+    : [...selectedSkuCodes.value, skuCode]
+}
+
+const toggleAllCurrentPage = () => {
+  const pageCodes = paginatedSkus.value.map(row => row.skuCode)
+
+  selectedSkuCodes.value = isAllCurrentPageSelected.value
+    ? selectedSkuCodes.value.filter(code => !pageCodes.includes(code))
+    : [...new Set([...selectedSkuCodes.value, ...pageCodes])]
+}
+
+const goToPage = (page) => {
+  if (page < 1 || page > totalPages.value) return
+  currentPage.value = page
 }
 
 function handleLogout() {
@@ -114,9 +254,7 @@ function handleLogout() {
           <div>
             <p class="text-[10px] font-black uppercase tracking-[0.18em] text-gray-400">Circular Inventory</p>
             <h1 class="mt-1 text-lg font-black text-gray-900">순환 재고 후보 조회</h1>
-            <p class="mt-1 text-xs font-bold text-gray-500">
-              시스템이 장기 미판매, 판매율 저조, 사이즈/컬러 불균형 조건에 해당하는 전환 후보를 추출합니다.
-            </p>
+            <p class="mt-1 text-xs font-bold text-gray-500">SKU 단위 후보를 조회하고 바로 순환 재고로 전환합니다.</p>
           </div>
 
           <div class="flex items-center gap-2">
@@ -137,79 +275,198 @@ function handleLogout() {
             </button>
           </div>
         </div>
+
+        <div class="mt-4 border border-[#D6EAEA] bg-[#F7FBFB] px-3 py-3">
+          <p class="text-[11px] font-black text-[#004D3C]">후보 조건</p>
+          <p class="mt-1 text-[11px] font-bold text-gray-500">
+            아래 조건에 해당하는 SKU를 우선 후보로 선별해 전환 검토합니다.
+          </p>
+          <div class="mt-2 flex flex-wrap gap-1.5">
+            <span
+              v-for="(condition, index) in conditionItems"
+              :key="condition"
+              class="inline-flex items-center gap-1 bg-white px-2 py-1 text-[11px] font-bold text-gray-700 ring-1 ring-[#D6EAEA]"
+            >
+              {{ index + 1 }}. {{ condition }}
+            </span>
+          </div>
+        </div>
       </section>
 
       <section class="min-w-0 border border-gray-200 bg-white shadow-sm">
         <div class="flex items-center justify-between border-b border-gray-100 px-4 py-3">
           <div>
-            <h2 class="text-sm font-black text-gray-900">전환 후보 리스트</h2>
+            <h2 class="text-sm font-black text-gray-900">전환 후보 SKU 리스트</h2>
             <p class="mt-1 text-[11px] font-bold text-gray-400">
-              {{ hasRefreshed ? `후보 ${candidates.length.toLocaleString()}건 · 선택 ${selectedCandidateIds.length.toLocaleString()}건` : '재고 새로고침 후 후보가 표시됩니다.' }}
+              {{ hasRefreshed ? `조회 ${sortedSkus.length.toLocaleString()}건 · 선택 ${selectedSkuCodes.length.toLocaleString()}건` : '재고 새로고침 후 후보가 표시됩니다.' }}
             </p>
           </div>
+          <p v-if="hasRefreshed" class="text-[11px] font-bold text-gray-400">
+            {{ rangeStart.toLocaleString() }}-{{ rangeEnd.toLocaleString() }} / 전체 {{ sortedSkus.length.toLocaleString() }}건
+          </p>
+        </div>
+
+        <div
+          v-if="hasRefreshed"
+          class="grid gap-3 border-b border-gray-100 px-4 py-3 xl:grid-cols-[0.9fr_1fr_1.4fr]"
+        >
+          <label class="flex flex-col gap-1.5">
+            <span class="text-[11px] font-bold text-gray-500">카테고리</span>
+            <select
+              v-model="selectedCategory"
+              class="h-9 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none focus:border-[#004D3C]"
+            >
+              <option value="">전체</option>
+              <option v-for="category in categoryOptions" :key="category" :value="category">
+                {{ category }}
+              </option>
+            </select>
+          </label>
+
+          <label class="flex flex-col gap-1.5">
+            <span class="text-[11px] font-bold text-gray-500">창고</span>
+            <select
+              v-model="selectedWarehouse"
+              class="h-9 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none focus:border-[#004D3C]"
+            >
+              <option value="">전체</option>
+              <option v-for="warehouse in warehouseOptions" :key="warehouse" :value="warehouse">
+                {{ warehouse }}
+              </option>
+            </select>
+          </label>
+
+          <label class="flex flex-col gap-1.5">
+            <span class="text-[11px] font-bold text-gray-500">검색</span>
+            <input
+              v-model="searchTerm"
+              type="search"
+              class="h-9 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none placeholder:text-gray-400 focus:border-[#004D3C]"
+              placeholder="SKU 코드, 품목 코드, 품목명"
+            />
+          </label>
         </div>
 
         <div v-if="!hasRefreshed" class="flex min-h-64 flex-col items-center justify-center px-4 py-14 text-center">
           <p class="text-sm font-black text-gray-900">아직 조회된 순환 재고 후보가 없습니다.</p>
-          <p class="mt-2 text-xs font-bold text-gray-400">상단의 재고 새로고침 버튼을 눌러 전환 가능한 후보를 조회하세요.</p>
+          <p class="mt-2 text-xs font-bold text-gray-400">상단의 재고 새로고침 버튼을 눌러 SKU 후보를 조회하세요.</p>
         </div>
 
         <div v-else class="overflow-x-auto">
-          <table class="min-w-[980px] w-full border-collapse text-left text-xs">
+          <table class="min-w-[1180px] w-full border-collapse text-left text-xs">
             <thead class="bg-gray-50 text-[10px] uppercase tracking-[0.12em] text-gray-500">
               <tr>
                 <th class="w-16 px-3 py-3 text-center font-black">
                   <input
                     type="checkbox"
                     class="h-3.5 w-3.5 accent-[#004D3C]"
-                    :checked="isAllSelected"
-                    @change="toggleAllCandidates"
+                    :checked="isAllCurrentPageSelected"
+                    @change="toggleAllCurrentPage"
                   />
+                </th>
+                <th class="px-3 py-3 font-black">
+                  <button type="button" class="inline-flex items-center gap-1 hover:text-gray-900" @click="toggleSort('skuCode')">
+                    SKU 코드
+                    <span class="text-[9px]">{{ sortIcon('skuCode') }}</span>
+                  </button>
                 </th>
                 <th class="px-3 py-3 font-black">품목 코드</th>
                 <th class="px-3 py-3 font-black">카테고리</th>
                 <th class="px-3 py-3 font-black">품목명</th>
                 <th class="px-3 py-3 font-black">창고</th>
-                <th class="px-3 py-3 text-center font-black">전환 가능 재고</th>
-                <th class="px-3 py-3 text-right font-black">원단 무게</th>
+                <th class="px-3 py-3 text-center font-black">색상</th>
+                <th class="px-3 py-3 text-center font-black">사이즈</th>
+                <th class="px-3 py-3 text-right font-black">
+                  <button type="button" class="inline-flex items-center gap-1 hover:text-gray-900" @click="toggleSort('availableStock')">
+                    가용재고
+                    <span class="text-[9px]">{{ sortIcon('availableStock') }}</span>
+                  </button>
+                </th>
+                <th class="px-3 py-3 text-right font-black">
+                  <button type="button" class="inline-flex items-center gap-1 hover:text-gray-900" @click="toggleSort('convertibleStock')">
+                    전환 가능 재고
+                    <span class="text-[9px]">{{ sortIcon('convertibleStock') }}</span>
+                  </button>
+                </th>
+                <th class="px-3 py-3 font-black">
+                  <button type="button" class="inline-flex items-center gap-1 hover:text-gray-900" @click="toggleSort('updatedAt')">
+                    최종 업데이트
+                    <span class="text-[9px]">{{ sortIcon('updatedAt') }}</span>
+                  </button>
+                </th>
               </tr>
             </thead>
             <tbody class="divide-y divide-gray-100">
               <tr
-                v-for="candidate in candidates"
-                :key="candidate.id"
+                v-for="row in paginatedSkus"
+                :key="row.id"
                 class="cursor-pointer transition"
-                :class="selectedCandidateIds.includes(candidate.id) ? 'bg-[#EBF5F5] font-bold' : 'hover:bg-[#EBF5F5]/60'"
-                @click="toggleCandidate(candidate.id)"
+                :class="selectedSkuCodes.includes(row.skuCode) ? 'bg-[#EBF5F5] font-bold' : 'hover:bg-[#EBF5F5]/60'"
+                @click="toggleSku(row.skuCode)"
               >
                 <td class="px-3 py-3 text-center">
                   <input
                     type="checkbox"
                     class="h-3.5 w-3.5 accent-[#004D3C]"
-                    :checked="selectedCandidateIds.includes(candidate.id)"
-                    @click.stop="toggleCandidate(candidate.id)"
+                    :checked="selectedSkuCodes.includes(row.skuCode)"
+                    @click.stop="toggleSku(row.skuCode)"
                   />
                 </td>
-                <td class="px-3 py-3 font-mono font-bold text-gray-500">{{ candidate.itemCode }}</td>
-                <td class="px-3 py-3 font-bold text-gray-700">{{ candidate.category }}</td>
-                <td class="px-3 py-3">
-                  <p class="font-black text-gray-900">{{ candidate.itemName }}</p>
-                  <div class="mt-1 flex flex-wrap gap-1">
-                    <span
-                      v-for="reason in candidate.matchedReasons"
-                      :key="reason"
-                      class="bg-[#EBF5F5] px-2 py-0.5 text-[10px] font-black text-gray-600"
-                    >
-                      {{ reason }}
-                    </span>
-                  </div>
+                <td class="px-3 py-3 font-mono font-bold text-gray-600">{{ row.skuCode }}</td>
+                <td class="px-3 py-3 font-mono font-bold text-gray-500">{{ row.itemCode }}</td>
+                <td class="px-3 py-3 font-bold text-gray-700">{{ row.category }}</td>
+                <td class="px-3 py-3 font-black text-gray-900">{{ row.itemName }}</td>
+                <td class="px-3 py-3 font-bold text-gray-700">{{ row.warehouseName }}</td>
+                <td class="px-3 py-3 text-center font-black text-gray-900">{{ row.color }}</td>
+                <td class="px-3 py-3 text-center font-black text-gray-900">{{ row.size }}</td>
+                <td class="px-3 py-3 text-right font-black text-gray-900">{{ row.availableStock.toLocaleString() }}</td>
+                <td class="px-3 py-3 text-right font-black text-gray-900">{{ row.convertibleStock.toLocaleString() }}</td>
+                <td class="px-3 py-3 font-bold text-gray-500">{{ row.updatedAt }}</td>
+              </tr>
+              <tr v-if="paginatedSkus.length === 0">
+                <td colspan="11" class="px-3 py-14 text-center text-sm font-bold text-gray-400">
+                  조건에 맞는 순환 재고 후보가 없습니다.
                 </td>
-                <td class="px-3 py-3 font-bold text-gray-700">{{ candidate.warehouseName }}</td>
-                <td class="px-3 py-3 text-center font-black text-gray-900">{{ candidate.convertibleStock.toLocaleString() }}</td>
-                <td class="px-3 py-3 text-right font-black text-gray-900">{{ candidate.fabricWeight }}</td>
               </tr>
             </tbody>
           </table>
+        </div>
+
+        <div
+          v-if="hasRefreshed"
+          class="flex items-center justify-between border-t border-gray-100 bg-gray-50 px-3 py-2"
+        >
+          <span class="text-[11px] font-medium text-gray-400">
+            {{ rangeStart.toLocaleString() }}-{{ rangeEnd.toLocaleString() }} / 전체 {{ sortedSkus.length.toLocaleString() }}건
+          </span>
+          <div class="flex items-center gap-1">
+            <button
+              type="button"
+              :disabled="currentPage === 1"
+              class="flex h-7 w-7 items-center justify-center border border-gray-300 bg-white text-[12px] text-gray-500 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
+              @click="goToPage(currentPage - 1)"
+            >
+              ‹
+            </button>
+            <button
+              v-for="page in totalPages"
+              :key="page"
+              type="button"
+              class="flex h-7 min-w-[28px] items-center justify-center border text-[12px] font-medium transition"
+              :class="page === currentPage ? 'border-[#004D3C] bg-[#004D3C] text-white' : 'border-gray-300 bg-white text-gray-500 hover:bg-gray-100'"
+              @click="goToPage(page)"
+            >
+              {{ page }}
+            </button>
+            <button
+              type="button"
+              :disabled="currentPage === totalPages"
+              class="flex h-7 w-7 items-center justify-center border border-gray-300 bg-white text-[12px] text-gray-500 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
+              @click="goToPage(currentPage + 1)"
+            >
+              ›
+            </button>
+          </div>
         </div>
       </section>
     </div>

--- a/src/views/hq/circular-inventory/HqCircularInventoryView.vue
+++ b/src/views/hq/circular-inventory/HqCircularInventoryView.vue
@@ -12,8 +12,7 @@ const circularInventoryMenus = roleMenus.hq.find(menu => menu.label === '순환 
 
 const activeTopMenu = computed(() => '순환 재고 관리')
 const activeSideMenu = ref('순환 재고 조회')
-const selectedCategory = ref('')
-const selectedChildCategory = ref('')
+const searchTerm = ref('')
 const materialFilters = ref([])
 const isMaterialDropdownOpen = ref(false)
 const materialDropdownRef = ref(null)
@@ -39,62 +38,196 @@ const circularInventoryData = [
   { id: 'CI-015', itemCode: 'SPA-OUT-004', parentCategory: '아우터', childCategory: '가디건', itemName: '브이넥 니트 가디건', materials: [{ name: '아크릴', ratio: 50 }, { name: '폴리', ratio: 30 }, { name: '나일론', ratio: 20 }], quantity: 37, weight: '29.6kg' },
 ]
 
-const categoryOptions = ['상의', '바지', '치마', '아우터']
-const childCategoryMap = {
-  상의: ['반팔', '긴팔', '셔츠', '니트', '후드티'],
-  바지: ['청바지', '반바지', '긴바지', '츄리닝'],
-  치마: ['미니스커트', '롱스커트'],
-  아우터: ['패딩', '후드집업', '자켓', '가디건'],
+const naturalSingleMaterials = ['면', '울', '캐시미어', '실크', '린넨']
+const syntheticMaterials = ['폴리에스터', '아크릴', '나일론', '스판덱스']
+const materialGroupOptions = ['천연 단일 섬유', '합성 섬유', '혼방']
+const materialNameAliasMap = {
+  코튼: '면',
+  cotton: '면',
+  폴리: '폴리에스터',
+  polyester: '폴리에스터',
+  acrylic: '아크릴',
+  polyamide: '나일론',
+  nylon: '나일론',
+  elastane: '스판덱스',
+  스판: '스판덱스',
+  spandex: '스판덱스',
+  wool: '울',
+  cashmere: '캐시미어',
+  silk: '실크',
+  linen: '린넨',
 }
-const materialOptions = ['면', '폴리에스터', '울', '아크릴', '데님', '나일론', '폴리', '스판', '덕다운', '합성피혁']
+const materialOptions = [
+  ...naturalSingleMaterials,
+  ...syntheticMaterials,
+  '혼방',
+]
+const materialOptionsByGroup = {
+  '천연 단일 섬유': naturalSingleMaterials,
+  '합성 섬유': syntheticMaterials,
+  혼방: [...naturalSingleMaterials, ...syntheticMaterials],
+}
+const colorOptions = ['검정', '흰색', '그레이', '아이보리']
+const colorCodeMap = { 검정: 'BLK', 흰색: 'WHT', 그레이: 'GRY', 아이보리: 'IVR' }
+const sizeOptions = ['XS', 'S', 'M', 'L', 'XL']
 
-const childCategoryOptions = computed(() =>
-  selectedCategory.value ? childCategoryMap[selectedCategory.value] : [],
+const normalizeMaterialName = (name) => {
+  const normalized = String(name ?? '').trim()
+  const lower = normalized.toLowerCase()
+  return materialNameAliasMap[lower] ?? materialNameAliasMap[normalized] ?? normalized
+}
+
+const normalizedInventoryData = computed(() =>
+  circularInventoryData.map((item) => ({
+    ...item,
+    materials: item.materials.map(material => ({
+      ...material,
+      name: normalizeMaterialName(material.name),
+    })),
+  })),
 )
 
+const deriveMaterialType = (materials) => {
+  if (!Array.isArray(materials) || materials.length === 0) return '혼방'
+  if (materials.length >= 2) return '혼방'
+
+  const [single] = materials
+  const isPureSingle = Number(single.ratio) === 100
+  if (!isPureSingle) return '혼방'
+
+  if (naturalSingleMaterials.includes(single.name)) return '천연 단일 섬유'
+  if (syntheticMaterials.includes(single.name)) return '합성 섬유'
+  return '혼방'
+}
+
+const formatMaterialDetail = (materials) => {
+  if (!Array.isArray(materials) || materials.length === 0) return '-'
+  const sorted = [...materials].sort((a, b) => b.ratio - a.ratio)
+  if (sorted.length === 1 && Number(sorted[0].ratio) === 100) return `${sorted[0].name} 100%`
+  if (sorted.length >= 3) {
+    const primary = sorted[0]
+    const restRatio = sorted.slice(1).reduce((sum, material) => sum + Number(material.ratio || 0), 0)
+    return `${primary.name} ${primary.ratio}% + 기타 ${restRatio}%`
+  }
+  return sorted.map(material => `${material.name} ${material.ratio}%`).join(' + ')
+}
+
+const parseWeight = (weight) => Number(String(weight).replace('kg', '')) || 0
+const formatPerItemWeight = (weight, quantity) => {
+  if (!quantity || quantity <= 0) return '0kg'
+  const perItemWeight = parseWeight(weight) / quantity
+  return `${perItemWeight.toFixed(2)}kg`
+}
+
 const activeMaterialFilters = computed(() =>
-  materialFilters.value.filter(filter => filter.material),
+  materialFilters.value.filter(filter => filter.materialGroup),
 )
 
 const materialFilterSummary = computed(() => {
   if (activeMaterialFilters.value.length === 0) return '소재 조건 없음'
 
   const [firstFilter] = activeMaterialFilters.value
-  const firstLabel = firstFilter.minRatio
-    ? `${firstFilter.material} ${firstFilter.minRatio}% 이상`
-    : firstFilter.material
+  const materialLabel = firstFilter.material
+    ? `${firstFilter.materialGroup || '섬유 구분'} / ${firstFilter.material}`
+    : (firstFilter.materialGroup || '섬유 구분')
+  const firstLabel = firstFilter.material && firstFilter.minRatio
+    ? `${materialLabel} ${firstFilter.minRatio}% 이상`
+    : materialLabel
   const restCount = activeMaterialFilters.value.length - 1
 
   return restCount > 0 ? `${firstLabel} 외 ${restCount}건` : firstLabel
 })
 
+const skuInventoryData = computed(() => {
+  const partitionRatios = [
+    0.08, 0.05, 0.06, 0.05, 0.04,
+    0.07, 0.06, 0.07, 0.06, 0.05,
+    0.05, 0.04, 0.05, 0.04, 0.04,
+    0.06, 0.04, 0.05, 0.04, 0.05,
+  ]
+
+  return normalizedInventoryData.value.flatMap((item) => {
+    const totalWeight = parseWeight(item.weight)
+    const perUnitWeight = item.quantity > 0 ? totalWeight / item.quantity : 0
+
+    return colorOptions.flatMap((color, colorIndex) =>
+      sizeOptions.map((size, sizeIndex) => {
+        const partitionIndex = colorIndex * sizeOptions.length + sizeIndex
+        const quantity = Math.max(1, Math.round(item.quantity * partitionRatios[partitionIndex]))
+        const skuWeight = (quantity * perUnitWeight).toFixed(1)
+
+        return {
+          id: `${item.id}-${color}-${size}`,
+          skuCode: `${item.itemCode}-${colorCodeMap[color]}-${size}`,
+          itemCode: item.itemCode,
+          category: `${item.parentCategory} > ${item.childCategory}`,
+          itemName: item.itemName,
+          color,
+          size,
+          materials: item.materials,
+          quantity,
+          weight: `${skuWeight}kg`,
+        }
+      }),
+    )
+  })
+})
+
 const filteredInventoryBase = computed(() => {
-  return circularInventoryData.filter((item) => {
-    const matchesCategory = !selectedCategory.value || item.parentCategory === selectedCategory.value
-    const matchesChildCategory = !selectedChildCategory.value || item.childCategory === selectedChildCategory.value
+  const keyword = searchTerm.value.trim().toLowerCase()
+
+  return skuInventoryData.value
+    .map(item => ({
+      ...item,
+      materialType: deriveMaterialType(item.materials),
+      materialDetail: formatMaterialDetail(item.materials),
+    }))
+    .filter((item) => {
     const matchesMaterial = activeMaterialFilters.value.every((filter) => {
+      if (!filter.materialGroup) return false
+
+      const matchesGroup = filter.materialGroup === '혼방'
+        ? item.materialType === '혼방'
+        : item.materialType === filter.materialGroup
+      if (!matchesGroup) return false
+
+      if (!filter.material) return true
+
       const itemMaterial = item.materials.find(material => material.name === filter.material)
       if (!itemMaterial) return false
 
       const minRatio = Number(filter.minRatio) || 0
       return minRatio === 0 || itemMaterial.ratio >= minRatio
     })
+    const matchesSearch = !keyword || [item.itemCode, item.itemName, item.materialDetail]
+      .join(' ')
+      .toLowerCase()
+      .includes(keyword)
 
-    return matchesCategory && matchesChildCategory && matchesMaterial
+    return matchesMaterial && matchesSearch
   })
 })
-
-const parseWeight = (weight) => Number(String(weight).replace('kg', '')) || 0
 
 const filteredInventory = computed(() => {
   const rows = [...filteredInventoryBase.value]
   if (!sortKey.value) return rows
 
   return rows.sort((a, b) => {
-    const aValue = sortKey.value === 'weight' ? parseWeight(a.weight) : a[sortKey.value]
-    const bValue = sortKey.value === 'weight' ? parseWeight(b.weight) : b[sortKey.value]
+    const aValue = sortKey.value === 'weight'
+      ? parseWeight(a.weight)
+      : sortKey.value === 'skuCode'
+        ? a.skuCode
+        : a[sortKey.value]
+    const bValue = sortKey.value === 'weight'
+      ? parseWeight(b.weight)
+      : sortKey.value === 'skuCode'
+        ? b.skuCode
+        : b[sortKey.value]
     const direction = sortDirection.value === 'asc' ? 1 : -1
 
+    if (typeof aValue === 'string' && typeof bValue === 'string') {
+      return aValue.localeCompare(bValue, 'ko') * direction
+    }
     return (aValue - bValue) * direction
   })
 })
@@ -105,9 +238,7 @@ const isAllSelected = computed(() =>
 )
 
 const canRegisterSale = computed(() => selectedInventoryIds.value.length > 0)
-
-const formatMaterials = (materials) =>
-  materials.map(material => `${material.name} ${material.ratio}%`).join(', ')
+const filteredItemCount = computed(() => new Set(filteredInventory.value.map(item => item.itemCode)).size)
 
 const toggleInventory = (itemId) => {
   selectedInventoryIds.value = selectedInventoryIds.value.includes(itemId)
@@ -123,12 +254,19 @@ const toggleAllInventory = () => {
     : [...new Set([...selectedInventoryIds.value, ...filteredIds])]
 }
 
-const isMaterialDisabled = (material, index) =>
-  materialFilters.value.some((filter, filterIndex) => filterIndex !== index && filter.material === material)
+const isMaterialDisabled = (material, index) => {
+  const currentFilter = materialFilters.value[index]
+  return materialFilters.value.some((filter, filterIndex) =>
+    filterIndex !== index
+    && filter.materialGroup === currentFilter?.materialGroup
+    && filter.material === material,
+  )
+}
 
 const addMaterialFilter = () => {
-  if (materialFilters.value.length >= materialOptions.length) return
-  materialFilters.value = [...materialFilters.value, { material: '', minRatio: '' }]
+  const maxFilterCount = materialGroupOptions.length + materialOptions.length
+  if (materialFilters.value.length >= maxFilterCount) return
+  materialFilters.value = [...materialFilters.value, { materialGroup: '', material: '', minRatio: '' }]
 }
 
 const removeMaterialFilter = (index) => {
@@ -137,10 +275,6 @@ const removeMaterialFilter = (index) => {
 
 const clearMaterialFilters = () => {
   materialFilters.value = []
-}
-
-const handleCategoryChange = () => {
-  selectedChildCategory.value = ''
 }
 
 const toggleSort = (key) => {
@@ -159,8 +293,7 @@ const sortIcon = (key) => {
 }
 
 const resetFilters = () => {
-  selectedCategory.value = ''
-  selectedChildCategory.value = ''
+  searchTerm.value = ''
   materialFilters.value = []
   isMaterialDropdownOpen.value = false
 }
@@ -214,35 +347,7 @@ onBeforeUnmount(() => {
           </button>
         </div>
 
-        <div class="mt-4 grid items-end gap-3 xl:grid-cols-[8.5rem_9rem_minmax(18rem,1fr)_auto]">
-          <label class="flex flex-col gap-1.5">
-            <span class="text-[11px] font-bold text-gray-500">카테고리</span>
-            <select
-              v-model="selectedCategory"
-              class="h-9 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none focus:border-[#004D3C]"
-              @change="handleCategoryChange"
-            >
-              <option value="">전체</option>
-              <option v-for="category in categoryOptions" :key="category" :value="category">
-                {{ category }}
-              </option>
-            </select>
-          </label>
-
-          <label class="flex flex-col gap-1.5">
-            <span class="text-[11px] font-bold text-gray-500">하위 카테고리</span>
-            <select
-              v-model="selectedChildCategory"
-              class="h-9 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none focus:border-[#004D3C] disabled:bg-gray-50 disabled:text-gray-400"
-              :disabled="!selectedCategory"
-            >
-              <option value="">전체</option>
-              <option v-for="category in childCategoryOptions" :key="category" :value="category">
-                {{ category }}
-              </option>
-            </select>
-          </label>
-
+        <div class="mt-4 grid items-end gap-3 xl:grid-cols-[minmax(24rem,1fr)_minmax(16rem,1fr)_auto]">
           <div ref="materialDropdownRef" class="relative flex flex-col gap-1.5">
             <span class="text-[11px] font-bold text-gray-500">소재 조건</span>
             <button
@@ -282,15 +387,27 @@ onBeforeUnmount(() => {
                 <div
                   v-for="(filter, index) in materialFilters"
                   :key="index"
-                  class="grid grid-cols-[minmax(8rem,1fr)_6rem_auto_2rem] items-center gap-2"
+                  class="grid grid-cols-[minmax(8rem,1fr)_minmax(8rem,1fr)_6rem_auto_2rem] items-center gap-2"
                 >
+                  <select
+                    v-model="filter.materialGroup"
+                    class="h-8 border border-gray-200 bg-gray-50 px-2 text-[11px] font-bold text-gray-900 outline-none focus:border-[#004D3C] focus:bg-white"
+                    @change="filter.material = ''"
+                  >
+                    <option value="">섬유 구분 선택</option>
+                    <option v-for="group in materialGroupOptions" :key="group" :value="group">
+                      {{ group }}
+                    </option>
+                  </select>
+
                   <select
                     v-model="filter.material"
                     class="h-8 border border-gray-200 bg-gray-50 px-2 text-[11px] font-bold text-gray-900 outline-none focus:border-[#004D3C] focus:bg-white"
+                    :disabled="!filter.materialGroup"
                   >
-                    <option value="">소재 선택</option>
+                    <option value="">소재 상세 선택</option>
                     <option
-                      v-for="material in materialOptions"
+                      v-for="material in (materialOptionsByGroup[filter.materialGroup] ?? [])"
                       :key="material"
                       :value="material"
                       :disabled="isMaterialDisabled(material, index)"
@@ -307,7 +424,6 @@ onBeforeUnmount(() => {
                     class="h-8 border border-gray-200 bg-gray-50 px-2 text-right text-[11px] font-bold text-gray-900 outline-none focus:border-[#004D3C] focus:bg-white"
                     placeholder="0"
                   />
-                  <span class="text-[10px] font-black text-gray-400">% 이상</span>
                   <button
                     type="button"
                     class="h-8 border border-gray-200 text-[12px] font-black text-gray-400 hover:bg-gray-50 hover:text-black"
@@ -329,13 +445,23 @@ onBeforeUnmount(() => {
               <button
                 type="button"
                 class="mt-3 h-8 w-full border border-[#D6EAEA] bg-[#EBF5F5] text-xs font-black text-[#004D3C] transition hover:bg-[#dff0f0] disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-400"
-                :disabled="materialFilters.length >= materialOptions.length"
+                :disabled="materialFilters.length >= materialGroupOptions.length + materialOptions.length"
                 @click="addMaterialFilter"
               >
                 + 조건 추가
               </button>
             </div>
           </div>
+
+          <label class="flex flex-col gap-1.5">
+            <span class="text-[11px] font-bold text-gray-500">검색</span>
+            <input
+              v-model="searchTerm"
+              type="search"
+              class="h-9 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none placeholder:text-gray-400 focus:border-[#004D3C]"
+              placeholder="품목 코드, 품목명, 소재 상세"
+            />
+          </label>
 
           <button
             type="button"
@@ -352,16 +478,16 @@ onBeforeUnmount(() => {
           <div>
             <h2 class="text-sm font-black text-gray-900">순환 재고 리스트</h2>
             <p class="mt-1 text-[11px] font-bold text-gray-400">
-              조회 {{ filteredInventory.length.toLocaleString() }}건 · 선택 {{ selectedInventoryIds.length.toLocaleString() }}건
+              조회 품목 {{ filteredItemCount.toLocaleString() }}건 · 조회 SKU {{ filteredInventory.length.toLocaleString() }}건 · 선택 SKU {{ selectedInventoryIds.length.toLocaleString() }}건
             </p>
           </div>
         </div>
 
         <div class="overflow-x-auto">
-          <table class="min-w-[980px] w-full border-collapse text-left text-xs">
+          <table class="w-full table-fixed border-collapse text-left text-xs min-w-[1200px]">
             <thead class="bg-gray-50 text-[10px] uppercase tracking-[0.12em] text-gray-500">
               <tr>
-                <th class="w-16 px-3 py-3 text-center font-black">
+                <th class="w-10 px-3 py-3 text-center font-black">
                   <input
                     type="checkbox"
                     class="h-3.5 w-3.5 accent-[#004D3C]"
@@ -369,22 +495,31 @@ onBeforeUnmount(() => {
                     @change="toggleAllInventory"
                   />
                 </th>
-                <th class="px-3 py-3 font-black">품목 코드</th>
-                <th class="px-3 py-3 font-black">카테고리</th>
+                <th class="w-[176px] px-3 py-3 font-black">
+                  <button type="button" class="inline-flex items-center gap-1 hover:text-gray-900" @click="toggleSort('skuCode')">
+                    SKU 코드
+                    <span class="text-[9px]">{{ sortIcon('skuCode') }}</span>
+                  </button>
+                </th>
+                <th class="w-[120px] px-3 py-3 font-black">품목 코드</th>
                 <th class="px-3 py-3 font-black">품목명</th>
-                <th class="px-3 py-3 font-black">소재</th>
-                <th class="px-3 py-3 text-right font-black">
-                  <button type="button" class="inline-flex items-center gap-1 hover:text-gray-900" @click="toggleSort('quantity')">
+                <th class="w-[72px] px-3 py-3 text-center font-black">색상</th>
+                <th class="w-[56px] px-3 py-3 text-center font-black">사이즈</th>
+                <th class="w-[120px] px-3 py-3 font-black">소재 구분</th>
+                <th class="w-[160px] px-3 py-3 font-black">소재 상세</th>
+                <th class="w-[84px] px-3 py-3 text-right font-black">
+                  <button type="button" class="flex w-full items-center justify-end gap-1 hover:text-gray-900" @click="toggleSort('quantity')">
                     수량
                     <span class="text-[9px]">{{ sortIcon('quantity') }}</span>
                   </button>
                 </th>
-                <th class="px-3 py-3 text-right font-black">
-                  <button type="button" class="inline-flex items-center gap-1 hover:text-gray-900" @click="toggleSort('weight')">
+                <th class="w-[80px] px-3 py-3 text-right font-black">
+                  <button type="button" class="flex w-full items-center justify-end gap-1 hover:text-gray-900" @click="toggleSort('weight')">
                     무게
                     <span class="text-[9px]">{{ sortIcon('weight') }}</span>
                   </button>
                 </th>
+                <th class="w-[110px] px-3 py-3 text-right font-black">옷 하나당 무게</th>
               </tr>
             </thead>
             <tbody class="divide-y divide-gray-100">
@@ -403,15 +538,19 @@ onBeforeUnmount(() => {
                     @click.stop="toggleInventory(item.id)"
                   />
                 </td>
-                <td class="px-3 py-3 font-mono font-bold text-gray-500">{{ item.itemCode }}</td>
-                <td class="px-3 py-3 font-bold text-gray-700">{{ item.parentCategory }} &gt; {{ item.childCategory }}</td>
-                <td class="px-3 py-3 font-black text-gray-900">{{ item.itemName }}</td>
-                <td class="px-3 py-3 font-black text-gray-900">{{ formatMaterials(item.materials) }}</td>
+                <td class="px-3 py-3 font-mono font-bold text-gray-600 whitespace-nowrap">{{ item.skuCode }}</td>
+                <td class="px-3 py-3 font-mono font-bold text-gray-500 whitespace-nowrap">{{ item.itemCode }}</td>
+                <td class="px-3 py-3 font-black text-gray-900 truncate">{{ item.itemName }}</td>
+                <td class="px-3 py-3 text-center font-black text-gray-900">{{ item.color }}</td>
+                <td class="px-3 py-3 text-center font-black text-gray-900">{{ item.size }}</td>
+                <td class="px-3 py-3 font-black text-gray-900">{{ item.materialType }}</td>
+                <td class="px-3 py-3 font-black text-gray-900 truncate">{{ item.materialDetail }}</td>
                 <td class="px-3 py-3 text-right font-black text-gray-900">{{ item.quantity.toLocaleString() }}</td>
                 <td class="px-3 py-3 text-right font-black text-gray-900">{{ item.weight }}</td>
+                <td class="px-3 py-3 text-right font-black text-gray-900">{{ formatPerItemWeight(item.weight, item.quantity) }}</td>
               </tr>
               <tr v-if="filteredInventory.length === 0">
-                <td colspan="7" class="px-3 py-14 text-center text-sm font-bold text-gray-400">
+                <td colspan="11" class="px-3 py-14 text-center text-sm font-bold text-gray-400">
                   조건에 맞는 순환 재고가 없습니다.
                 </td>
               </tr>


### PR DESCRIPTION
## 📌 요약
- 순환 재고 조회/후보 화면을 품목 단위에서 SKU 단위 중심으로 개편했습니다.
- 소재 표현을 `소재 구분 / 소재 상세` 2열로 정리하고, 소재 조건 필터를 2단계 구조로 개선했습니다.

<br><br>

## 🎯 작업 내용
- 순환 재고 리스트를 SKU 기준으로 전환하고 선택/정렬/페이지네이션 동작을 SKU 기준으로 정비
- 소재 조건 필터를 `섬유 구분(천연 단일 섬유/합성 섬유/혼방) → 소재 상세 → % 이상` 2단계 선택 구조로 개편
- 검색창(품목 코드/품목명/소재 상세) 반영, 소재 상세 문자열 템플릿 통일, 혼방 3개 이상은 `대표소재 + 기타` 형태로 축약
- 테이블 열 간격/너비 조정 및 우측 `옷 하나당 무게(무게/수량)` 컬럼 추가

<br><br>

## ✔️ 참고 사항
- 혼방에서 소재 상세는 전체 소재(천연+합성) 선택 가능하도록 처리했습니다.
- `옷 하나당 무게`는 표시 전용 컬럼이며, 수량이 0 이하인 경우 안전 가드 처리됩니다.

<br><br>

## ✔️ 관련 이슈

- Close #308

<br><br>
