### PR TITLE
refactor(purchase-order): 발주 상세 패널 품목에 SKU 옵션 노출

### DIFF
--- a/src/views/hq/HqPurchaseOrderView.vue
+++ b/src/views/hq/HqPurchaseOrderView.vue
@@ -558,15 +558,26 @@ const TruckIcon = IconBase([
                   </tr>
                 </thead>
                 <tbody class="divide-y divide-gray-100">
-                  <tr v-for="item in poStore.selectedOrder.items" :key="item.id">
-                    <td class="px-2 py-2 font-bold text-gray-800">{{ item.productName }}</td>
-                    <td class="px-2 py-2 text-right font-bold text-gray-700">
+                  <tr v-for="item in poStore.selectedOrder.items" :key="item.skuCode || item.productId">
+                    <td class="px-2 py-2 align-top">
+                      <div class="font-bold text-gray-800">{{ item.productName }}</div>
+                      <div v-if="item.optionValue" class="mt-0.5 text-[11px] font-bold text-[#004D3C]">
+                        {{ item.optionValue }}
+                        <span v-if="item.optionName" class="ml-1 font-normal text-gray-400">
+                          ({{ item.optionName }})
+                        </span>
+                      </div>
+                      <div v-if="item.skuCode" class="text-[10px] text-gray-400">
+                        {{ item.skuCode }}
+                      </div>
+                    </td>
+                    <td class="px-2 py-2 text-right font-bold text-gray-700 align-top">
                       {{ item.quantity }}
                     </td>
-                    <td class="px-2 py-2 text-right text-gray-500">
+                    <td class="px-2 py-2 text-right text-gray-500 align-top">
                       ₩{{ item.unitPrice.toLocaleString() }}
                     </td>
-                    <td class="px-2 py-2 text-right font-bold text-gray-700">
+                    <td class="px-2 py-2 text-right font-bold text-gray-700 align-top">
                       ₩{{ item.subtotal.toLocaleString() }}
                     </td>
                   </tr>


### PR DESCRIPTION
## 📌 요약
- 발주 상세 [발주 품목] 표가 `productName`만 노출하던 문제 정리
- BE `DetailRes`의 `skuCode` / `optionName` / `optionValue`를 카탈로그·cart 표기 규칙에 맞춰 표시

<br><br>

## 🎯 작업 내용
- 품목 행에 옵션 값 / 캡션 / SKU 코드 함께 노출
- 카탈로그·장바구니와 동일한 표기 규칙 적용 (일관성)

<br><br>

## ✔️ 참고 사항
- BE 응답 변경 없음 — FE 표시 정합만 정리

<br><br>

## ✔️ 관련 이슈
- Close #326 