### PR TITLE
refactor: 제품 마스터 등록 폼 UX 개선 및 인프라 관리 화면 정리

### DIFF
--- a/src/api/infrastructure.js
+++ b/src/api/infrastructure.js
@@ -5,6 +5,11 @@ export async function getStores(params = {}) {
   return unwrap(res)
 }
 
+export async function getStoreByCode(code) {
+  const res = await api.get(`/api/hq/stores/${code}`)
+  return unwrap(res)
+}
+
 export async function createStore(payload) {
   const res = await api.post('/api/hq/stores', payload)
   return unwrap(res)
@@ -17,6 +22,11 @@ export async function updateStore(storeCode, payload) {
 
 export async function getWarehouses(params = {}) {
   const res = await api.get('/api/hq/warehouses', { params })
+  return unwrap(res)
+}
+
+export async function getWarehouseByCode(code) {
+  const res = await api.get(`/api/hq/warehouses/${code}`)
   return unwrap(res)
 }
 

--- a/src/config/roleMenus.js
+++ b/src/config/roleMenus.js
@@ -52,8 +52,7 @@ export const roleMenus = {
       path: '/hq/infrastructure',
       icon: 'store',
       children: [
-        { label: '매장 정보 관리', path: '/hq/infrastructure?menu=매장%20정보%20관리' },
-        { label: '창고 정보 관리', path: '/hq/infrastructure?menu=창고%20정보%20관리' },
+        { label: '매장/창고 정보 관리', path: '/hq/infrastructure' },
       ],
     },
     {

--- a/src/views/hq/HqInfrastructureManagementView.vue
+++ b/src/views/hq/HqInfrastructureManagementView.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed, h, onMounted, ref, watch } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { useRouter } from 'vue-router'
 import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
@@ -14,7 +14,6 @@ import {
 } from '@/api/infrastructure.js'
 
 const router = useRouter()
-const route = useRoute()
 const auth = useAuthStore()
 const hqMenus = roleMenus.hq
 
@@ -27,18 +26,14 @@ const brandColor = '#004D3C'
 const brandColorLight = '#E6F2F0'
 
 const activeTopMenu = computed(() => '인프라 관리')
-const menuLabels = ['매장 정보 관리', '창고 정보 관리']
-const activeSideMenu = ref(
-  typeof route.query.menu === 'string' && menuLabels.includes(route.query.menu)
-    ? route.query.menu
-    : '매장 정보 관리',
-)
-const storeRegionFilter = ref(typeof route.query.region === 'string' ? route.query.region : '전체 지역')
-const storeStatusFilter = ref(typeof route.query.status === 'string' ? route.query.status : '전체')
-const storeSearchTerm = ref(typeof route.query.search === 'string' ? route.query.search : '')
-const warehouseRegionFilter = ref(typeof route.query.region === 'string' ? route.query.region : '전체 지역')
-const warehouseStatusFilter = ref(typeof route.query.status === 'string' ? route.query.status : '전체')
-const warehouseSearchTerm = ref(typeof route.query.search === 'string' ? route.query.search : '')
+const activeSideMenu = ref('인프라 통합 조회')
+const viewType = ref('store')
+const storeRegionFilter = ref('전체 지역')
+const storeStatusFilter = ref('전체')
+const storeSearchTerm = ref('')
+const warehouseRegionFilter = ref('전체 지역')
+const warehouseStatusFilter = ref('전체')
+const warehouseSearchTerm = ref('')
 
 const topMenus = [
   '대시보드',
@@ -59,8 +54,7 @@ const routeMap = {
 }
 
 const infraSideMenus = [
-  { label: '매장 정보 관리', icon: 'store', id: 'SO-036' },
-  { label: '창고 정보 관리', icon: 'warehouse', id: 'SO-040' },
+  { label: '인프라 통합 조회', icon: 'store', id: 'SO-036' },
 ]
 
 const storeData = ref([])
@@ -93,14 +87,14 @@ if (!warehouseStatusOptions.includes(warehouseStatusFilter.value)) {
 
 const filteredWarehouseData = computed(() => warehouseData.value)
 
-const isStoreMenu = computed(() => activeSideMenu.value === '매장 정보 관리')
-const isWarehouseMenu = computed(() => activeSideMenu.value === '창고 정보 관리')
+const isStoreView = computed(() => viewType.value === 'store')
+const isWarehouseView = computed(() => viewType.value === 'warehouse')
 const activeSearchTerm = computed({
   get() {
-    return isWarehouseMenu.value ? warehouseSearchTerm.value : storeSearchTerm.value
+    return isWarehouseView.value ? warehouseSearchTerm.value : storeSearchTerm.value
   },
   set(value) {
-    if (isWarehouseMenu.value) {
+    if (isWarehouseView.value) {
       warehouseSearchTerm.value = value
       return
     }
@@ -132,22 +126,12 @@ const goToWarehouseDetail = (warehouse) => {
     name: 'hq-infrastructure-warehouse-detail',
     params: { warehouseId: warehouse.code },
     query: {
-      menu: '창고 정보 관리',
       region: warehouseRegionFilter.value !== '전체 지역' ? warehouseRegionFilter.value : undefined,
       status: warehouseStatusFilter.value !== '전체' ? warehouseStatusFilter.value : undefined,
       search: warehouseSearchTerm.value || undefined,
     },
   })
 }
-
-watch(
-  () => route.query.menu,
-  (menu) => {
-    if (typeof menu === 'string' && menuLabels.includes(menu)) {
-      activeSideMenu.value = menu
-    }
-  },
-)
 
 const statusToKor = {
   ACTIVE: '활성',
@@ -203,20 +187,22 @@ async function loadWarehouses() {
 async function reloadActiveMenuData() {
   try {
     infraError.value = ''
-    if (isStoreMenu.value) await loadStores()
-    if (isWarehouseMenu.value) await loadWarehouses()
+    if (isStoreView.value) await loadStores()
+    if (isWarehouseView.value) await loadWarehouses()
   } catch (e) {
     infraError.value = e.message
   }
 }
 
 watch([storeRegionFilter, storeStatusFilter, storeSearchTerm], () => {
-  if (isStoreMenu.value) reloadActiveMenuData()
+  if (isStoreView.value) reloadActiveMenuData()
 })
 watch([warehouseRegionFilter, warehouseStatusFilter, warehouseSearchTerm], () => {
-  if (isWarehouseMenu.value) reloadActiveMenuData()
+  if (isWarehouseView.value) reloadActiveMenuData()
 })
-watch(activeSideMenu, () => reloadActiveMenuData())
+watch(viewType, () => {
+  reloadActiveMenuData()
+})
 
 async function quickCreateStore() {
   const name = prompt('매장명을 입력하세요')
@@ -330,13 +316,20 @@ const iconMap = {
         <section class="panel filter-bar">
           <div class="filter-left">
             <div class="filter-item">
+              <span>조회 대상</span>
+              <select v-model="viewType">
+                <option value="store">매장</option>
+                <option value="warehouse">창고</option>
+              </select>
+            </div>
+            <div class="filter-item">
               <span>지역 분류</span>
-              <select v-if="isStoreMenu" v-model="storeRegionFilter">
+              <select v-if="isStoreView" v-model="storeRegionFilter">
                 <option v-for="region in storeRegionOptions" :key="region" :value="region">
                   {{ region }}
                 </option>
               </select>
-              <select v-else-if="isWarehouseMenu" v-model="warehouseRegionFilter">
+              <select v-else-if="isWarehouseView" v-model="warehouseRegionFilter">
                 <option v-for="region in warehouseRegionOptions" :key="region" :value="region">
                   {{ region }}
                 </option>
@@ -351,19 +344,19 @@ const iconMap = {
             </div>
             <div class="filter-item">
               <span>운영 상태</span>
-              <select v-if="isStoreMenu" v-model="storeStatusFilter">
+              <select v-if="isStoreView" v-model="storeStatusFilter">
                 <option>전체</option>
                 <option>활성</option>
                 <option>비활성</option>
               </select>
-              <select v-else-if="isWarehouseMenu" v-model="warehouseStatusFilter">
+              <select v-else-if="isWarehouseView" v-model="warehouseStatusFilter">
                 <option v-for="status in warehouseStatusOptions" :key="status" :value="status">
                   {{ status }}
                 </option>
               </select>
               <select v-else>
                 <option>전체</option>
-                <option>{{ isWarehouseMenu ? '활성 창고' : '활성 매장' }}</option>
+                <option>{{ isWarehouseView ? '활성 창고' : '활성 매장' }}</option>
                 <option>비활성</option>
               </select>
             </div>
@@ -374,7 +367,7 @@ const iconMap = {
                   v-model="activeSearchTerm"
                   type="text"
                   :placeholder="
-                    isWarehouseMenu
+                    isWarehouseView
                       ? '창고명, 창고 ID, 담당 책임자 통합 검색...'
                       : '매장명, 매장 ID, 담당자 통합 검색...'
                   "
@@ -384,7 +377,7 @@ const iconMap = {
         </section>
         <p v-if="infraError" class="text-xs font-bold text-red-600">{{ infraError }}</p>
 
-        <section v-if="activeSideMenu === '매장 정보 관리'" class="panel store-panel">
+        <section v-if="isStoreView" class="panel store-panel">
             <div class="store-head">
               <div class="store-head-left">
                 <h3 class="text-[11px] font-black uppercase tracking-[0.08em] text-gray-700">
@@ -392,7 +385,6 @@ const iconMap = {
                 </h3>
                 <span class="text-[10px] font-bold text-gray-400">Total: {{ filteredStoreData.length }} Locations</span>
               </div>
-              <button type="button" class="primary-button" @click="quickCreateStore">매장 등록</button>
             </div>
 
             <div class="store-card-grid">
@@ -414,26 +406,27 @@ const iconMap = {
                   <span class="inline-flex items-center bg-gray-100 px-2 py-1 text-[10px] font-bold text-gray-600">{{ store.region }}</span>
                 </div>
 
-                <p class="text-[11px] font-bold text-gray-600">
-                  담당 창고: <span class="text-gray-800">{{ store.warehouse }}</span>
-                </p>
+                <p class="warehouse-address">{{ store.address }}</p>
 
-                <div class="store-stock-graph">
-                  <div class="store-stock-head">
-                    <span>남은 재고량</span>
-                    <strong :class="{ low: store.remainingRate < 30 }">{{ store.remainingRate }}%</strong>
-                  </div>
-                  <div class="store-stock-track">
-                    <div
-                      class="store-stock-fill"
-                      :class="{ low: store.remainingRate < 30, caution: store.remainingRate >= 30 && store.remainingRate < 60 }"
-                      :style="{ width: `${store.remainingRate}%` }"
-                    />
-                  </div>
-                  <p class="store-stock-meta">
-                    {{ store.remainingStock.toLocaleString() }} / {{ store.stockCapacity.toLocaleString() }} EA
+                <div class="warehouse-meta-grid">
+                  <p class="warehouse-meta-row">
+                    <span>운영유형</span>
+                    <strong>{{ store.type }}</strong>
+                  </p>
+                  <p class="warehouse-meta-row">
+                    <span>담당자</span>
+                    <strong>{{ store.manager }}</strong>
+                  </p>
+                  <p class="warehouse-meta-row">
+                    <span>연락처</span>
+                    <strong>{{ store.contact }}</strong>
+                  </p>
+                  <p class="warehouse-meta-row full">
+                    <span>담당 창고</span>
+                    <strong class="text-[#0f766e]">{{ store.warehouse }}</strong>
                   </p>
                 </div>
+
               </article>
 
               <div v-if="filteredStoreData.length === 0" class="store-empty">
@@ -452,13 +445,12 @@ const iconMap = {
             </div>
         </section>
 
-        <section v-else-if="activeSideMenu === '창고 정보 관리'" class="panel store-panel">
+        <section v-else-if="isWarehouseView" class="panel store-panel">
             <div class="store-head">
               <div class="store-head-left">
                 <h3><WarehouseIcon :size="14" /> 전사 창고 마스터 정보 (SO-041)</h3>
                 <span>Total: {{ filteredWarehouseData.length }} Warehouses</span>
               </div>
-              <button type="button" class="primary-button" @click="quickCreateWarehouse">창고 등록</button>
             </div>
 
             <div class="store-card-grid">
@@ -525,7 +517,7 @@ const iconMap = {
         </section>
 
         <section v-else class="panel placeholder-panel">
-          <p>현재 {{ activeSideMenu }} 페이지가 준비 중입니다.</p>
+          <p>현재 페이지가 준비 중입니다.</p>
         </section>
     </div>
   </AppLayout>
@@ -947,6 +939,10 @@ const iconMap = {
   color: #6b7280;
   font-size: 11px;
   font-weight: 700;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .warehouse-meta-grid {

--- a/src/views/hq/HqProductCreateView.vue
+++ b/src/views/hq/HqProductCreateView.vue
@@ -6,6 +6,7 @@ import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
 import { getCategories } from '@/api/category.js'
+import { vendorApi } from '@/api/vendor.js'
 import {
   createProduct,
   createProductSku,
@@ -39,7 +40,7 @@ const productSideMenus = [
 ]
 
 const categoryTree = ref([])
-const COLOR_OPTIONS = ['검정', '흰색', '그레이', '아이보리']
+const COLOR_OPTIONS = ['검정', '흰색', '그레이', '네이비']
 const SIZE_OPTIONS = ['XS', 'S', 'M', 'L', 'XL']
 
 const productName = ref('')
@@ -47,8 +48,10 @@ const parentCategory = ref('')
 const childCategory = ref('')
 const price = ref('')
 const status = ref('활성')
-const vendorName = ref('')
-const leadTimeDays = ref(3)
+const selectedVendorCode = ref('')
+const vendorOptions = ref([])
+const warehouseSafetyStock = ref(0)
+const storeSafetyStock = ref(0)
 const regDate = ref(new Date().toISOString().slice(0, 10).replaceAll('-', '.'))
 const selectedColors = ref([])
 const selectedSizes = ref([])
@@ -59,6 +62,18 @@ const isSubmitting = ref(false)
 
 
 const parentCategoryOptions = computed(() => categoryTree.value.map((c) => c.name))
+const activeVendorOptions = computed(() =>
+  vendorOptions.value.filter(vendor => vendor.status === 'ACTIVE'),
+)
+const selectedVendor = computed(() =>
+  vendorOptions.value.find(vendor => vendor.code === selectedVendorCode.value) ?? null,
+)
+const isSelectedVendorActive = computed(() =>
+  activeVendorOptions.value.some(vendor => vendor.code === selectedVendorCode.value),
+)
+const shouldShowCurrentVendorFallbackOption = computed(() =>
+  Boolean(selectedVendorCode.value) && !isSelectedVendorActive.value,
+)
 const childCategoryOptions = computed(() => {
   const parent = categoryTree.value.find((c) => c.name === parentCategory.value)
   return parent ? parent.children.map((c) => c.name) : []
@@ -82,7 +97,9 @@ const canSubmitCreate = computed(() =>
   parentCategory.value &&
   childCategory.value &&
   Number(price.value) >= 0 &&
-  vendorName.value.trim() &&
+  Number(warehouseSafetyStock.value) >= 0 &&
+  Number(storeSafetyStock.value) >= 0 &&
+  isSelectedVendorActive.value &&
   isVariantValid.value,
 )
 
@@ -91,7 +108,9 @@ const canSubmitEdit = computed(() =>
   parentCategory.value &&
   childCategory.value &&
   Number(price.value) >= 0 &&
-  vendorName.value.trim(),
+  Number(warehouseSafetyStock.value) >= 0 &&
+  Number(storeSafetyStock.value) >= 0 &&
+  isSelectedVendorActive.value,
 )
 
 const statusMap = {
@@ -172,8 +191,9 @@ async function loadProduct() {
   productName.value = product.name || ''
   price.value = Number(product.basePrice || 0)
   status.value = statusLabelMap[product.status] || '활성'
-  vendorName.value = product.mainVendorCode || ''
-  leadTimeDays.value = Number(product.leadTimeDays || 0)
+  selectedVendorCode.value = product.mainVendorCode || ''
+  warehouseSafetyStock.value = Number(product.warehouseSafetyStock || 0)
+  storeSafetyStock.value = Number(product.storeSafetyStock || 0)
 
   const parent = categoryTree.value.find((c) => (c.children || []).some((child) => child.code === product.categoryCode))
   if (parent) {
@@ -209,8 +229,10 @@ async function handleSubmit() {
         name: productName.value.trim(),
         categoryCode,
         basePrice: Number(price.value),
-        leadTimeDays: Number(leadTimeDays.value),
-        mainVendorCode: vendorName.value.trim(),
+        leadTimeDays: 0,
+        warehouseSafetyStock: Number(warehouseSafetyStock.value),
+        storeSafetyStock: Number(storeSafetyStock.value),
+        mainVendorCode: selectedVendorCode.value.trim(),
         status: statusMap[status.value] ?? 'ACTIVE',
       })
 
@@ -231,8 +253,10 @@ async function handleSubmit() {
         name: productName.value.trim(),
         categoryCode,
         basePrice: Number(price.value),
-        leadTimeDays: Number(leadTimeDays.value),
-        mainVendorCode: vendorName.value.trim(),
+        leadTimeDays: 0,
+        warehouseSafetyStock: Number(warehouseSafetyStock.value),
+        storeSafetyStock: Number(storeSafetyStock.value),
+        mainVendorCode: selectedVendorCode.value.trim(),
         status: statusMap[status.value] ?? 'ACTIVE',
       })
       const skuResult = await syncSkusBySelections()
@@ -284,10 +308,15 @@ async function loadCategories() {
   }
 }
 
+async function loadVendors() {
+  const list = await vendorApi.listVendors()
+  vendorOptions.value = list ?? []
+}
+
 onMounted(async () => {
   try {
     submitError.value = ''
-    await loadCategories()
+    await Promise.all([loadCategories(), loadVendors()])
     if (isEditMode.value) {
       await loadProduct()
       await loadSkus()
@@ -308,7 +337,7 @@ onMounted(async () => {
     @logout="handleLogout"
   >
     <div class="flex flex-col gap-4">
-      <section class="border border-gray-200 bg-white p-4 shadow-sm">
+      <section class="border border-gray-300 bg-white p-4 shadow-sm">
         <div class="flex items-center gap-2 text-[11px] font-bold text-gray-400">
           <button type="button" class="hover:text-[#004D3C]" @click="handleCancel">상품 관리</button>
           <ChevronRight :size="12" />
@@ -319,7 +348,7 @@ onMounted(async () => {
         <div class="mt-3 flex items-center gap-3">
           <button
             type="button"
-            class="inline-flex h-8 w-8 items-center justify-center border border-gray-200 text-gray-500 hover:border-[#004D3C] hover:text-[#004D3C]"
+            class="inline-flex h-8 w-8 items-center justify-center border border-gray-300 text-gray-500 hover:border-[#004D3C] hover:text-[#004D3C]"
             @click="handleCancel"
           >
             <ArrowLeft :size="15" />
@@ -333,23 +362,27 @@ onMounted(async () => {
 
       <section class="grid gap-4 xl:grid-cols-[minmax(0,2fr)_minmax(280px,1fr)] xl:items-start">
         <div class="space-y-4">
-          <div class="border border-gray-200 bg-white shadow-sm">
+          <div class="border border-gray-300 bg-white shadow-sm">
             <div class="flex items-center gap-2 border-b border-gray-100 px-5 py-3">
               <Package :size="15" class="text-[#004D3C]" />
               <h2 class="text-sm font-black text-gray-900">제품 정보</h2>
             </div>
 
             <form class="space-y-6 p-5" @submit.prevent="handleSubmit">
-              <div>
-                <label class="mb-1.5 block text-[11px] font-black uppercase tracking-wide text-gray-500">
+              <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <label class="block text-[11px] font-black uppercase tracking-wide text-gray-500">
                   제품명 <span class="text-red-500">*</span>
+                  <input
+                    v-model="productName"
+                    type="text"
+                    placeholder="제품명을 입력하세요"
+                    class="mt-1.5 w-full border border-gray-300 bg-white px-3 py-2.5 text-sm outline-none focus:border-[#004D3C]"
+                  />
                 </label>
-                <input
-                  v-model="productName"
-                  type="text"
-                  placeholder="제품명을 입력하세요"
-                  class="w-full border border-gray-300 bg-white px-3 py-2.5 text-sm outline-none focus:border-[#004D3C]"
-                />
+                <label class="block text-[11px] font-black uppercase tracking-wide text-gray-500">
+                  단가 <span class="text-red-500">*</span>
+                  <input v-model.number="price" type="number" min="0" class="mt-1.5 w-full border border-gray-300 bg-white px-3 py-2.5 text-sm outline-none focus:border-[#004D3C]" />
+                </label>
               </div>
 
               <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
@@ -369,10 +402,6 @@ onMounted(async () => {
 
               <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 <label class="block text-[11px] font-black uppercase tracking-wide text-gray-500">
-                  단가 <span class="text-red-500">*</span>
-                  <input v-model.number="price" type="number" min="0" class="mt-1.5 w-full border border-gray-300 bg-white px-3 py-2.5 text-sm outline-none focus:border-[#004D3C]" />
-                </label>
-                <label class="block text-[11px] font-black uppercase tracking-wide text-gray-500">
                   상태
                   <select v-model="status" class="mt-1.5 w-full border border-gray-300 bg-white px-3 py-2.5 text-sm text-gray-800 outline-none focus:border-[#004D3C]">
                     <option value="활성">활성</option>
@@ -380,55 +409,85 @@ onMounted(async () => {
                     <option value="비활성">비활성</option>
                   </select>
                 </label>
+                <label class="block text-[11px] font-black uppercase tracking-wide text-gray-500">
+                  메인 거래처 <span class="text-red-500">*</span>
+                  <select
+                    v-model="selectedVendorCode"
+                    class="mt-1.5 w-full border border-gray-300 bg-white px-3 py-2.5 text-sm text-gray-800 outline-none focus:border-[#004D3C]"
+                  >
+                    <option value="">거래처를 선택하세요</option>
+                    <option
+                      v-if="shouldShowCurrentVendorFallbackOption"
+                      :value="selectedVendorCode"
+                    >
+                      현재 설정 거래처 (비활성/미존재) - 재선택 필요
+                    </option>
+                    <option
+                      v-for="vendor in activeVendorOptions"
+                      :key="vendor.code"
+                      :value="vendor.code"
+                    >
+                      {{ vendor.name }} ({{ vendor.code }})
+                    </option>
+                  </select>
+                  <p
+                    v-if="shouldShowCurrentVendorFallbackOption"
+                    class="mt-1 text-[10px] font-bold text-red-500"
+                  >
+                    현재 설정 거래처는 사용할 수 없습니다. 활성 거래처를 다시 선택해주세요.
+                  </p>
+                </label>
               </div>
 
               <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 <label class="block text-[11px] font-black uppercase tracking-wide text-gray-500">
-                  메인 거래처 <span class="text-red-500">*</span>
-                  <input v-model="vendorName" type="text" class="mt-1.5 w-full border border-gray-300 bg-white px-3 py-2.5 text-sm outline-none focus:border-[#004D3C]" />
+                  창고 공통 안전재고 <span class="text-red-500">*</span>
+                  <input v-model.number="warehouseSafetyStock" type="number" min="0" class="mt-1.5 w-full border border-gray-300 bg-white px-3 py-2.5 text-sm outline-none focus:border-[#004D3C]" />
                 </label>
                 <label class="block text-[11px] font-black uppercase tracking-wide text-gray-500">
-                  리드타임(일)
-                  <input v-model.number="leadTimeDays" type="number" min="0" class="mt-1.5 w-full border border-gray-300 bg-white px-3 py-2.5 text-sm outline-none focus:border-[#004D3C]" />
+                  매장 공통 안전재고 <span class="text-red-500">*</span>
+                  <input v-model.number="storeSafetyStock" type="number" min="0" class="mt-1.5 w-full border border-gray-300 bg-white px-3 py-2.5 text-sm outline-none focus:border-[#004D3C]" />
                 </label>
               </div>
 
-              <div class="!mt-4 space-y-5 rounded-md border border-gray-300 bg-white p-5">
+              <div class="!mt-4 rounded-md border border-gray-300 bg-white p-5">
                 <p class="text-[11px] font-black uppercase tracking-wide text-gray-500">
                   옵션 구성 <span v-if="!isEditMode" class="text-red-500">*</span>
                 </p>
-                <div class="space-y-2">
-                  <p class="text-[10px] font-bold text-gray-400">색상</p>
-                  <div class="flex flex-wrap gap-2">
-                    <button
-                      v-for="color in COLOR_OPTIONS"
-                      :key="color"
-                      type="button"
-                      class="border px-3 py-1.5 text-xs font-black transition"
-                      :class="selectedColors.includes(color)
-                        ? 'border-[#004D3C] bg-[#004D3C] text-white'
-                        : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-100'"
-                      @click="toggleColor(color)"
-                    >
-                      {{ color }}
-                    </button>
+                <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <div class="space-y-2">
+                    <p class="text-[10px] font-bold text-gray-400">색상</p>
+                    <div class="flex flex-wrap gap-2">
+                      <button
+                        v-for="color in COLOR_OPTIONS"
+                        :key="color"
+                        type="button"
+                        class="min-w-[72px] border px-3 py-1.5 text-xs font-black transition"
+                        :class="selectedColors.includes(color)
+                          ? 'border-[#004D3C] bg-[#004D3C] text-white'
+                          : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-100'"
+                        @click="toggleColor(color)"
+                      >
+                        {{ color }}
+                      </button>
+                    </div>
                   </div>
-                </div>
-                <div class="space-y-2">
-                  <p class="text-[10px] font-bold text-gray-400">사이즈</p>
-                  <div class="flex flex-wrap gap-2">
-                    <button
-                      v-for="size in SIZE_OPTIONS"
-                      :key="size"
-                      type="button"
-                      class="border px-2.5 py-1 text-xs font-black transition"
-                      :class="selectedSizes.includes(size)
-                        ? 'border-[#0E7A60] bg-[#EBF5F5] text-[#0E7A60]'
-                        : 'border-gray-300 bg-white text-gray-600 hover:bg-gray-100'"
-                      @click="toggleSize(size)"
-                    >
-                      {{ size }}
-                    </button>
+                  <div class="space-y-2">
+                    <p class="text-[10px] font-bold text-gray-400">사이즈</p>
+                    <div class="flex flex-wrap gap-2">
+                      <button
+                        v-for="size in SIZE_OPTIONS"
+                        :key="size"
+                        type="button"
+                        class="min-w-[56px] border px-2.5 py-1 text-xs font-black transition"
+                        :class="selectedSizes.includes(size)
+                          ? 'border-[#0E7A60] bg-[#EBF5F5] text-[#0E7A60]'
+                          : 'border-gray-300 bg-white text-gray-600 hover:bg-gray-100'"
+                        @click="toggleSize(size)"
+                      >
+                        {{ size }}
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -464,7 +523,7 @@ onMounted(async () => {
         </div>
 
         <aside class="space-y-4 xl:sticky xl:top-16">
-          <section class="border border-gray-200 bg-white p-4 shadow-sm">
+          <section class="border border-gray-300 bg-white p-4 shadow-sm">
             <h3 class="text-xs font-black uppercase tracking-wide text-gray-500">현재 입력 요약</h3>
             <div class="mt-3 space-y-2 text-xs">
               <div class="flex items-center justify-between border border-gray-100 bg-gray-50 px-3 py-2">
@@ -481,7 +540,17 @@ onMounted(async () => {
               </div>
               <div class="flex items-center justify-between border border-gray-100 bg-gray-50 px-3 py-2">
                 <span class="font-black text-gray-500">메인 거래처</span>
-                <span class="font-black text-gray-800">{{ vendorName || '-' }}</span>
+                <span class="font-black text-gray-800">
+                  {{ selectedVendor ? `${selectedVendor.name} (${selectedVendor.code})` : (selectedVendorCode || '-') }}
+                </span>
+              </div>
+              <div class="flex items-center justify-between border border-gray-100 bg-gray-50 px-3 py-2">
+                <span class="font-black text-gray-500">창고 공통 안전재고</span>
+                <span class="font-black text-gray-800">{{ Number(warehouseSafetyStock).toLocaleString() }}</span>
+              </div>
+              <div class="flex items-center justify-between border border-gray-100 bg-gray-50 px-3 py-2">
+                <span class="font-black text-gray-500">매장 공통 안전재고</span>
+                <span class="font-black text-gray-800">{{ Number(storeSafetyStock).toLocaleString() }}</span>
               </div>
               <div class="flex items-center justify-between border border-gray-100 bg-gray-50 px-3 py-2">
                 <span class="font-black text-gray-500">상태</span>

--- a/src/views/hq/HqProductManagementView.vue
+++ b/src/views/hq/HqProductManagementView.vue
@@ -5,6 +5,7 @@ import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
 import { deleteCategory, getCategories, getCategory, updateCategory } from '@/api/category.js'
+import { vendorApi } from '@/api/vendor.js'
 import {
   getProducts,
 } from '@/api/productMaster.js'
@@ -36,6 +37,7 @@ const productSideMenus = [
 ]
 
 const productMasterData = ref([])
+const vendors = ref([])
 
 const categories = ref([])
 const categoryError = ref('')
@@ -281,6 +283,7 @@ function resolveCategoryNames(categoryCode) {
 
 async function loadProducts() {
   try {
+    const vendorNameByCode = new Map(vendors.value.map(v => [v.code, v.name]))
     const list = await getProducts({
       keyword: productKeyword.value || undefined,
       categoryCode: selectedParentFilter.value === 'all' ? undefined : selectedParentFilter.value,
@@ -291,13 +294,18 @@ async function loadProducts() {
       name: p.name,
       price: p.basePrice,
       leadTime: `${p.leadTimeDays}일`,
-      vendor: p.mainVendorCode,
+      vendor: vendorNameByCode.get(p.mainVendorCode) ?? p.mainVendorCode,
       status: productStatusMap[p.status] ?? p.status,
       regDate: formatDate(p.updatedAt),
     }))
   } catch (e) {
     categoryError.value = e.message
   }
+}
+
+async function loadVendors() {
+  const list = await vendorApi.listVendors()
+  vendors.value = list ?? []
 }
 
 watch(productKeyword, () => {
@@ -308,7 +316,7 @@ watch([selectedParentFilter, selectedChildFilter], () => {
 })
 
 onMounted(() => {
-  loadCategories().then(loadProducts)
+  Promise.all([loadCategories(), loadVendors()]).then(loadProducts)
 })
 </script>
 

--- a/src/views/hq/HqStoreDetailView.vue
+++ b/src/views/hq/HqStoreDetailView.vue
@@ -1,9 +1,10 @@
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
+import { getStoreByCode, updateStore } from '@/api/infrastructure.js'
 
 const route = useRoute()
 const router = useRouter()
@@ -17,40 +18,117 @@ const infraSideMenus = [
   { label: '창고 정보 관리', icon: 'warehouse' },
 ]
 
-const locations = ['서울', '경기', '인천', '부산', '대구']
-const names = ['스톡잇 강남점', '홍대 문구센터', '판교 테크노잡화', '여의도 IFC몰점', '성수 리빙샵', '인천 터미널점', '분당 서현점', '부산 센텀점', '광교 갤러리아점', '대전 둔산점']
-const managers = ['김사라', '박범수', '이선엽', '이후경', '정유진', '최진혁']
-const warehouses = ['인천 제1센터', '인천 제2센터', '용인 물류센터', '부산 중앙창고']
+const store = ref(null)
+const isLoading = ref(false)
+const loadError = ref('')
 
-const storeData = Array.from({ length: 32 }).map((_, i) => {
-  const isExpiring = i % 7 === 0
-  const stockCapacity = 1200 + (i % 5) * 300
-  const remainingStock = 240 + (i * 77) % 1200
-  const remainingRate = Math.min(100, Math.round((remainingStock / stockCapacity) * 100))
-  return {
-    id: `ST-${String(i + 1).padStart(3, '0')}`,
-    name: `${names[i % names.length]}${i > 9 ? ` ${Math.floor(i / 10) + 1}관` : ''}`,
-    region: locations[i % locations.length],
-    manager: managers[i % managers.length],
-    contact: `010-4821-${String(1000 + i)}`,
-    warehouse: warehouses[i % warehouses.length],
-    endDate: isExpiring ? '2024.05.15' : '2025.12.31',
-    status: i === 15 ? '비활성' : '활성',
-    stockCapacity,
-    remainingStock,
-    remainingRate,
-  }
+const isEditMode = ref(false)
+const isSaving = ref(false)
+const saveError = ref('')
+const saveSuccess = ref('')
+const editForm = ref({
+  managerName: '',
+  contact: '',
+  status: 'ACTIVE',
 })
 
-const selectedStore = computed(() =>
-  storeData.find((store) => store.id === String(route.params.storeId ?? '')),
-)
+const statusToKor = {
+  ACTIVE: '활성',
+  INACTIVE: '비활성',
+  SUSPENDED: '점검중',
+}
+
+const typeToKor = {
+  DIRECT: '직영점',
+  FRANCHISE: '가맹점',
+}
+
+const statusOptions = [
+  { value: 'ACTIVE', label: '활성' },
+  { value: 'INACTIVE', label: '비활성' },
+  { value: 'SUSPENDED', label: '점검중' },
+]
+
+const storeCode = computed(() => String(route.params.storeId ?? '').trim())
 
 const backQuery = computed(() => ({
   region: typeof route.query.region === 'string' ? route.query.region : undefined,
   status: typeof route.query.status === 'string' ? route.query.status : undefined,
   search: typeof route.query.search === 'string' ? route.query.search : undefined,
 }))
+
+function resetEditForm() {
+  if (!store.value) return
+  editForm.value = {
+    managerName: store.value.managerName || '',
+    contact: store.value.contact || '',
+    status: store.value.status || 'ACTIVE',
+  }
+}
+
+function startEdit() {
+  resetEditForm()
+  saveError.value = ''
+  saveSuccess.value = ''
+  isEditMode.value = true
+}
+
+function cancelEdit() {
+  resetEditForm()
+  saveError.value = ''
+  isEditMode.value = false
+}
+
+async function loadStoreDetail() {
+  isLoading.value = true
+  loadError.value = ''
+  try {
+    const found = await getStoreByCode(storeCode.value)
+    store.value = found || null
+    resetEditForm()
+  } catch (error) {
+    loadError.value = error.message || '매장 정보를 불러오지 못했습니다.'
+    store.value = null
+  } finally {
+    isLoading.value = false
+  }
+}
+
+async function saveEdit() {
+  if (!store.value || isSaving.value) return
+  saveError.value = ''
+  saveSuccess.value = ''
+
+  const managerName = editForm.value.managerName.trim()
+  const contact = editForm.value.contact.trim()
+
+  if (!managerName || !contact) {
+    saveError.value = '담당자와 연락처를 입력해주세요.'
+    return
+  }
+
+  isSaving.value = true
+  try {
+    await updateStore(store.value.code, {
+      name: store.value.name,
+      region: store.value.region,
+      type: store.value.type,
+      managerName,
+      contact,
+      address: store.value.address,
+      warehouseCode: store.value.warehouseCode,
+      status: editForm.value.status,
+    })
+
+    isEditMode.value = false
+    saveSuccess.value = '매장 정보가 저장되었습니다.'
+    await loadStoreDetail()
+  } catch (error) {
+    saveError.value = error.message || '매장 정보 저장에 실패했습니다.'
+  } finally {
+    isSaving.value = false
+  }
+}
 
 function goBack() {
   router.push({
@@ -63,6 +141,10 @@ function handleLogout() {
   auth.logout()
   router.push('/login')
 }
+
+onMounted(() => {
+  loadStoreDetail()
+})
 </script>
 
 <template>
@@ -75,14 +157,16 @@ function handleLogout() {
     @logout="handleLogout"
   >
     <div class="flex flex-col gap-4">
-      <section class="border border-gray-200 bg-white p-4 shadow-sm">
+      <section class="border border-gray-300 bg-white p-4 shadow-sm">
         <div class="flex flex-wrap items-start justify-between gap-3">
           <div>
             <p class="text-[10px] font-black uppercase tracking-[0.16em] text-gray-400">Store Detail</p>
             <h1 class="mt-1 text-lg font-black text-gray-900">매장 상세 정보</h1>
-            <template v-if="selectedStore">
-              <p class="mt-2 text-sm font-bold text-gray-700">{{ selectedStore.name }}</p>
-              <p class="mt-1 text-xs font-bold text-gray-500">{{ selectedStore.id }} · {{ selectedStore.region }}</p>
+            <template v-if="store">
+              <p class="mt-2 text-sm font-bold text-gray-700">{{ store.name }}</p>
+              <p class="mt-1 text-xs font-bold text-gray-500">
+                {{ store.code }} · {{ store.region }}
+              </p>
             </template>
           </div>
           <button
@@ -95,39 +179,91 @@ function handleLogout() {
         </div>
       </section>
 
-      <section v-if="selectedStore" class="grid gap-4 xl:grid-cols-[1.1fr_1fr]">
-        <article class="border border-gray-200 bg-white p-4 shadow-sm">
-          <h2 class="text-xs font-black uppercase tracking-[0.1em] text-gray-500">기본 정보</h2>
-          <div class="mt-3 grid gap-2 text-xs">
-            <p class="flex items-center justify-between"><span class="font-bold text-gray-500">매장 ID</span><strong class="font-black text-gray-900">{{ selectedStore.id }}</strong></p>
-            <p class="flex items-center justify-between"><span class="font-bold text-gray-500">매장명</span><strong class="font-black text-gray-900">{{ selectedStore.name }}</strong></p>
-            <p class="flex items-center justify-between"><span class="font-bold text-gray-500">지역</span><strong class="font-black text-gray-900">{{ selectedStore.region }}</strong></p>
-            <p class="flex items-center justify-between"><span class="font-bold text-gray-500">담당자</span><strong class="font-black text-gray-900">{{ selectedStore.manager }}</strong></p>
-            <p class="flex items-center justify-between"><span class="font-bold text-gray-500">연락처</span><strong class="font-black text-gray-900">{{ selectedStore.contact }}</strong></p>
-            <p class="flex items-center justify-between"><span class="font-bold text-gray-500">담당 창고</span><strong class="font-black text-gray-900">{{ selectedStore.warehouse }}</strong></p>
-            <p class="flex items-center justify-between"><span class="font-bold text-gray-500">계약 종료일</span><strong class="font-black" :class="selectedStore.endDate === '2024.05.15' ? 'text-red-600' : 'text-gray-900'">{{ selectedStore.endDate }}</strong></p>
-          </div>
-        </article>
+      <p v-if="loadError" class="border border-red-200 bg-red-50 px-3 py-2 text-xs font-bold text-red-600">{{ loadError }}</p>
 
-        <article class="border border-gray-200 bg-white p-4 shadow-sm">
-          <h2 class="text-xs font-black uppercase tracking-[0.1em] text-gray-500">남은 재고량</h2>
-          <div class="mt-4">
-            <div class="mb-2 flex items-center justify-between text-xs font-bold text-gray-600">
-              <span>재고 잔여율</span>
-              <strong class="text-base font-black" :class="selectedStore.remainingRate < 30 ? 'text-red-600' : 'text-gray-900'">{{ selectedStore.remainingRate }}%</strong>
-            </div>
-            <div class="h-3 w-full bg-gray-200">
-              <div
-                class="h-full"
-                :class="selectedStore.remainingRate < 30 ? 'bg-red-500' : selectedStore.remainingRate < 60 ? 'bg-amber-500' : 'bg-[#0f766e]'"
-                :style="{ width: `${selectedStore.remainingRate}%` }"
-              />
-            </div>
-            <p class="mt-2 text-right text-[11px] font-bold text-gray-500">
-              {{ selectedStore.remainingStock.toLocaleString() }} / {{ selectedStore.stockCapacity.toLocaleString() }} EA
-            </p>
+      <section v-if="isLoading" class="border border-gray-300 bg-white p-10 text-center text-sm font-bold text-gray-400 shadow-sm">
+        매장 정보를 불러오는 중입니다.
+      </section>
+
+      <section v-else-if="store" class="border border-gray-300 bg-white p-4 shadow-sm">
+        <div class="flex items-center justify-between gap-2">
+          <h2 class="text-xs font-black uppercase tracking-[0.1em] text-gray-500">기본 정보</h2>
+          <div class="flex items-center gap-2">
+            <button
+              v-if="!isEditMode"
+              type="button"
+              class="h-8 border border-gray-300 bg-white px-3 text-[11px] font-black text-gray-700 hover:bg-gray-50"
+              @click="startEdit"
+            >
+              편집
+            </button>
+            <template v-else>
+              <button
+                type="button"
+                class="h-8 border border-gray-300 bg-white px-3 text-[11px] font-black text-gray-700 hover:bg-gray-50"
+                :disabled="isSaving"
+                @click="cancelEdit"
+              >
+                취소
+              </button>
+              <button
+                type="button"
+                class="h-8 border border-[#004D3C] bg-[#004D3C] px-3 text-[11px] font-black text-white hover:bg-[#003d30] disabled:cursor-not-allowed disabled:opacity-40"
+                :disabled="isSaving"
+                @click="saveEdit"
+              >
+                {{ isSaving ? '저장 중...' : '저장' }}
+              </button>
+            </template>
           </div>
-        </article>
+        </div>
+
+        <p v-if="saveError" class="mt-3 border border-red-200 bg-red-50 px-2 py-1 text-[11px] font-bold text-red-600">{{ saveError }}</p>
+        <p v-if="saveSuccess" class="mt-3 border border-emerald-200 bg-emerald-50 px-2 py-1 text-[11px] font-bold text-emerald-700">{{ saveSuccess }}</p>
+
+        <div class="mt-3 grid gap-2 text-xs">
+          <p class="flex items-center justify-between"><span class="font-bold text-gray-500">매장 코드</span><strong class="font-black text-gray-900">{{ store.code }}</strong></p>
+          <p class="flex items-center justify-between"><span class="font-bold text-gray-500">매장명</span><strong class="font-black text-gray-900">{{ store.name }}</strong></p>
+          <p class="flex items-center justify-between"><span class="font-bold text-gray-500">지역</span><strong class="font-black text-gray-900">{{ store.region }}</strong></p>
+          <p class="flex items-center justify-between"><span class="font-bold text-gray-500">유형</span><strong class="font-black text-gray-900">{{ typeToKor[store.type] || store.type }}</strong></p>
+
+          <template v-if="!isEditMode">
+            <p class="flex items-center justify-between"><span class="font-bold text-gray-500">담당자</span><strong class="font-black text-gray-900">{{ store.managerName }}</strong></p>
+            <p class="flex items-center justify-between"><span class="font-bold text-gray-500">연락처</span><strong class="font-black text-gray-900">{{ store.contact }}</strong></p>
+            <p class="flex items-center justify-between"><span class="font-bold text-gray-500">상태</span><strong class="font-black text-gray-900">{{ statusToKor[store.status] || store.status }}</strong></p>
+          </template>
+
+          <template v-else>
+            <label class="grid gap-1">
+              <span class="font-bold text-gray-500">담당자</span>
+              <input
+                v-model="editForm.managerName"
+                type="text"
+                class="h-8 border border-gray-300 bg-white px-2 text-xs font-bold text-gray-900 outline-none focus:border-[#004D3C]"
+              />
+            </label>
+            <label class="grid gap-1">
+              <span class="font-bold text-gray-500">연락처</span>
+              <input
+                v-model="editForm.contact"
+                type="text"
+                class="h-8 border border-gray-300 bg-white px-2 text-xs font-bold text-gray-900 outline-none focus:border-[#004D3C]"
+              />
+            </label>
+            <label class="grid gap-1">
+              <span class="font-bold text-gray-500">상태</span>
+              <select
+                v-model="editForm.status"
+                class="h-8 border border-gray-300 bg-white px-2 text-xs font-bold text-gray-900 outline-none focus:border-[#004D3C]"
+              >
+                <option v-for="option in statusOptions" :key="option.value" :value="option.value">{{ option.label }}</option>
+              </select>
+            </label>
+          </template>
+
+          <p class="flex items-center justify-between"><span class="font-bold text-gray-500">담당 창고</span><strong class="font-black text-gray-900">{{ store.warehouseCode }}</strong></p>
+          <p class="flex items-start justify-between gap-3"><span class="font-bold text-gray-500">주소</span><strong class="text-right font-black text-gray-900">{{ store.address }}</strong></p>
+        </div>
       </section>
 
       <section v-else class="border border-dashed border-gray-300 bg-white p-10 text-center text-sm font-bold text-gray-400 shadow-sm">

--- a/src/views/hq/HqWarehouseDetailView.vue
+++ b/src/views/hq/HqWarehouseDetailView.vue
@@ -1,9 +1,10 @@
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
+import { getWarehouseByCode } from '@/api/infrastructure.js'
 
 const route = useRoute()
 const router = useRouter()
@@ -11,93 +12,55 @@ const auth = useAuthStore()
 const hqMenus = roleMenus.hq
 
 const activeTopMenu = computed(() => '인프라 관리')
-const activeSideMenu = ref('창고 정보 관리')
-const infraSideMenus = [
-  { label: '매장 정보 관리', icon: 'store' },
-  { label: '창고 정보 관리', icon: 'warehouse' },
-]
+const activeSideMenu = ref('매장/창고 정보 관리')
+const infraSideMenus = [{ label: '매장/창고 정보 관리', icon: 'store' }]
 
-const warehouseData = [
-  {
-    id: 'WH-001',
-    name: '인천 제1센터',
-    address: '인천광역시 서구 봉수대로 241',
-    manager: '박범수',
-    contact: '032-541-1201',
-    capacity: '12,000 PLT / 6,500㎡',
-    stockQty: 124582,
-    occupancy: 82,
-    status: '활성',
-    mappedStores: ['스톡잇 강남점', '홍대 문구센터', '여의도 IFC몰점', '성수 리빙샵'],
-    recentFlows: [
-      { time: '16:45', type: '입고', item: '고속 충전기 25W', qty: '+500' },
-      { time: '15:20', type: '출고', item: 'A4 복사용지 80g', qty: '-1,200' },
-      { time: '13:10', type: '이동', item: '무선 마우스 블랙', qty: '-240' },
-    ],
-  },
-  {
-    id: 'WH-002',
-    name: '인천 제2센터',
-    address: '인천광역시 중구 서해대로 98',
-    manager: '이후경',
-    contact: '032-541-1202',
-    capacity: '8,500 PLT / 4,100㎡',
-    stockQty: 84550,
-    occupancy: 68,
-    status: '활성',
-    mappedStores: ['판교 테크노잡화', '분당 서현점', '광교 갤러리아점'],
-    recentFlows: [
-      { time: '17:05', type: '입고', item: '절전형 멀티탭 3m', qty: '+300' },
-      { time: '14:30', type: '출고', item: '기계식 키보드 청축', qty: '-80' },
-      { time: '11:10', type: '출고', item: '손세정제 리필 500ml', qty: '-420' },
-    ],
-  },
-  {
-    id: 'WH-003',
-    name: '용인 물류센터',
-    address: '경기도 용인시 처인구 남사읍 물류로 75',
-    manager: '김사라',
-    contact: '031-338-4401',
-    capacity: '15,000 PLT / 8,300㎡',
-    stockQty: 142300,
-    occupancy: 91,
-    status: '포화 임박',
-    mappedStores: ['성수 리빙샵', '인천 터미널점', '대전 둔산점', '부산 센텀점'],
-    recentFlows: [
-      { time: '16:20', type: '입고', item: '종이컵 6.5온스', qty: '+4,500' },
-      { time: '15:05', type: '출고', item: '니트릴 고무장갑', qty: '-650' },
-      { time: '09:40', type: '출고', item: '휴대용 가글 250ml', qty: '-320' },
-    ],
-  },
-  {
-    id: 'WH-004',
-    name: '부산 중앙창고',
-    address: '부산광역시 강서구 유통단지1로 55',
-    manager: '이선엽',
-    contact: '051-923-7701',
-    capacity: '6,200 PLT / 3,200㎡',
-    stockQty: 46320,
-    occupancy: 44,
-    status: '비활성',
-    mappedStores: ['부산 센텀점'],
-    recentFlows: [
-      { time: '어제', type: '점검', item: '냉동 블루베리 1kg', qty: '보류' },
-      { time: '어제', type: '출고', item: '무선 이어폰', qty: '-45' },
-      { time: '2일 전', type: '입고', item: '유리제 머그컵 350ml', qty: '+220' },
-    ],
-  },
-]
+const warehouse = ref(null)
+const isLoading = ref(false)
+const loadError = ref('')
 
-const selectedWarehouse = computed(() =>
-  warehouseData.find((warehouse) => warehouse.id === String(route.params.warehouseId ?? '')),
-)
+const statusToKor = {
+  ACTIVE: '활성',
+  INACTIVE: '비활성',
+  SUSPENDED: '점검중',
+}
+
+const warehouseCode = computed(() => String(route.params.warehouseId ?? '').trim())
 
 const backQuery = computed(() => ({
-  menu: '창고 정보 관리',
   region: typeof route.query.region === 'string' ? route.query.region : undefined,
   status: typeof route.query.status === 'string' ? route.query.status : undefined,
   search: typeof route.query.search === 'string' ? route.query.search : undefined,
 }))
+
+const occupancy = computed(() => {
+  if (!warehouse.value) return 0
+  return Math.min(95, 20 + Number(warehouse.value.mappedStoreCount || 0) * 15)
+})
+
+const stockQty = computed(() => {
+  if (!warehouse.value) return 0
+  return Number(warehouse.value.mappedStoreCount || 0) * 1000
+})
+
+const connectedStoresPlaceholder = computed(() => {
+  if (!warehouse.value) return []
+  return Array.from({ length: Number(warehouse.value.mappedStoreCount || 0) }).map((_, index) => `연결 매장 ${index + 1}`)
+})
+
+async function loadWarehouseDetail() {
+  isLoading.value = true
+  loadError.value = ''
+  try {
+    const found = await getWarehouseByCode(warehouseCode.value)
+    warehouse.value = found || null
+  } catch (error) {
+    loadError.value = error.message || '창고 정보를 불러오지 못했습니다.'
+    warehouse.value = null
+  } finally {
+    isLoading.value = false
+  }
+}
 
 function goBack() {
   router.push({
@@ -110,6 +73,10 @@ function handleLogout() {
   auth.logout()
   router.push('/login')
 }
+
+onMounted(() => {
+  loadWarehouseDetail()
+})
 </script>
 
 <template>
@@ -122,14 +89,14 @@ function handleLogout() {
     @logout="handleLogout"
   >
     <div class="flex flex-col gap-4">
-      <section class="border border-gray-200 bg-white p-4 shadow-sm">
+      <section class="border border-gray-300 bg-white p-4 shadow-sm">
         <div class="flex flex-wrap items-start justify-between gap-3">
           <div>
             <p class="text-[10px] font-black uppercase tracking-[0.16em] text-gray-400">Warehouse Detail</p>
             <h1 class="mt-1 text-lg font-black text-gray-900">창고 상세 정보</h1>
-            <template v-if="selectedWarehouse">
-              <p class="mt-2 text-sm font-bold text-gray-700">{{ selectedWarehouse.name }}</p>
-              <p class="mt-1 text-xs font-bold text-gray-500">{{ selectedWarehouse.id }}</p>
+            <template v-if="warehouse">
+              <p class="mt-2 text-sm font-bold text-gray-700">{{ warehouse.name }}</p>
+              <p class="mt-1 text-xs font-bold text-gray-500">{{ warehouse.code }}</p>
             </template>
           </div>
           <button
@@ -142,70 +109,71 @@ function handleLogout() {
         </div>
       </section>
 
-      <section v-if="selectedWarehouse" class="grid gap-4 xl:grid-cols-[1.1fr_1fr]">
-        <article class="border border-gray-200 bg-white p-4 shadow-sm">
+      <p v-if="loadError" class="border border-red-200 bg-red-50 px-3 py-2 text-xs font-bold text-red-600">{{ loadError }}</p>
+
+      <section v-if="isLoading" class="border border-gray-300 bg-white p-10 text-center text-sm font-bold text-gray-400 shadow-sm">
+        창고 정보를 불러오는 중입니다.
+      </section>
+
+      <section v-else-if="warehouse" class="grid gap-4 xl:grid-cols-[1.1fr_1fr]">
+        <article class="border border-gray-300 bg-white p-4 shadow-sm">
           <h2 class="text-xs font-black uppercase tracking-[0.1em] text-gray-500">기본 정보</h2>
           <div class="mt-3 grid gap-2 text-xs">
-            <p class="flex items-center justify-between"><span class="font-bold text-gray-500">창고 ID</span><strong class="font-black text-gray-900">{{ selectedWarehouse.id }}</strong></p>
-            <p class="flex items-center justify-between"><span class="font-bold text-gray-500">창고명</span><strong class="font-black text-gray-900">{{ selectedWarehouse.name }}</strong></p>
-            <p class="flex items-center justify-between"><span class="font-bold text-gray-500">주소</span><strong class="font-black text-gray-900">{{ selectedWarehouse.address }}</strong></p>
-            <p class="flex items-center justify-between"><span class="font-bold text-gray-500">담당 책임자</span><strong class="font-black text-gray-900">{{ selectedWarehouse.manager }}</strong></p>
-            <p class="flex items-center justify-between"><span class="font-bold text-gray-500">연락처</span><strong class="font-black text-gray-900">{{ selectedWarehouse.contact }}</strong></p>
-            <p class="flex items-center justify-between"><span class="font-bold text-gray-500">창고 용량</span><strong class="font-black text-gray-900">{{ selectedWarehouse.capacity }}</strong></p>
-            <p class="flex items-center justify-between"><span class="font-bold text-gray-500">상태</span><strong class="font-black text-gray-900">{{ selectedWarehouse.status }}</strong></p>
+            <p class="flex items-center justify-between"><span class="font-bold text-gray-500">창고 코드</span><strong class="font-black text-gray-900">{{ warehouse.code }}</strong></p>
+            <p class="flex items-center justify-between"><span class="font-bold text-gray-500">창고명</span><strong class="font-black text-gray-900">{{ warehouse.name }}</strong></p>
+            <p class="flex items-center justify-between"><span class="font-bold text-gray-500">주소</span><strong class="font-black text-gray-900">{{ warehouse.address }}</strong></p>
+            <p class="flex items-center justify-between"><span class="font-bold text-gray-500">담당 책임자</span><strong class="font-black text-gray-900">{{ warehouse.managerName }}</strong></p>
+            <p class="flex items-center justify-between"><span class="font-bold text-gray-500">연락처</span><strong class="font-black text-gray-900">{{ warehouse.contact }}</strong></p>
+            <p class="flex items-center justify-between"><span class="font-bold text-gray-500">창고 용량</span><strong class="font-black text-gray-900">{{ warehouse.capacity }}</strong></p>
+            <p class="flex items-center justify-between"><span class="font-bold text-gray-500">상태</span><strong class="font-black text-gray-900">{{ statusToKor[warehouse.status] || warehouse.status }}</strong></p>
           </div>
         </article>
 
-        <article class="border border-gray-200 bg-white p-4 shadow-sm">
+        <article class="border border-gray-300 bg-white p-4 shadow-sm">
           <h2 class="text-xs font-black uppercase tracking-[0.1em] text-gray-500">공간 점유율 / 현재 재고</h2>
           <div class="mt-4">
             <div class="mb-2 flex items-center justify-between text-xs font-bold text-gray-600">
-              <span>공간 점유율</span>
-              <strong class="text-base font-black" :class="selectedWarehouse.occupancy >= 90 ? 'text-red-600' : 'text-gray-900'">{{ selectedWarehouse.occupancy }}%</strong>
+              <span>공간 점유율(추정)</span>
+              <strong class="text-base font-black" :class="occupancy >= 90 ? 'text-red-600' : 'text-gray-900'">{{ occupancy }}%</strong>
             </div>
             <div class="h-3 w-full bg-gray-200">
               <div
                 class="h-full"
-                :class="selectedWarehouse.occupancy >= 90 ? 'bg-red-500' : selectedWarehouse.occupancy >= 80 ? 'bg-amber-500' : 'bg-[#0f766e]'"
-                :style="{ width: `${selectedWarehouse.occupancy}%` }"
+                :class="occupancy >= 90 ? 'bg-red-500' : occupancy >= 80 ? 'bg-amber-500' : 'bg-[#0f766e]'"
+                :style="{ width: `${occupancy}%` }"
               />
             </div>
             <p class="mt-2 text-right text-[11px] font-bold text-gray-500">
-              현재 재고 {{ selectedWarehouse.stockQty.toLocaleString() }} EA
+              현재 재고(추정) {{ stockQty.toLocaleString() }} EA
             </p>
+            <p class="mt-2 text-[10px] font-bold text-gray-400">* 점유율/재고는 mappedStoreCount 기반 임시 추정치입니다.</p>
           </div>
         </article>
 
-        <article class="border border-gray-200 bg-white p-4 shadow-sm">
+        <article class="border border-gray-300 bg-white p-4 shadow-sm">
           <h2 class="text-xs font-black uppercase tracking-[0.1em] text-gray-500">연결 매장</h2>
           <ul class="mt-3 space-y-2">
             <li
-              v-for="storeName in selectedWarehouse.mappedStores"
+              v-for="storeName in connectedStoresPlaceholder"
               :key="storeName"
               class="border border-gray-200 bg-gray-50 px-3 py-2 text-xs font-bold text-gray-700"
             >
               {{ storeName }}
             </li>
+            <li
+              v-if="connectedStoresPlaceholder.length === 0"
+              class="border border-dashed border-gray-200 bg-gray-50 px-3 py-3 text-center text-xs font-bold text-gray-400"
+            >
+              연결된 매장이 없습니다.
+            </li>
           </ul>
         </article>
 
-        <article class="border border-gray-200 bg-white p-4 shadow-sm">
+        <article class="border border-gray-300 bg-white p-4 shadow-sm">
           <h2 class="text-xs font-black uppercase tracking-[0.1em] text-gray-500">최근 입출고 이력</h2>
-          <ul class="mt-3 space-y-2">
-            <li
-              v-for="flow in selectedWarehouse.recentFlows"
-              :key="`${flow.time}-${flow.item}`"
-              class="flex items-center justify-between border border-gray-200 bg-gray-50 px-3 py-2 text-xs"
-            >
-              <div>
-                <p class="font-black text-gray-800">{{ flow.item }}</p>
-                <p class="mt-1 font-bold text-gray-500">{{ flow.time }} · {{ flow.type }}</p>
-              </div>
-              <strong :class="String(flow.qty).startsWith('-') ? 'text-red-600' : 'text-[#0f766e]'" class="font-black">
-                {{ flow.qty }}
-              </strong>
-            </li>
-          </ul>
+          <div class="mt-3 border border-dashed border-gray-200 bg-gray-50 px-3 py-6 text-center text-xs font-bold text-gray-400">
+            최근 입출고 이력 API 연동 후 표시됩니다.
+          </div>
         </article>
       </section>
 


### PR DESCRIPTION
## 📌 요약
- 제품 마스터 등록/수정 UX를 정리하고, 인프라(매장/창고) 조회/상세 흐름의 데이터 정합성과 화면 일관성을 개선했습니다.

<br><br>

## 🎯 작업 내용
- 제품 마스터 등록/수정 폼 개선
  - 메인 거래처를 텍스트 입력에서 선택형 드롭다운으로 전환(활성 거래처 기준)
  - 리드타임 입력 제거, `창고 공통 안전재고`/`매장 공통 안전재고` 입력 및 저장 반영
  - 입력 폼 4줄 레이아웃 재배치, 색상 옵션(아이보리 → 네이비) 및 UI(테두리/옵션 구성) 정리
- 인프라 관리 화면 정리
  - 사이드 메뉴를 `매장/창고 정보 관리` 1개로 통합
  - 레거시 `menu/view` 분기 제거, 상단 필터 기반 조회 대상 전환 유지
  - 매장 카드 정보 보강(유형/담당자/연락처/주소/담당창고), 상단 등록 버튼 제거
- 인프라 상세 정합성 개선
  - 매장/창고 상세의 목록 복귀/조회 흐름 정리
  - 단건 API 연동에 맞춰 FE 상세 조회 로직 전환

<br><br>

## ✔️ 참고 사항
- 상세 페이지(매장/창고) 라우트는 유지하고, 통합 UI 기준으로 불필요한 분기만 제거했습니다.
- 창고 상세 보조 정보 중 API 미연동 영역은 안내형 placeholder를 유지합니다.

<br><br>

## ✔️ 관련 이슈

- Close #315 

<br><br>
