### PR TITLE
feat: 창고간 재고 이동/이동 내역 조회 페이지 구현

### DIFF
--- a/src/components/hq/circular-inventory/CircularInventoryBrowseSection.vue
+++ b/src/components/hq/circular-inventory/CircularInventoryBrowseSection.vue
@@ -58,6 +58,7 @@ const isMaterialDropdownOpen = ref(false)
 const materialDropdownRef = ref(null)
 const sortKey = ref('')
 const sortDirection = ref('asc')
+const hoveredRowId = ref(null)
 const visibleColumns = ref({
   color: true,
   size: true,
@@ -723,13 +724,17 @@ onBeforeUnmount(() => {
             <tr
               v-for="item in filteredRows"
               :key="item.id"
-              class="transition"
+              class="transition-colors"
               :class="[
                 highlightedRowIds.includes(item.id) || highlightedInventoryIds.includes(item.inventoryId)
                   ? 'bg-[#EBF5F5] font-bold'
-                  : 'hover:bg-[#EBF5F5]/60',
+                  : hoveredRowId === item.id
+                    ? 'bg-[#EBF5F5]/60'
+                    : '',
                 enableRowClick ? 'cursor-pointer' : '',
               ]"
+              @mouseenter="hoveredRowId = item.id"
+              @mouseleave="hoveredRowId = null"
               @click="handleRowClick(item)"
             >
               <td v-if="hasActionColumn && actionColumnPosition === 'start'" class="px-3 py-3 text-center">
@@ -740,8 +745,22 @@ onBeforeUnmount(() => {
                   :highlighted="highlightedRowIds.includes(item.id) || highlightedInventoryIds.includes(item.inventoryId)"
                 />
               </td>
-              <td class="sticky left-0 z-10 whitespace-nowrap bg-white px-3 py-3 font-mono font-bold text-gray-600">{{ item.skuCode }}</td>
-              <td class="sticky left-[170px] z-10 truncate bg-white px-3 py-3 font-black text-gray-900">{{ item.itemName }}</td>
+              <td
+                class="sticky left-0 z-10 whitespace-nowrap px-3 py-3 font-mono font-bold text-gray-600 transition-colors"
+                :class="highlightedRowIds.includes(item.id) || highlightedInventoryIds.includes(item.inventoryId)
+                  ? 'bg-[#EBF5F5]'
+                  : hoveredRowId === item.id
+                    ? 'bg-[#EBF5F5]/60'
+                    : 'bg-white'"
+              >{{ item.skuCode }}</td>
+              <td
+                class="sticky left-[170px] z-10 truncate px-3 py-3 font-black text-gray-900 transition-colors"
+                :class="highlightedRowIds.includes(item.id) || highlightedInventoryIds.includes(item.inventoryId)
+                  ? 'bg-[#EBF5F5]'
+                  : hoveredRowId === item.id
+                    ? 'bg-[#EBF5F5]/60'
+                    : 'bg-white'"
+              >{{ item.itemName }}</td>
               <td v-if="visibleColumns.color" class="px-3 py-3 text-center font-black text-gray-900">{{ item.color }}</td>
               <td v-if="visibleColumns.size" class="px-3 py-3 text-center font-black text-gray-900">{{ item.size }}</td>
               <td class="px-3 py-3 font-black text-gray-900">{{ item.materialType }}</td>

--- a/src/config/roleMenus.js
+++ b/src/config/roleMenus.js
@@ -12,7 +12,8 @@ export const roleMenus = {
       icon: 'warehouse',
       children: [
         { label: '전사 재고 조회', path: '/hq/inventory/company-wide' },
-        { label: '창고별 재고 비교', path: '/hq/inventory/warehouse-comparison' },
+        { label: '창고간 재고 이동', path: '/hq/inventory/warehouse-comparison' },
+        { label: '창고간 재고 이동 내역', path: '/hq/inventory/warehouse-transfer-history' },
       ],
     },
     {

--- a/src/constants/hqWarehouseTransferData.js
+++ b/src/constants/hqWarehouseTransferData.js
@@ -1,0 +1,79 @@
+export const transferSkuCatalog = [
+  { skuCode: 'PRD-TOP-SS-001-BLK-S', itemCode: 'PRD-TOP-SS-001', itemName: '코튼 베이직 반팔 티셔츠', color: '검정', size: 'S', category: '상의 > 반팔' },
+  { skuCode: 'PRD-TOP-SS-001-WHT-M', itemCode: 'PRD-TOP-SS-001', itemName: '코튼 베이직 반팔 티셔츠', color: '흰색', size: 'M', category: '상의 > 반팔' },
+  { skuCode: 'PRD-TOP-SH-003-NVY-L', itemCode: 'PRD-TOP-SH-003', itemName: '오버핏 옥스포드 셔츠', color: '네이비', size: 'L', category: '상의 > 셔츠' },
+  { skuCode: 'PRD-PNT-SH-002-GRY-M', itemCode: 'PRD-PNT-SH-002', itemName: '라이트 코튼 쇼츠', color: '그레이', size: 'M', category: '바지 > 반바지' },
+  { skuCode: 'PRD-SKT-LS-002-BLK-M', itemCode: 'PRD-SKT-LS-002', itemName: '플리츠 롱스커트', color: '검정', size: 'M', category: '치마 > 롱스커트' },
+  { skuCode: 'PRD-OUT-PD-001-NVY-XL', itemCode: 'PRD-OUT-PD-001', itemName: '라이트 숏 패딩', color: '네이비', size: 'XL', category: '아우터 > 패딩' },
+]
+
+export const warehouseInventoryMap = {
+  'PRD-TOP-SS-001-BLK-S': [
+    { warehouseCode: 'WH-ICN-01', warehouseName: '인천 제1창고', location: '인천 서구', onHandStock: 128, reservedStock: 12, safetyStock: 40, updatedAt: '2026.04.30 09:30' },
+    { warehouseCode: 'WH-ICH-01', warehouseName: '이천 풀필먼트', location: '경기 이천시', onHandStock: 22, reservedStock: 4, safetyStock: 30, updatedAt: '2026.04.30 09:12' },
+    { warehouseCode: 'WH-BSN-01', warehouseName: '부산 물류창고', location: '부산 강서구', onHandStock: 0, reservedStock: 0, safetyStock: 25, updatedAt: '2026.04.30 08:55' },
+    { warehouseCode: 'WH-DJN-01', warehouseName: '대전 허브창고', location: '대전 유성구', onHandStock: 54, reservedStock: 6, safetyStock: 20, updatedAt: '2026.04.30 08:40' },
+  ],
+  'PRD-TOP-SS-001-WHT-M': [
+    { warehouseCode: 'WH-ICN-01', warehouseName: '인천 제1창고', location: '인천 서구', onHandStock: 98, reservedStock: 8, safetyStock: 35, updatedAt: '2026.04.30 09:25' },
+    { warehouseCode: 'WH-ICH-01', warehouseName: '이천 풀필먼트', location: '경기 이천시', onHandStock: 14, reservedStock: 4, safetyStock: 28, updatedAt: '2026.04.30 09:00' },
+    { warehouseCode: 'WH-BSN-01', warehouseName: '부산 물류창고', location: '부산 강서구', onHandStock: 42, reservedStock: 4, safetyStock: 22, updatedAt: '2026.04.30 08:35' },
+    { warehouseCode: 'WH-DJN-01', warehouseName: '대전 허브창고', location: '대전 유성구', onHandStock: 18, reservedStock: 6, safetyStock: 18, updatedAt: '2026.04.30 08:20' },
+  ],
+  'PRD-TOP-SH-003-NVY-L': [
+    { warehouseCode: 'WH-ICN-01', warehouseName: '인천 제1창고', location: '인천 서구', onHandStock: 72, reservedStock: 6, safetyStock: 20, updatedAt: '2026.04.30 09:18' },
+    { warehouseCode: 'WH-ICH-01', warehouseName: '이천 풀필먼트', location: '경기 이천시', onHandStock: 12, reservedStock: 3, safetyStock: 16, updatedAt: '2026.04.30 08:58' },
+    { warehouseCode: 'WH-BSN-01', warehouseName: '부산 물류창고', location: '부산 강서구', onHandStock: 58, reservedStock: 4, safetyStock: 18, updatedAt: '2026.04.30 08:32' },
+    { warehouseCode: 'WH-DJN-01', warehouseName: '대전 허브창고', location: '대전 유성구', onHandStock: 8, reservedStock: 2, safetyStock: 14, updatedAt: '2026.04.30 08:10' },
+  ],
+  'PRD-PNT-SH-002-GRY-M': [
+    { warehouseCode: 'WH-ICN-01', warehouseName: '인천 제1창고', location: '인천 서구', onHandStock: 45, reservedStock: 5, safetyStock: 18, updatedAt: '2026.04.30 09:08' },
+    { warehouseCode: 'WH-ICH-01', warehouseName: '이천 풀필먼트', location: '경기 이천시', onHandStock: 6, reservedStock: 2, safetyStock: 15, updatedAt: '2026.04.30 08:49' },
+    { warehouseCode: 'WH-BSN-01', warehouseName: '부산 물류창고', location: '부산 강서구', onHandStock: 24, reservedStock: 4, safetyStock: 14, updatedAt: '2026.04.30 08:22' },
+    { warehouseCode: 'WH-DJN-01', warehouseName: '대전 허브창고', location: '대전 유성구', onHandStock: 0, reservedStock: 0, safetyStock: 12, updatedAt: '2026.04.30 08:05' },
+  ],
+  'PRD-SKT-LS-002-BLK-M': [
+    { warehouseCode: 'WH-ICN-01', warehouseName: '인천 제1창고', location: '인천 서구', onHandStock: 39, reservedStock: 7, safetyStock: 16, updatedAt: '2026.04.30 09:14' },
+    { warehouseCode: 'WH-ICH-01', warehouseName: '이천 풀필먼트', location: '경기 이천시', onHandStock: 8, reservedStock: 3, safetyStock: 14, updatedAt: '2026.04.30 08:44' },
+    { warehouseCode: 'WH-BSN-01', warehouseName: '부산 물류창고', location: '부산 강서구', onHandStock: 16, reservedStock: 4, safetyStock: 10, updatedAt: '2026.04.30 08:18' },
+    { warehouseCode: 'WH-DJN-01', warehouseName: '대전 허브창고', location: '대전 유성구', onHandStock: 2, reservedStock: 1, safetyStock: 9, updatedAt: '2026.04.30 08:02' },
+  ],
+  'PRD-OUT-PD-001-NVY-XL': [
+    { warehouseCode: 'WH-ICN-01', warehouseName: '인천 제1창고', location: '인천 서구', onHandStock: 56, reservedStock: 4, safetyStock: 18, updatedAt: '2026.04.30 09:05' },
+    { warehouseCode: 'WH-ICH-01', warehouseName: '이천 풀필먼트', location: '경기 이천시', onHandStock: 20, reservedStock: 4, safetyStock: 16, updatedAt: '2026.04.30 08:41' },
+    { warehouseCode: 'WH-BSN-01', warehouseName: '부산 물류창고', location: '부산 강서구', onHandStock: 5, reservedStock: 2, safetyStock: 12, updatedAt: '2026.04.30 08:16' },
+    { warehouseCode: 'WH-DJN-01', warehouseName: '대전 허브창고', location: '대전 유성구', onHandStock: 0, reservedStock: 0, safetyStock: 10, updatedAt: '2026.04.30 08:01' },
+  ],
+}
+
+export function buildWarehouseRows(skuCode) {
+  return (warehouseInventoryMap[skuCode] || []).map((row) => {
+    const availableStock = Math.max(0, row.onHandStock - row.reservedStock)
+    let status = '정상'
+    if (availableStock <= 0) status = '품절'
+    else if (availableStock < row.safetyStock) status = '부족'
+
+    return {
+      ...row,
+      availableStock,
+      status,
+    }
+  })
+}
+
+export function getImbalanceMetrics(rows) {
+  if (!rows.length) {
+    return { imbalanceScore: 0, status: '정상', maxAvailable: 0, minAvailable: 0 }
+  }
+
+  const availableStocks = rows.map(row => row.availableStock)
+  const maxAvailable = Math.max(...availableStocks)
+  const minAvailable = Math.min(...availableStocks)
+  const imbalanceScore = Math.max(0, maxAvailable - minAvailable)
+
+  let status = '정상'
+  if (imbalanceScore >= 60) status = '불균형'
+  else if (imbalanceScore >= 25) status = '주의'
+
+  return { imbalanceScore, status, maxAvailable, minAvailable }
+}

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -38,6 +38,9 @@ import AllFlowTransactionsView from '@/views/hq/dashboard/AllFlowTransactionsVie
 
 import HqCompanyWideInventoryView from '@/views/hq/inventory/HqCompanyWideInventoryView.vue'
 import HqWarehouseInventoryComparisonView from '@/views/hq/inventory/HqWarehouseInventoryComparisonView.vue'
+import HqWarehouseSkuTransferDetailView from '@/views/hq/inventory/HqWarehouseSkuTransferDetailView.vue'
+import HqWarehouseTransferHistoryView from '@/views/hq/inventory/HqWarehouseTransferHistoryView.vue'
+import HqWarehouseTransferHistoryDetailView from '@/views/hq/inventory/HqWarehouseTransferHistoryDetailView.vue'
 import HqCompanyWideInventorySkuDetailView from '@/views/hq/inventory/HqCompanyWideInventorySkuDetailView.vue'
 import HqProductManagementView from '@/views/hq/HqProductManagementView.vue'
 import HqInfrastructureManagementView from '@/views/hq/HqInfrastructureManagementView.vue'
@@ -89,6 +92,24 @@ const router = createRouter({
       meta: { requiresAuth: true, role: 'hq' },
     },
     { path: '/hq/inventory/warehouse-comparison', name: 'hq-inventory-warehouse-comparison', component: HqWarehouseInventoryComparisonView, meta: { requiresAuth: true, role: 'hq' } },
+    {
+      path: '/hq/inventory/warehouse-comparison/:skuCode',
+      name: 'hq-inventory-warehouse-transfer-detail',
+      component: HqWarehouseSkuTransferDetailView,
+      meta: { requiresAuth: true, role: 'hq' },
+    },
+    {
+      path: '/hq/inventory/warehouse-transfer-history',
+      name: 'hq-inventory-warehouse-transfer-history',
+      component: HqWarehouseTransferHistoryView,
+      meta: { requiresAuth: true, role: 'hq' },
+    },
+    {
+      path: '/hq/inventory/warehouse-transfer-history/:transferNo',
+      name: 'hq-inventory-warehouse-transfer-history-detail',
+      component: HqWarehouseTransferHistoryDetailView,
+      meta: { requiresAuth: true, role: 'hq' },
+    },
     { path: '/hq/products', name: 'hq-products', component: HqProductManagementView, meta: { requiresAuth: true, role: 'hq' } },
     { path: '/hq/products/categories/add', name: 'hq-category-add', component: HqCategoryAddView, meta: { requiresAuth: true, role: 'hq' } },
     {

--- a/src/views/hq/inventory/HqWarehouseInventoryComparisonView.vue
+++ b/src/views/hq/inventory/HqWarehouseInventoryComparisonView.vue
@@ -1,130 +1,90 @@
 <script setup>
-import { computed, ref, watch } from 'vue'
-import { useRouter } from 'vue-router'
+import { computed, ref } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
 import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
+import { transferSkuCatalog, buildWarehouseRows, getImbalanceMetrics } from '@/constants/hqWarehouseTransferData.js'
 
 const router = useRouter()
+const route = useRoute()
 const auth = useAuthStore()
 const hqMenus = roleMenus.hq
 const inventoryMenus = roleMenus.hq.find(menu => menu.label === '재고 관리')?.children ?? []
 
 const activeTopMenu = computed(() => '재고 관리')
-const activeSideMenu = ref('창고별 재고 비교')
+const activeSideMenu = ref('창고간 재고 이동')
 
-const productSearch = ref('')
-const isProductDropdownOpen = ref(false)
-const selectedWarehouseCodes = ref([])
-const draggedWarehouseCode = ref('')
+const searchTerm = ref(String(route.query.search || ''))
+const selectedCategory = ref(String(route.query.category || '전체'))
+const selectedStatus = ref(String(route.query.status || '전체'))
+const selectedWarehouseGroup = ref(String(route.query.warehouseGroup || '전체'))
 
-const products = [
-  { itemCode: 'SPA-TOP-001', itemName: '코튼 베이직 반팔 티셔츠', category: '상의 > 반팔' },
-  { itemCode: 'SPA-TOP-003', itemName: '오버핏 옥스포드 셔츠', category: '상의 > 셔츠' },
-  { itemCode: 'SPA-PNT-002', itemName: '라이트 코튼 쇼츠', category: '바지 > 반바지' },
-  { itemCode: 'SPA-SKT-002', itemName: '플리츠 롱스커트', category: '치마 > 롱스커트' },
-  { itemCode: 'SPA-OUT-001', itemName: '라이트 숏 패딩', category: '아우터 > 패딩' },
-]
+const categoryOptions = computed(() => ['전체', ...new Set(transferSkuCatalog.map(sku => sku.category))])
+const warehouseGroupOptions = ['전체', '수도권', '충청권', '영남권']
 
-const warehouseInventoryMap = {
-  'SPA-TOP-001': [
-    { warehouseCode: 'WH-ICN-01', warehouseName: '인천 제1창고', location: '인천 서구', actualStock: 420, availableStock: 398, safetyStock: 120, status: '정상', updatedAt: '2026.04.22 09:30' },
-    { warehouseCode: 'WH-ICH-01', warehouseName: '이천 풀필먼트', location: '경기 이천시', actualStock: 86, availableStock: 74, safetyStock: 90, status: '부족', updatedAt: '2026.04.22 09:12' },
-    { warehouseCode: 'WH-BSN-01', warehouseName: '부산 물류창고', location: '부산 강서구', actualStock: 0, availableStock: 0, safetyStock: 70, status: '품절', updatedAt: '2026.04.22 08:55' },
-    { warehouseCode: 'WH-DJN-01', warehouseName: '대전 허브창고', location: '대전 유성구', actualStock: 144, availableStock: 132, safetyStock: 80, status: '정상', updatedAt: '2026.04.22 08:40' },
-  ],
-  'SPA-TOP-003': [
-    { warehouseCode: 'WH-ICN-01', warehouseName: '인천 제1창고', location: '인천 서구', actualStock: 512, availableStock: 490, safetyStock: 130, status: '정상', updatedAt: '2026.04.22 09:25' },
-    { warehouseCode: 'WH-ICH-01', warehouseName: '이천 풀필먼트', location: '경기 이천시', actualStock: 34, availableStock: 28, safetyStock: 60, status: '부족', updatedAt: '2026.04.22 09:00' },
-    { warehouseCode: 'WH-BSN-01', warehouseName: '부산 물류창고', location: '부산 강서구', actualStock: 180, availableStock: 172, safetyStock: 75, status: '정상', updatedAt: '2026.04.22 08:35' },
-    { warehouseCode: 'WH-DJN-01', warehouseName: '대전 허브창고', location: '대전 유성구', actualStock: 92, availableStock: 84, safetyStock: 70, status: '정상', updatedAt: '2026.04.22 08:20' },
-  ],
-  'SPA-PNT-002': [
-    { warehouseCode: 'WH-ICN-01', warehouseName: '인천 제1창고', location: '인천 서구', actualStock: 110, availableStock: 98, safetyStock: 80, status: '정상', updatedAt: '2026.04.22 09:18' },
-    { warehouseCode: 'WH-ICH-01', warehouseName: '이천 풀필먼트', location: '경기 이천시', actualStock: 46, availableStock: 39, safetyStock: 65, status: '부족', updatedAt: '2026.04.22 08:58' },
-    { warehouseCode: 'WH-BSN-01', warehouseName: '부산 물류창고', location: '부산 강서구', actualStock: 310, availableStock: 296, safetyStock: 90, status: '정상', updatedAt: '2026.04.22 08:32' },
-    { warehouseCode: 'WH-DJN-01', warehouseName: '대전 허브창고', location: '대전 유성구', actualStock: 72, availableStock: 64, safetyStock: 60, status: '정상', updatedAt: '2026.04.22 08:10' },
-  ],
-  'SPA-SKT-002': [
-    { warehouseCode: 'WH-ICN-01', warehouseName: '인천 제1창고', location: '인천 서구', actualStock: 24, availableStock: 18, safetyStock: 55, status: '부족', updatedAt: '2026.04.22 09:08' },
-    { warehouseCode: 'WH-ICH-01', warehouseName: '이천 풀필먼트', location: '경기 이천시', actualStock: 0, availableStock: 0, safetyStock: 45, status: '품절', updatedAt: '2026.04.22 08:49' },
-    { warehouseCode: 'WH-BSN-01', warehouseName: '부산 물류창고', location: '부산 강서구', actualStock: 64, availableStock: 58, safetyStock: 50, status: '정상', updatedAt: '2026.04.22 08:22' },
-    { warehouseCode: 'WH-DJN-01', warehouseName: '대전 허브창고', location: '대전 유성구', actualStock: 38, availableStock: 32, safetyStock: 50, status: '부족', updatedAt: '2026.04.22 08:05' },
-  ],
-  'SPA-OUT-001': [
-    { warehouseCode: 'WH-ICN-01', warehouseName: '인천 제1창고', location: '인천 서구', actualStock: 122, availableStock: 116, safetyStock: 50, status: '정상', updatedAt: '2026.04.22 09:14' },
-    { warehouseCode: 'WH-ICH-01', warehouseName: '이천 풀필먼트', location: '경기 이천시', actualStock: 98, availableStock: 92, safetyStock: 45, status: '정상', updatedAt: '2026.04.22 08:44' },
-    { warehouseCode: 'WH-BSN-01', warehouseName: '부산 물류창고', location: '부산 강서구', actualStock: 18, availableStock: 14, safetyStock: 35, status: '부족', updatedAt: '2026.04.22 08:18' },
-    { warehouseCode: 'WH-DJN-01', warehouseName: '대전 허브창고', location: '대전 유성구', actualStock: 0, availableStock: 0, safetyStock: 30, status: '품절', updatedAt: '2026.04.22 08:02' },
-  ],
+const warehouseGroupByCode = {
+  'WH-ICN-01': '수도권',
+  'WH-ICH-01': '수도권',
+  'WH-DJN-01': '충청권',
+  'WH-BSN-01': '영남권',
 }
 
-const selectedProduct = ref(products[0])
-const warehouseRows = ref([...warehouseInventoryMap[selectedProduct.value.itemCode]])
+const skuRows = computed(() => transferSkuCatalog.map((sku) => {
+  const rows = buildWarehouseRows(sku.skuCode)
+  const metrics = getImbalanceMetrics(rows)
+  const totalOnHand = rows.reduce((sum, row) => sum + row.onHandStock, 0)
+  const totalAvailable = rows.reduce((sum, row) => sum + row.availableStock, 0)
 
-const filteredProducts = computed(() => {
-  const keyword = productSearch.value.trim().toLowerCase()
-  if (!keyword) return products
-
-  return products.filter(product =>
-    [product.itemCode, product.itemName, product.category].join(' ').toLowerCase().includes(keyword),
-  )
-})
-
-const canTransferInventory = computed(() => selectedWarehouseCodes.value.length === 2)
-
-const selectedCountLabel = computed(() => `${selectedWarehouseCodes.value.length}/2개 선택`)
-
-const selectProduct = (product) => {
-  selectedProduct.value = product
-  productSearch.value = `${product.itemCode} ${product.itemName}`
-  isProductDropdownOpen.value = false
-}
-
-const toggleWarehouseSelection = (warehouseCode) => {
-  if (selectedWarehouseCodes.value.includes(warehouseCode)) {
-    selectedWarehouseCodes.value = selectedWarehouseCodes.value.filter(code => code !== warehouseCode)
-    return
+  return {
+    ...sku,
+    totalOnHand,
+    totalAvailable,
+    ...metrics,
+    warehouseGroups: [...new Set(rows.map(row => warehouseGroupByCode[row.warehouseCode]).filter(Boolean))],
   }
+}))
 
-  if (selectedWarehouseCodes.value.length >= 2) return
+const filteredSkuRows = computed(() => {
+  const keyword = searchTerm.value.trim().toLowerCase()
 
-  selectedWarehouseCodes.value = [...selectedWarehouseCodes.value, warehouseCode]
-}
+  return skuRows.value
+    .filter((row) => {
+      if (selectedCategory.value !== '전체' && row.category !== selectedCategory.value) return false
+      if (selectedStatus.value !== '전체' && row.status !== selectedStatus.value) return false
+      if (selectedWarehouseGroup.value !== '전체' && !row.warehouseGroups.includes(selectedWarehouseGroup.value)) return false
+      if (!keyword) return true
 
-const handleDragStart = (warehouseCode) => {
-  draggedWarehouseCode.value = warehouseCode
-}
-
-const handleDrop = (targetWarehouseCode) => {
-  if (!draggedWarehouseCode.value || draggedWarehouseCode.value === targetWarehouseCode) return
-
-  const nextRows = [...warehouseRows.value]
-  const fromIndex = nextRows.findIndex(row => row.warehouseCode === draggedWarehouseCode.value)
-  const toIndex = nextRows.findIndex(row => row.warehouseCode === targetWarehouseCode)
-
-  if (fromIndex < 0 || toIndex < 0) return
-
-  const [movedRow] = nextRows.splice(fromIndex, 1)
-  nextRows.splice(toIndex, 0, movedRow)
-  warehouseRows.value = nextRows
-  draggedWarehouseCode.value = ''
-}
-
-const handleDragEnd = () => {
-  draggedWarehouseCode.value = ''
-}
+      return [row.skuCode, row.itemCode, row.itemName].join(' ').toLowerCase().includes(keyword)
+    })
+    .sort((a, b) => b.imbalanceScore - a.imbalanceScore)
+})
 
 const statusClass = (status) => ({
   정상: 'bg-[#EBF5F5] text-black',
-  부족: 'bg-amber-50 text-amber-700',
-  품절: 'bg-red-50 text-red-700',
+  주의: 'bg-amber-50 text-amber-700',
+  불균형: 'bg-red-50 text-red-700',
 })[status] ?? 'bg-gray-100 text-gray-600'
 
-watch(selectedProduct, (product) => {
-  warehouseRows.value = [...warehouseInventoryMap[product.itemCode]]
-  selectedWarehouseCodes.value = []
-})
+const moveToSkuDetail = (sku) => {
+  router.push({
+    name: 'hq-inventory-warehouse-transfer-detail',
+    params: { skuCode: sku.skuCode },
+    query: {
+      search: searchTerm.value || undefined,
+      category: selectedCategory.value !== '전체' ? selectedCategory.value : undefined,
+      status: selectedStatus.value !== '전체' ? selectedStatus.value : undefined,
+      warehouseGroup: selectedWarehouseGroup.value !== '전체' ? selectedWarehouseGroup.value : undefined,
+    },
+  })
+}
+
+const resetFilters = () => {
+  searchTerm.value = ''
+  selectedCategory.value = '전체'
+  selectedStatus.value = '전체'
+  selectedWarehouseGroup.value = '전체'
+}
 
 function handleLogout() {
   auth.logout()
@@ -142,131 +102,100 @@ function handleLogout() {
   >
     <div class="flex flex-col gap-4">
       <section class="border border-gray-200 bg-white p-4 shadow-sm">
-        <div class="mb-4 flex flex-wrap items-start justify-between gap-3">
-          <div>
-            <p class="text-[10px] font-black uppercase tracking-[0.18em] text-gray-400">Inventory</p>
-            <h1 class="mt-1 text-lg font-black text-gray-900">창고별 재고 비교</h1>
-            <p class="mt-1 text-xs font-bold text-gray-500">상품 하나를 선택해 창고별 보유 재고를 비교합니다.</p>
-          </div>
-
-          <button
-            type="button"
-            class="h-9 px-4 text-xs font-black transition"
-            :class="canTransferInventory ? 'bg-[#004D3C] text-white hover:bg-[#00382c]' : 'cursor-not-allowed bg-gray-100 text-gray-400'"
-            :disabled="!canTransferInventory"
-          >
-            재고 이동
-          </button>
+        <div class="mb-4">
+          <p class="text-[10px] font-black uppercase tracking-[0.18em] text-gray-400">Inventory</p>
+          <h1 class="mt-1 text-lg font-black text-gray-900">창고간 재고 이동</h1>
+          <p class="mt-1 text-xs font-bold text-gray-500">불균형 SKU를 우선 확인하고 상세에서 창고 간 이동을 실행합니다.</p>
         </div>
 
-        <div class="grid gap-3 lg:grid-cols-[1.3fr_1fr]">
-          <div class="relative">
-            <label class="flex flex-col gap-1.5">
-              <span class="text-[11px] font-bold text-gray-500">상품 검색</span>
-              <input
-                v-model="productSearch"
-                type="search"
-                class="h-10 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none placeholder:text-gray-400 focus:border-[#004D3C]"
-                placeholder="상품 코드 또는 상품명"
-                @focus="isProductDropdownOpen = true"
-              />
-            </label>
+        <div class="grid gap-2 md:grid-cols-2 xl:grid-cols-[1.2fr_0.9fr_0.9fr_0.9fr_auto]">
+          <label class="flex flex-col gap-1">
+            <span class="text-[11px] font-bold text-gray-500">검색</span>
+            <input
+              v-model="searchTerm"
+              type="search"
+              class="h-10 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none placeholder:text-gray-400 focus:border-[#004D3C]"
+              placeholder="SKU 코드, 품목 코드, 품목명"
+            />
+          </label>
 
-            <div
-              v-if="isProductDropdownOpen"
-              class="absolute left-0 right-0 top-full z-20 mt-1 max-h-64 overflow-y-auto border border-gray-300 bg-white p-1 shadow-lg"
-            >
-              <button
-                v-for="product in filteredProducts"
-                :key="product.itemCode"
-                type="button"
-                class="flex w-full flex-col gap-0.5 px-3 py-2 text-left hover:bg-[#EBF5F5]"
-                @click="selectProduct(product)"
-              >
-                <span class="text-xs font-black text-gray-900">{{ product.itemName }}</span>
-                <span class="text-[11px] font-bold text-gray-500">{{ product.itemCode }} · {{ product.category }}</span>
-              </button>
-              <p v-if="filteredProducts.length === 0" class="px-3 py-6 text-center text-xs font-bold text-gray-400">
-                검색 결과가 없습니다.
-              </p>
-            </div>
-          </div>
+          <label class="flex flex-col gap-1">
+            <span class="text-[11px] font-bold text-gray-500">카테고리</span>
+            <select v-model="selectedCategory" class="h-10 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none focus:border-[#004D3C]">
+              <option v-for="category in categoryOptions" :key="category" :value="category">{{ category }}</option>
+            </select>
+          </label>
 
-          <div class="border border-[#D6EAEA] bg-[#EBF5F5] px-4 py-3">
-            <p class="text-[10px] font-black uppercase tracking-[0.14em] text-gray-500">Selected Product</p>
-            <p class="mt-1 text-sm font-black text-gray-900">{{ selectedProduct.itemName }}</p>
-            <div class="mt-2 flex flex-wrap gap-2 text-[11px] font-bold text-gray-600">
-              <span class="bg-white px-2 py-1">{{ selectedProduct.itemCode }}</span>
-              <span class="bg-white px-2 py-1">{{ selectedProduct.category }}</span>
-              <span class="bg-white px-2 py-1">{{ selectedCountLabel }}</span>
-            </div>
+          <label class="flex flex-col gap-1">
+            <span class="text-[11px] font-bold text-gray-500">불균형 상태</span>
+            <select v-model="selectedStatus" class="h-10 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none focus:border-[#004D3C]">
+              <option value="전체">전체</option>
+              <option value="불균형">불균형</option>
+              <option value="주의">주의</option>
+              <option value="정상">정상</option>
+            </select>
+          </label>
+
+          <label class="flex flex-col gap-1">
+            <span class="text-[11px] font-bold text-gray-500">창고군</span>
+            <select v-model="selectedWarehouseGroup" class="h-10 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none focus:border-[#004D3C]">
+              <option v-for="group in warehouseGroupOptions" :key="group" :value="group">{{ group }}</option>
+            </select>
+          </label>
+
+          <div class="flex items-end">
+            <button type="button" class="h-10 border border-gray-300 px-4 text-xs font-black text-gray-700 transition hover:bg-gray-100" @click="resetFilters">
+              초기화
+            </button>
           </div>
         </div>
       </section>
 
-      <section class="min-w-0 border border-gray-200 bg-white shadow-sm">
+      <section class="border border-gray-200 bg-white shadow-sm">
         <div class="flex items-center justify-between border-b border-gray-100 px-4 py-3">
-          <div>
-            <h2 class="text-sm font-black text-gray-900">창고별 재고 리스트</h2>
-            <p class="mt-1 text-[11px] font-bold text-gray-400">행 왼쪽 핸들을 드래그해 창고 순서를 바꿀 수 있습니다.</p>
-          </div>
-          <p class="text-[11px] font-black text-gray-500">총 {{ warehouseRows.length }}개 창고</p>
+          <h2 class="text-sm font-black text-gray-900">불균형 SKU 리스트</h2>
+          <p class="text-[11px] font-black text-gray-500">총 {{ filteredSkuRows.length }}건</p>
         </div>
 
         <div class="overflow-x-auto">
           <table class="min-w-[1080px] w-full border-collapse text-left text-xs">
             <thead class="bg-gray-50 text-[10px] uppercase tracking-[0.12em] text-gray-500">
               <tr>
-                <th class="w-20 px-3 py-3 text-center font-black">선택</th>
-                <th class="px-3 py-3 font-black">창고 코드</th>
-                <th class="px-3 py-3 font-black">창고명</th>
-                <th class="px-3 py-3 font-black">위치</th>
-                <th class="px-3 py-3 text-right font-black">실재고</th>
-                <th class="px-3 py-3 text-right font-black">가용재고</th>
-                <th class="px-3 py-3 text-right font-black">안전재고</th>
+                <th class="px-3 py-3 font-black">SKU 코드</th>
+                <th class="px-3 py-3 font-black">품목 코드</th>
+                <th class="px-3 py-3 font-black">품목명</th>
+                <th class="px-3 py-3 font-black">옵션</th>
+                <th class="px-3 py-3 font-black">카테고리</th>
+                <th class="px-3 py-3 text-right font-black">총 실재고</th>
+                <th class="px-3 py-3 text-right font-black">총 가용재고</th>
+                <th class="px-3 py-3 text-right font-black">불균형 점수</th>
                 <th class="px-3 py-3 text-center font-black">상태</th>
-                <th class="px-3 py-3 font-black">최종 업데이트</th>
               </tr>
             </thead>
             <tbody class="divide-y divide-gray-100">
               <tr
-                v-for="row in warehouseRows"
-                :key="row.warehouseCode"
-                draggable="true"
-                class="cursor-pointer transition"
-                :class="[
-                  selectedWarehouseCodes.includes(row.warehouseCode) ? 'bg-[#EBF5F5] font-bold' : 'hover:bg-[#EBF5F5]/60',
-                  draggedWarehouseCode === row.warehouseCode ? 'opacity-50' : '',
-                ]"
-                @click="toggleWarehouseSelection(row.warehouseCode)"
-                @dragstart="handleDragStart(row.warehouseCode)"
-                @dragover.prevent
-                @drop.prevent="handleDrop(row.warehouseCode)"
-                @dragend="handleDragEnd"
+                v-for="row in filteredSkuRows"
+                :key="row.skuCode"
+                class="cursor-pointer transition hover:bg-[#EBF5F5]/60"
+                @click="moveToSkuDetail(row)"
               >
+                <td class="px-3 py-3 font-mono font-bold text-gray-700">{{ row.skuCode }}</td>
+                <td class="px-3 py-3 font-mono font-bold text-gray-500">{{ row.itemCode }}</td>
+                <td class="px-3 py-3 font-black text-gray-900">{{ row.itemName }}</td>
+                <td class="px-3 py-3 font-bold text-gray-600">{{ row.color }}/{{ row.size }}</td>
+                <td class="px-3 py-3 font-bold text-gray-600">{{ row.category }}</td>
+                <td class="px-3 py-3 text-right font-black text-gray-900">{{ row.totalOnHand.toLocaleString() }}</td>
+                <td class="px-3 py-3 text-right font-black text-gray-900">{{ row.totalAvailable.toLocaleString() }}</td>
+                <td class="px-3 py-3 text-right font-black text-gray-900">{{ row.imbalanceScore.toLocaleString() }}</td>
                 <td class="px-3 py-3 text-center">
-                  <div class="inline-flex items-center gap-3">
-                    <span class="cursor-grab text-base font-black text-gray-400 active:cursor-grabbing">⋮⋮</span>
-                    <input
-                      type="checkbox"
-                      class="h-3.5 w-3.5 accent-[#004D3C]"
-                      :checked="selectedWarehouseCodes.includes(row.warehouseCode)"
-                      @click.stop="toggleWarehouseSelection(row.warehouseCode)"
-                    />
-                  </div>
+                  <span class="inline-flex min-w-14 justify-center px-2 py-1 text-[11px] font-black" :class="statusClass(row.status)">{{ row.status }}</span>
                 </td>
-                <td class="px-3 py-3 font-mono font-bold text-gray-500">{{ row.warehouseCode }}</td>
-                <td class="px-3 py-3 font-black text-gray-900">{{ row.warehouseName }}</td>
-                <td class="px-3 py-3 font-bold text-gray-600">{{ row.location }}</td>
-                <td class="px-3 py-3 text-right font-black text-gray-900">{{ row.actualStock.toLocaleString() }}</td>
-                <td class="px-3 py-3 text-right font-black text-gray-900">{{ row.availableStock.toLocaleString() }}</td>
-                <td class="px-3 py-3 text-right font-bold text-gray-500">{{ row.safetyStock.toLocaleString() }}</td>
-                <td class="px-3 py-3 text-center">
-                  <span class="inline-flex min-w-12 justify-center px-2 py-1 text-[11px] font-black" :class="statusClass(row.status)">
-                    {{ row.status }}
-                  </span>
+              </tr>
+
+              <tr v-if="filteredSkuRows.length === 0">
+                <td colspan="9" class="px-4 py-10 text-center text-xs font-bold text-gray-400">
+                  조건에 맞는 SKU가 없습니다.
                 </td>
-                <td class="px-3 py-3 font-bold text-gray-500">{{ row.updatedAt }}</td>
               </tr>
             </tbody>
           </table>

--- a/src/views/hq/inventory/HqWarehouseSkuTransferDetailView.vue
+++ b/src/views/hq/inventory/HqWarehouseSkuTransferDetailView.vue
@@ -1,0 +1,389 @@
+<script setup>
+import { computed, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import AppLayout from '@/components/common/AppLayout.vue'
+import { roleMenus } from '@/config/roleMenus.js'
+import { useAuthStore } from '@/stores/auth.js'
+import { transferSkuCatalog, buildWarehouseRows } from '@/constants/hqWarehouseTransferData.js'
+
+const route = useRoute()
+const router = useRouter()
+const auth = useAuthStore()
+const hqMenus = roleMenus.hq
+const inventoryMenus = roleMenus.hq.find(menu => menu.label === '재고 관리')?.children ?? []
+
+const activeTopMenu = computed(() => '재고 관리')
+const activeSideMenu = ref('창고간 재고 이동')
+
+const selectedWarehouseCodes = ref([])
+const transferQty = ref('')
+const transferReason = ref('재고 불균형 해소')
+const transferNote = ref('')
+const sheetOpen = ref(false)
+const toastMessage = ref('')
+let toastTimer = null
+
+const selectedSku = computed(() => transferSkuCatalog.find(sku => sku.skuCode === route.params.skuCode) ?? null)
+const warehouseRows = ref([])
+
+watch(selectedSku, (sku) => {
+  warehouseRows.value = sku ? buildWarehouseRows(sku.skuCode) : []
+  selectedWarehouseCodes.value = []
+  transferQty.value = ''
+  transferReason.value = '재고 불균형 해소'
+  transferNote.value = ''
+  sheetOpen.value = false
+}, { immediate: true })
+
+const selectedWarehouses = computed(() => warehouseRows.value.filter(row => selectedWarehouseCodes.value.includes(row.warehouseCode)))
+const canTransfer = computed(() => selectedWarehouses.value.length === 2)
+
+const fromWarehouse = computed(() => {
+  if (!canTransfer.value) return null
+  return [...selectedWarehouses.value].sort((a, b) => b.availableStock - a.availableStock)[0]
+})
+
+const toWarehouse = computed(() => {
+  if (!canTransfer.value) return null
+  return [...selectedWarehouses.value].sort((a, b) => a.availableStock - b.availableStock)[0]
+})
+
+const maxTransferQty = computed(() => fromWarehouse.value?.availableStock ?? 0)
+
+const transferValidationMessage = computed(() => {
+  if (!canTransfer.value) return '이동할 창고 2개를 선택해주세요.'
+
+  const qty = Number(transferQty.value)
+  if (!Number.isFinite(qty) || qty <= 0) return '이동 수량은 1 이상이어야 합니다.'
+  if (qty > maxTransferQty.value) return `이동 가능 수량(${maxTransferQty.value}개) 이내로 입력해주세요.`
+  if (fromWarehouse.value?.warehouseCode === toWarehouse.value?.warehouseCode) return '동일 창고 간 이동은 불가능합니다.'
+
+  return ''
+})
+
+const canSubmitTransfer = computed(() => !transferValidationMessage.value)
+
+const expectedStocks = computed(() => {
+  if (!canSubmitTransfer.value) return null
+  const qty = Number(transferQty.value)
+
+  return {
+    fromAfter: fromWarehouse.value.availableStock - qty,
+    toAfter: toWarehouse.value.availableStock + qty,
+  }
+})
+
+const statusClass = (status) => ({
+  정상: 'bg-[#EBF5F5] text-black',
+  부족: 'bg-amber-50 text-amber-700',
+  품절: 'bg-red-50 text-red-700',
+})[status] ?? 'bg-gray-100 text-gray-600'
+
+const toggleWarehouseSelection = (warehouseCode) => {
+  if (selectedWarehouseCodes.value.includes(warehouseCode)) {
+    selectedWarehouseCodes.value = selectedWarehouseCodes.value.filter(code => code !== warehouseCode)
+    return
+  }
+
+  if (selectedWarehouseCodes.value.length >= 2) return
+  selectedWarehouseCodes.value = [...selectedWarehouseCodes.value, warehouseCode]
+}
+
+const openSheet = () => {
+  if (!canTransfer.value) return
+  sheetOpen.value = true
+}
+
+const closeSheet = () => {
+  sheetOpen.value = false
+}
+
+const submitTransfer = () => {
+  if (!canSubmitTransfer.value) return
+
+  const qty = Number(transferQty.value)
+  const sourceWarehouseName = fromWarehouse.value?.warehouseName ?? ''
+  const targetWarehouseName = toWarehouse.value?.warehouseName ?? ''
+  const fromIndex = warehouseRows.value.findIndex(row => row.warehouseCode === fromWarehouse.value.warehouseCode)
+  const toIndex = warehouseRows.value.findIndex(row => row.warehouseCode === toWarehouse.value.warehouseCode)
+
+  if (fromIndex < 0 || toIndex < 0) return
+
+  warehouseRows.value[fromIndex].onHandStock -= qty
+  warehouseRows.value[fromIndex].availableStock -= qty
+  warehouseRows.value[toIndex].onHandStock += qty
+  warehouseRows.value[toIndex].availableStock += qty
+
+  selectedWarehouseCodes.value = []
+  transferQty.value = ''
+  transferReason.value = '재고 불균형 해소'
+  transferNote.value = ''
+  sheetOpen.value = false
+
+  showToast(`재고 이동 완료: ${sourceWarehouseName} → ${targetWarehouseName}`)
+}
+
+const showToast = (message) => {
+  toastMessage.value = message
+  if (toastTimer) clearTimeout(toastTimer)
+  toastTimer = setTimeout(() => {
+    toastMessage.value = ''
+  }, 2600)
+}
+
+const moveBack = () => {
+  router.push({
+    name: 'hq-inventory-warehouse-comparison',
+    query: {
+      search: route.query.search || undefined,
+      category: route.query.category || undefined,
+      status: route.query.status || undefined,
+      warehouseGroup: route.query.warehouseGroup || undefined,
+    },
+  })
+}
+
+function handleLogout() {
+  auth.logout()
+  router.push('/login')
+}
+</script>
+
+<template>
+  <AppLayout
+    :active-top-menu="activeTopMenu"
+    :top-menus="hqMenus"
+    :side-menus="inventoryMenus"
+    v-model:active-side-menu="activeSideMenu"
+    @logout="handleLogout"
+  >
+    <div v-if="selectedSku" class="flex flex-col gap-4 pb-20">
+      <section class="border border-gray-200 bg-white p-4 shadow-sm">
+        <div class="mb-3 flex items-start justify-between gap-2">
+          <div>
+            <p class="text-[10px] font-black uppercase tracking-[0.18em] text-gray-400">Inventory</p>
+            <h1 class="mt-1 text-lg font-black text-gray-900">창고별 SKU 분포 상세</h1>
+            <p class="mt-1 text-xs font-bold text-gray-500">창고 2개를 선택한 뒤 하단 바에서 이동 정보를 입력하세요.</p>
+          </div>
+          <button type="button" class="h-9 border border-gray-300 px-4 text-xs font-black text-gray-700 hover:bg-gray-100" @click="moveBack">
+            목록으로
+          </button>
+        </div>
+
+        <div class="flex flex-wrap gap-2 text-[11px] font-bold text-gray-600">
+          <span class="bg-gray-100 px-2 py-1">{{ selectedSku.skuCode }}</span>
+          <span class="bg-gray-100 px-2 py-1">{{ selectedSku.itemCode }}</span>
+          <span class="bg-gray-100 px-2 py-1">{{ selectedSku.itemName }}</span>
+          <span class="bg-gray-100 px-2 py-1">{{ selectedSku.category }}</span>
+          <span class="bg-gray-100 px-2 py-1">{{ selectedSku.color }}/{{ selectedSku.size }}</span>
+        </div>
+      </section>
+
+      <section class="border border-gray-200 bg-white shadow-sm">
+        <div class="flex items-center justify-between border-b border-gray-100 px-4 py-3">
+          <h2 class="text-sm font-black text-gray-900">창고별 재고 분포</h2>
+          <p class="text-[11px] font-black text-gray-500">{{ selectedWarehouseCodes.length }}/2개 선택</p>
+        </div>
+
+        <div class="overflow-x-auto">
+          <table class="min-w-[980px] w-full border-collapse text-left text-xs">
+            <thead class="bg-gray-50 text-[10px] uppercase tracking-[0.12em] text-gray-500">
+              <tr>
+                <th class="w-16 px-3 py-3 text-center font-black">선택</th>
+                <th class="px-3 py-3 font-black">창고 코드</th>
+                <th class="px-3 py-3 font-black">창고명</th>
+                <th class="px-3 py-3 font-black">위치</th>
+                <th class="px-3 py-3 text-right font-black">실재고</th>
+                <th class="px-3 py-3 text-right font-black">예약</th>
+                <th class="px-3 py-3 text-right font-black">가용</th>
+                <th class="px-3 py-3 text-right font-black">안전재고</th>
+                <th class="px-3 py-3 text-center font-black">상태</th>
+                <th class="px-3 py-3 font-black">최종 업데이트</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100">
+              <tr
+                v-for="row in warehouseRows"
+                :key="row.warehouseCode"
+                class="cursor-pointer transition"
+                :class="selectedWarehouseCodes.includes(row.warehouseCode) ? 'bg-[#EBF5F5] font-bold' : 'hover:bg-[#EBF5F5]/60'"
+                @click="toggleWarehouseSelection(row.warehouseCode)"
+              >
+                <td class="px-3 py-3 text-center">
+                  <input
+                    type="checkbox"
+                    class="h-3.5 w-3.5 accent-[#004D3C]"
+                    :checked="selectedWarehouseCodes.includes(row.warehouseCode)"
+                    @click.stop="toggleWarehouseSelection(row.warehouseCode)"
+                  />
+                </td>
+                <td class="px-3 py-3 font-mono font-bold text-gray-500">{{ row.warehouseCode }}</td>
+                <td class="px-3 py-3 font-black text-gray-900">{{ row.warehouseName }}</td>
+                <td class="px-3 py-3 font-bold text-gray-600">{{ row.location }}</td>
+                <td class="px-3 py-3 text-right font-black text-gray-900">{{ row.onHandStock.toLocaleString() }}</td>
+                <td class="px-3 py-3 text-right font-bold text-gray-500">{{ row.reservedStock.toLocaleString() }}</td>
+                <td class="px-3 py-3 text-right font-black text-gray-900">{{ row.availableStock.toLocaleString() }}</td>
+                <td class="px-3 py-3 text-right font-bold text-gray-500">{{ row.safetyStock.toLocaleString() }}</td>
+                <td class="px-3 py-3 text-center">
+                  <span class="inline-flex min-w-12 justify-center px-2 py-1 text-[11px] font-black" :class="statusClass(row.status)">{{ row.status }}</span>
+                </td>
+                <td class="px-3 py-3 font-bold text-gray-500">{{ row.updatedAt }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <div class="fixed bottom-0 left-0 right-0 z-40 border-t border-gray-200 bg-white/95 backdrop-blur">
+        <div class="flex items-center gap-3 px-4 py-3">
+          <div class="min-w-0 flex-1">
+            <p class="text-[11px] font-black text-gray-500">선택 창고</p>
+            <p v-if="selectedWarehouseCodes.length === 0" class="text-xs font-bold text-gray-400">
+              창고를 2개 선택해주세요.
+            </p>
+            <p v-else-if="selectedWarehouseCodes.length === 1" class="text-xs font-bold text-gray-400">
+              {{ selectedWarehouses[0].warehouseName }} 선택됨 · 1개 더 선택해주세요.
+            </p>
+            <p v-else class="truncate text-xs font-bold text-gray-800">
+              {{ fromWarehouse.warehouseName }}
+              <span class="mx-1 text-gray-400">→</span>
+              {{ toWarehouse.warehouseName }}
+              <span class="ml-2 text-gray-400">(2/2)</span>
+            </p>
+          </div>
+          <button
+            type="button"
+            class="ml-auto flex h-10 shrink-0 items-center gap-1.5 px-4 text-xs font-black transition"
+            :class="canTransfer ? 'bg-[#004D3C] text-white hover:bg-[#00382c]' : 'cursor-not-allowed bg-gray-100 text-gray-400'"
+            :disabled="!canTransfer"
+            @click="openSheet"
+          >
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <polyline points="18 15 12 9 6 15" />
+            </svg>
+            이동 정보 입력
+          </button>
+        </div>
+      </div>
+
+      <div v-if="sheetOpen" class="fixed inset-0 z-50">
+        <div class="absolute inset-0 bg-black/35" @click="closeSheet" />
+        <section class="absolute bottom-0 left-0 right-0 max-h-[84vh] overflow-y-auto border-t border-gray-200 bg-white shadow-2xl">
+          <div class="w-full px-6 py-5 lg:px-8">
+            <div class="mb-5 flex items-start justify-between gap-4 border-b border-gray-100 pb-4">
+              <div>
+                <h2 class="text-base font-black text-gray-900">재고 이동 정보 입력</h2>
+                <p class="mt-1 text-[11px] font-bold text-gray-500">출발/도착 창고를 확인하고 이동 수량과 사유를 입력하세요.</p>
+              </div>
+              <button type="button" class="h-8 shrink-0 border border-gray-300 px-3 text-xs font-black text-gray-700 hover:bg-gray-100" @click="closeSheet">닫기</button>
+            </div>
+
+            <div class="grid w-full gap-6 lg:grid-cols-2 lg:items-start">
+              <div class="space-y-4 border border-gray-200 bg-gray-50 p-4">
+                <div class="grid gap-3 text-xs sm:grid-cols-2">
+                  <div class="border border-gray-200 bg-white p-3">
+                    <p class="text-[11px] font-black text-gray-500">출발 창고</p>
+                    <p class="mt-1 text-sm font-black text-gray-900">{{ fromWarehouse?.warehouseName || '-' }}</p>
+                    <p class="mt-2 text-base font-black text-gray-800">가용 {{ fromWarehouse?.availableStock?.toLocaleString?.() ?? 0 }}개</p>
+                  </div>
+                  <div class="border border-gray-200 bg-white p-3">
+                    <p class="text-[11px] font-black text-gray-500">도착 창고</p>
+                    <p class="mt-1 text-sm font-black text-gray-900">{{ toWarehouse?.warehouseName || '-' }}</p>
+                    <p class="mt-2 text-base font-black text-gray-800">가용 {{ toWarehouse?.availableStock?.toLocaleString?.() ?? 0 }}개</p>
+                  </div>
+                </div>
+
+                <div class="grid gap-3 sm:grid-cols-2">
+                  <label class="flex flex-col gap-1">
+                    <span class="text-[11px] font-black text-gray-500">이동 수량</span>
+                    <div class="flex h-11 items-center border border-gray-300 bg-white focus-within:border-[#004D3C]">
+                      <input
+                        v-model="transferQty"
+                        type="number"
+                        min="1"
+                        :max="maxTransferQty"
+                        class="h-full w-full px-3 text-sm font-black text-gray-900 outline-none"
+                        placeholder="수량 입력"
+                      />
+                      <span class="pr-3 text-[11px] font-black text-gray-500">개</span>
+                    </div>
+                    <span class="text-[11px] font-bold text-gray-500">최대 {{ maxTransferQty.toLocaleString() }}개 이동 가능</span>
+                  </label>
+
+                  <label class="flex flex-col gap-1">
+                    <span class="text-[11px] font-black text-gray-500">이동 사유</span>
+                    <select v-model="transferReason" class="h-11 border border-gray-300 bg-white px-3 text-sm font-black text-gray-900 outline-none focus:border-[#004D3C]">
+                      <option value="재고 불균형 해소">재고 불균형 해소</option>
+                      <option value="프로모션 대응">프로모션 대응</option>
+                      <option value="품절 예방">품절 예방</option>
+                      <option value="기타">기타</option>
+                    </select>
+                  </label>
+                </div>
+
+                <label class="flex flex-col gap-1">
+                  <span class="text-[11px] font-black text-gray-500">메모</span>
+                  <textarea
+                    v-model="transferNote"
+                    rows="3"
+                    class="border border-gray-300 bg-white px-3 py-2 text-sm font-bold text-gray-900 outline-none focus:border-[#004D3C]"
+                    placeholder="이동 목적 또는 특이사항"
+                  />
+                </label>
+              </div>
+
+              <div class="space-y-3 self-start">
+                <div class="border border-[#D6EAEA] bg-[#EBF5F5] p-4">
+                  <p class="text-[11px] font-black text-gray-600">이동 후 가용재고 예상</p>
+                  <template v-if="expectedStocks">
+                    <p class="mt-2 text-[11px] font-bold text-gray-700">{{ fromWarehouse?.warehouseName }}: {{ expectedStocks.fromAfter.toLocaleString() }}개</p>
+                    <p class="mt-1 text-[11px] font-bold text-gray-700">{{ toWarehouse?.warehouseName }}: {{ expectedStocks.toAfter.toLocaleString() }}개</p>
+                  </template>
+                  <p v-else class="mt-2 text-[11px] font-bold text-gray-500">수량 입력 후 예상 재고를 확인할 수 있습니다.</p>
+                </div>
+
+                <div class="border border-gray-200 bg-gray-50 p-4">
+                  <p class="mb-2 text-[11px] font-black text-gray-500">이동 요약</p>
+                  <p class="text-[11px] font-bold text-gray-700">SKU: {{ selectedSku.skuCode }}</p>
+                  <p class="mt-1 text-[11px] font-bold text-gray-700">선택 창고: {{ selectedWarehouseCodes.length }}/2</p>
+                  <p class="mt-1 text-[11px] font-bold text-gray-700">최대 이동 가능: {{ maxTransferQty.toLocaleString() }}개</p>
+                </div>
+
+                <p v-if="transferValidationMessage" class="text-[11px] font-bold text-red-600">{{ transferValidationMessage }}</p>
+
+                <div class="mx-auto flex w-full max-w-[360px] gap-2 lg:max-w-none">
+                  <button type="button" class="h-10 flex-1 border border-gray-300 px-4 text-xs font-black text-gray-700 hover:bg-gray-100" @click="closeSheet">
+                    취소
+                  </button>
+                  <button
+                    type="button"
+                    class="h-10 flex-1 px-4 text-xs font-black transition"
+                    :class="canSubmitTransfer ? 'bg-[#004D3C] text-white hover:bg-[#00382c]' : 'cursor-not-allowed bg-gray-100 text-gray-400'"
+                    :disabled="!canSubmitTransfer"
+                    @click="submitTransfer"
+                  >
+                    재고 이동 실행
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+
+    <section v-else class="border border-gray-200 bg-white p-10 text-center shadow-sm">
+      <p class="text-sm font-black text-gray-700">존재하지 않는 SKU입니다.</p>
+      <button type="button" class="mt-4 h-9 border border-gray-300 px-4 text-xs font-black text-gray-700 hover:bg-gray-100" @click="moveBack">
+        목록으로
+      </button>
+    </section>
+
+    <div
+      v-if="toastMessage"
+      class="fixed bottom-20 right-5 z-50 border border-emerald-200 bg-emerald-50 px-4 py-2 text-xs font-black text-emerald-700 shadow-sm"
+    >
+      {{ toastMessage }}
+    </div>
+  </AppLayout>
+</template>

--- a/src/views/hq/inventory/HqWarehouseTransferHistoryDetailView.vue
+++ b/src/views/hq/inventory/HqWarehouseTransferHistoryDetailView.vue
@@ -1,0 +1,257 @@
+<script setup>
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import AppLayout from '@/components/common/AppLayout.vue'
+import { roleMenus } from '@/config/roleMenus.js'
+import { useAuthStore } from '@/stores/auth.js'
+
+const route = useRoute()
+const router = useRouter()
+const auth = useAuthStore()
+const hqMenus = roleMenus.hq
+const inventoryMenus = roleMenus.hq.find(menu => menu.label === '재고 관리')?.children ?? []
+
+const activeTopMenu = computed(() => '재고 관리')
+const activeSideMenu = computed(() => '창고간 재고 이동 내역')
+
+const allRecords = [
+  {
+    transferNo: 'TRF-20260430-0012',
+    skuCode: 'PRD-TOP-SH-003-NVY-L',
+    itemName: '오버핏 옥스포드 셔츠',
+    fromWarehouseCode: 'WH-BSN-01',
+    fromWarehouseName: '부산 물류창고',
+    toWarehouseCode: 'WH-DJN-01',
+    toWarehouseName: '대전 허브창고',
+    transferQty: 24,
+    reason: '재고 불균형 해소',
+    requestedBy: '김본사',
+    requestedAt: '2026-04-30 09:42',
+    status: '완료',
+    memo: '부산권 수요 증가 대응을 위해 대전 허브로 선이동 처리.',
+    fromStockBefore: 58,
+    toStockBefore: 8,
+  },
+  {
+    transferNo: 'TRF-20260429-0007',
+    skuCode: 'PRD-OUT-PD-001-NVY-XL',
+    itemName: '라이트 숏 패딩',
+    fromWarehouseCode: 'WH-ICN-01',
+    fromWarehouseName: '인천 제1창고',
+    toWarehouseCode: 'WH-BSN-01',
+    toWarehouseName: '부산 물류창고',
+    transferQty: 18,
+    reason: '품절 예방',
+    requestedBy: '이재고',
+    requestedAt: '2026-04-29 14:20',
+    status: '완료',
+    memo: '주말 행사 대비 안전재고 확보 목적.',
+    fromStockBefore: 56,
+    toStockBefore: 5,
+  },
+  {
+    transferNo: 'TRF-20260428-0019',
+    skuCode: 'PRD-TOP-SS-001-BLK-S',
+    itemName: '코튼 베이직 반팔 티셔츠',
+    fromWarehouseCode: 'WH-ICN-01',
+    fromWarehouseName: '인천 제1창고',
+    toWarehouseCode: 'WH-ICH-01',
+    toWarehouseName: '이천 풀필먼트',
+    transferQty: 30,
+    reason: '프로모션 대응',
+    requestedBy: '박운영',
+    requestedAt: '2026-04-28 11:05',
+    status: '진행중',
+    memo: '온라인 프로모션 반응 확인 후 추가 이동 예정.',
+    fromStockBefore: 128,
+    toStockBefore: 22,
+  },
+  {
+    transferNo: 'TRF-20260427-0005',
+    skuCode: 'PRD-PNT-SH-002-GRY-M',
+    itemName: '라이트 코튼 쇼츠',
+    fromWarehouseCode: 'WH-DJN-01',
+    fromWarehouseName: '대전 허브창고',
+    toWarehouseCode: 'WH-ICN-01',
+    toWarehouseName: '인천 제1창고',
+    transferQty: 12,
+    reason: '재고 불균형 해소',
+    requestedBy: '최관리',
+    requestedAt: '2026-04-27 16:32',
+    status: '취소',
+    memo: '출발 창고의 출고 우선순위 변경으로 취소.',
+    fromStockBefore: 0,
+    toStockBefore: 45,
+  },
+]
+
+const record = computed(() => allRecords.find(r => r.transferNo === route.params.transferNo) ?? null)
+
+const fromStockAfter = computed(() => {
+  if (!record.value || record.value.status === '취소') return record.value?.fromStockBefore ?? 0
+  return record.value.fromStockBefore - record.value.transferQty
+})
+
+const toStockAfter = computed(() => {
+  if (!record.value || record.value.status === '취소') return record.value?.toStockBefore ?? 0
+  return record.value.toStockBefore + record.value.transferQty
+})
+
+const statusClass = (status) => ({
+  완료: 'bg-[#EBF5F5] text-black',
+  진행중: 'bg-amber-50 text-amber-700',
+  취소: 'bg-red-50 text-red-700',
+})[status] ?? 'bg-gray-100 text-gray-600'
+
+function handleLogout() {
+  auth.logout()
+  router.push('/login')
+}
+</script>
+
+<template>
+  <AppLayout
+    :active-top-menu="activeTopMenu"
+    :top-menus="hqMenus"
+    :side-menus="inventoryMenus"
+    :active-side-menu="activeSideMenu"
+    @logout="handleLogout"
+  >
+    <div v-if="record" class="flex flex-col gap-4">
+      <section class="border border-gray-200 bg-white p-5 shadow-sm">
+        <div class="flex items-start justify-between gap-2">
+          <div>
+            <p class="text-[10px] font-black uppercase tracking-[0.18em] text-gray-400">Inventory</p>
+            <h1 class="mt-1 text-lg font-black text-gray-900">재고 이동 상세</h1>
+          </div>
+          <button
+            type="button"
+            class="h-9 border border-gray-300 px-4 text-xs font-black text-gray-700 hover:bg-gray-100"
+            @click="router.push({ name: 'hq-inventory-warehouse-transfer-history' })"
+          >
+            목록으로
+          </button>
+        </div>
+
+        <div class="mt-5 flex flex-col gap-5 lg:flex-row lg:items-start lg:gap-8">
+          <div class="flex flex-1 flex-col gap-4">
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="inline-flex min-w-12 items-center justify-center px-2.5 py-1 text-xs font-black" :class="statusClass(record.status)">{{ record.status }}</span>
+              <span class="font-mono text-xs font-bold text-gray-400">{{ record.transferNo }}</span>
+            </div>
+
+            <div class="grid gap-x-10 gap-y-4 sm:grid-cols-2">
+              <div>
+                <p class="text-[11px] font-bold text-gray-400">품목명</p>
+                <p class="mt-0.5 text-sm font-black text-gray-900">{{ record.itemName }}</p>
+              </div>
+              <div>
+                <p class="text-[11px] font-bold text-gray-400">SKU 코드</p>
+                <p class="mt-0.5 font-mono text-sm font-bold text-gray-700">{{ record.skuCode }}</p>
+              </div>
+              <div>
+                <p class="text-[11px] font-bold text-gray-400">이동일시</p>
+                <p class="mt-0.5 text-sm font-bold text-gray-700">{{ record.requestedAt }}</p>
+              </div>
+              <div>
+                <p class="text-[11px] font-bold text-gray-400">이동 사유</p>
+                <p class="mt-0.5 text-sm font-bold text-gray-700">{{ record.reason }}</p>
+              </div>
+              <div>
+                <p class="text-[11px] font-bold text-gray-400">담당자</p>
+                <p class="mt-0.5 text-sm font-bold text-gray-700">{{ record.requestedBy }}</p>
+              </div>
+              <div>
+                <p class="text-[11px] font-bold text-gray-400">메모</p>
+                <p class="mt-0.5 whitespace-pre-wrap text-sm font-bold text-gray-700">
+                  {{ record.memo || '입력된 메모가 없습니다.' }}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div class="flex flex-col items-center justify-center border border-gray-200 bg-gray-50 px-10 py-5 lg:min-w-[160px]">
+            <p class="text-[11px] font-bold text-gray-400">이동 수량</p>
+            <p class="mt-1 text-3xl font-black text-gray-900">{{ record.transferQty.toLocaleString() }}</p>
+            <p class="text-sm font-bold text-gray-500">개</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="border border-gray-200 bg-white p-4 shadow-sm">
+        <h2 class="mb-4 text-sm font-black text-gray-900">이동 경로</h2>
+        <div class="flex items-center gap-3">
+          <div class="flex-1 rounded border border-gray-200 bg-gray-50 p-3">
+            <p class="text-[10px] font-black uppercase tracking-[0.1em] text-gray-400">출발 창고</p>
+            <p class="mt-1 text-sm font-black text-gray-900">{{ record.fromWarehouseName }}</p>
+            <p class="mt-0.5 font-mono text-[11px] font-bold text-gray-400">{{ record.fromWarehouseCode }}</p>
+          </div>
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="shrink-0 text-gray-400" aria-hidden="true">
+            <path d="M5 12h14"/><polyline points="12 5 19 12 12 19"/>
+          </svg>
+          <div class="flex-1 rounded border border-[#D6EAEA] bg-[#EBF5F5] p-3">
+            <p class="text-[10px] font-black uppercase tracking-[0.1em] text-[#004D3C]/60">도착 창고</p>
+            <p class="mt-1 text-sm font-black text-gray-900">{{ record.toWarehouseName }}</p>
+            <p class="mt-0.5 font-mono text-[11px] font-bold text-[#004D3C]/60">{{ record.toWarehouseCode }}</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="border border-gray-200 bg-white shadow-sm">
+        <div class="border-b border-gray-100 px-4 py-3">
+          <h2 class="text-sm font-black text-gray-900">이동 전/후 재고 현황</h2>
+          <p v-if="record.status === '취소'" class="mt-0.5 text-[11px] font-bold text-red-500">취소된 이동으로 재고 변동이 없습니다.</p>
+          <p v-else-if="record.status === '진행중'" class="mt-0.5 text-[11px] font-bold text-amber-600">진행 중인 이동으로 이동 후 재고는 예상값입니다.</p>
+        </div>
+        <div class="overflow-x-auto">
+          <table class="w-full min-w-[560px] border-collapse text-left text-xs">
+            <thead class="bg-gray-50 text-[10px] uppercase tracking-[0.12em] text-gray-500">
+              <tr>
+                <th class="px-4 py-3 font-black">창고</th>
+                <th class="px-4 py-3 font-black">코드</th>
+                <th class="px-4 py-3 text-right font-black">이동 전 재고</th>
+                <th class="px-4 py-3 text-right font-black">
+                  <span v-if="record.status === '취소'" class="text-gray-400">이동 후 재고</span>
+                  <span v-else-if="record.status === '진행중'" class="text-amber-600">이동 후 재고 (예상)</span>
+                  <span v-else>이동 후 재고</span>
+                </th>
+                <th class="px-4 py-3 text-right font-black">변동</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100">
+              <tr class="bg-white">
+                <td class="px-4 py-3 font-black text-gray-900">{{ record.fromWarehouseName }}</td>
+                <td class="px-4 py-3 font-mono text-[11px] font-bold text-gray-400">{{ record.fromWarehouseCode }}</td>
+                <td class="px-4 py-3 text-right font-black text-gray-900">{{ record.fromStockBefore.toLocaleString() }}</td>
+                <td class="px-4 py-3 text-right font-black text-gray-900">{{ fromStockAfter.toLocaleString() }}</td>
+                <td class="px-4 py-3 text-right font-black" :class="record.status === '취소' ? 'text-gray-400' : 'text-red-600'">
+                  {{ record.status === '취소' ? '±0' : `-${record.transferQty.toLocaleString()}` }}
+                </td>
+              </tr>
+              <tr class="bg-white">
+                <td class="px-4 py-3 font-black text-gray-900">{{ record.toWarehouseName }}</td>
+                <td class="px-4 py-3 font-mono text-[11px] font-bold text-gray-400">{{ record.toWarehouseCode }}</td>
+                <td class="px-4 py-3 text-right font-black text-gray-900">{{ record.toStockBefore.toLocaleString() }}</td>
+                <td class="px-4 py-3 text-right font-black text-gray-900">{{ toStockAfter.toLocaleString() }}</td>
+                <td class="px-4 py-3 text-right font-black" :class="record.status === '취소' ? 'text-gray-400' : 'text-[#004D3C]'">
+                  {{ record.status === '취소' ? '±0' : `+${record.transferQty.toLocaleString()}` }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+
+    <section v-else class="border border-gray-200 bg-white p-10 text-center shadow-sm">
+      <p class="text-sm font-black text-gray-700">존재하지 않는 이동 내역입니다.</p>
+      <button
+        type="button"
+        class="mt-4 h-9 border border-gray-300 px-4 text-xs font-black text-gray-700 hover:bg-gray-100"
+        @click="router.push({ name: 'hq-inventory-warehouse-transfer-history' })"
+      >
+        목록으로
+      </button>
+    </section>
+  </AppLayout>
+</template>

--- a/src/views/hq/inventory/HqWarehouseTransferHistoryView.vue
+++ b/src/views/hq/inventory/HqWarehouseTransferHistoryView.vue
@@ -1,0 +1,232 @@
+<script setup>
+import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import AppLayout from '@/components/common/AppLayout.vue'
+import { roleMenus } from '@/config/roleMenus.js'
+import { useAuthStore } from '@/stores/auth.js'
+
+const router = useRouter()
+const auth = useAuthStore()
+const hqMenus = roleMenus.hq
+const inventoryMenus = roleMenus.hq.find(menu => menu.label === '재고 관리')?.children ?? []
+
+const activeTopMenu = computed(() => '재고 관리')
+const activeSideMenu = ref('창고간 재고 이동 내역')
+
+const dateFrom = ref('2026-04-01')
+const dateTo = ref('2026-04-30')
+const selectedStatus = ref('전체')
+const searchTerm = ref('')
+
+const transferHistoryRows = ref([
+  {
+    transferNo: 'TRF-20260430-0012',
+    skuCode: 'PRD-TOP-SH-003-NVY-L',
+    itemName: '오버핏 옥스포드 셔츠',
+    fromWarehouseCode: 'WH-BSN-01',
+    fromWarehouseName: '부산 물류창고',
+    toWarehouseCode: 'WH-DJN-01',
+    toWarehouseName: '대전 허브창고',
+    transferQty: 24,
+    reason: '재고 불균형 해소',
+    requestedBy: '김본사',
+    requestedAt: '2026-04-30 09:42',
+    status: '완료',
+    fromStockBefore: 58,
+    toStockBefore: 8,
+  },
+  {
+    transferNo: 'TRF-20260429-0007',
+    skuCode: 'PRD-OUT-PD-001-NVY-XL',
+    itemName: '라이트 숏 패딩',
+    fromWarehouseCode: 'WH-ICN-01',
+    fromWarehouseName: '인천 제1창고',
+    toWarehouseCode: 'WH-BSN-01',
+    toWarehouseName: '부산 물류창고',
+    transferQty: 18,
+    reason: '품절 예방',
+    requestedBy: '이재고',
+    requestedAt: '2026-04-29 14:20',
+    status: '완료',
+    fromStockBefore: 56,
+    toStockBefore: 5,
+  },
+  {
+    transferNo: 'TRF-20260428-0019',
+    skuCode: 'PRD-TOP-SS-001-BLK-S',
+    itemName: '코튼 베이직 반팔 티셔츠',
+    fromWarehouseCode: 'WH-ICN-01',
+    fromWarehouseName: '인천 제1창고',
+    toWarehouseCode: 'WH-ICH-01',
+    toWarehouseName: '이천 풀필먼트',
+    transferQty: 30,
+    reason: '프로모션 대응',
+    requestedBy: '박운영',
+    requestedAt: '2026-04-28 11:05',
+    status: '진행중',
+    fromStockBefore: 128,
+    toStockBefore: 22,
+  },
+  {
+    transferNo: 'TRF-20260427-0005',
+    skuCode: 'PRD-PNT-SH-002-GRY-M',
+    itemName: '라이트 코튼 쇼츠',
+    fromWarehouseCode: 'WH-DJN-01',
+    fromWarehouseName: '대전 허브창고',
+    toWarehouseCode: 'WH-ICN-01',
+    toWarehouseName: '인천 제1창고',
+    transferQty: 12,
+    reason: '재고 불균형 해소',
+    requestedBy: '최관리',
+    requestedAt: '2026-04-27 16:32',
+    status: '취소',
+    fromStockBefore: 0,
+    toStockBefore: 45,
+  },
+])
+
+const statusClass = (status) => ({
+  완료: 'bg-[#EBF5F5] text-black',
+  진행중: 'bg-amber-50 text-amber-700',
+  취소: 'bg-red-50 text-red-700',
+})[status] ?? 'bg-gray-100 text-gray-600'
+
+const filteredRows = computed(() => {
+  const keyword = searchTerm.value.trim().toLowerCase()
+
+  return transferHistoryRows.value
+    .filter((row) => {
+      if (selectedStatus.value !== '전체' && row.status !== selectedStatus.value) return false
+
+      if (!keyword) return true
+      return [
+        row.transferNo,
+        row.skuCode,
+        row.fromWarehouseName,
+        row.toWarehouseName,
+      ].join(' ').toLowerCase().includes(keyword)
+    })
+    .sort((a, b) => new Date(b.requestedAt.replace(' ', 'T')) - new Date(a.requestedAt.replace(' ', 'T')))
+})
+
+const resetFilters = () => {
+  dateFrom.value = '2026-04-01'
+  dateTo.value = '2026-04-30'
+  selectedStatus.value = '전체'
+  searchTerm.value = ''
+}
+
+function handleLogout() {
+  auth.logout()
+  router.push('/login')
+}
+</script>
+
+<template>
+  <AppLayout
+    :active-top-menu="activeTopMenu"
+    :top-menus="hqMenus"
+    :side-menus="inventoryMenus"
+    v-model:active-side-menu="activeSideMenu"
+    @logout="handleLogout"
+  >
+    <div class="flex flex-col gap-4">
+      <section class="border border-gray-200 bg-white p-4 shadow-sm">
+        <p class="text-[10px] font-black uppercase tracking-[0.18em] text-gray-400">Inventory</p>
+        <h1 class="mt-1 text-lg font-black text-gray-900">창고간 재고 이동 내역</h1>
+        <p class="mt-1 text-xs font-bold text-gray-500">창고 간 재고 이동 이력을 조회하고 상태를 확인합니다.</p>
+
+        <div class="mt-4 grid gap-2 md:grid-cols-2 xl:grid-cols-[0.9fr_0.9fr_0.8fr_1.4fr_auto]">
+          <label class="flex flex-col gap-1">
+            <span class="text-[11px] font-bold text-gray-500">시작일</span>
+            <input v-model="dateFrom" type="date" class="h-10 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none focus:border-[#004D3C]" />
+          </label>
+
+          <label class="flex flex-col gap-1">
+            <span class="text-[11px] font-bold text-gray-500">종료일</span>
+            <input v-model="dateTo" type="date" class="h-10 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none focus:border-[#004D3C]" />
+          </label>
+
+          <label class="flex flex-col gap-1">
+            <span class="text-[11px] font-bold text-gray-500">처리 상태</span>
+            <select v-model="selectedStatus" class="h-10 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none focus:border-[#004D3C]">
+              <option value="전체">전체</option>
+              <option value="완료">완료</option>
+              <option value="진행중">진행중</option>
+              <option value="취소">취소</option>
+            </select>
+          </label>
+
+          <label class="flex flex-col gap-1">
+            <span class="text-[11px] font-bold text-gray-500">검색</span>
+            <input
+              v-model="searchTerm"
+              type="search"
+              class="h-10 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none placeholder:text-gray-400 focus:border-[#004D3C]"
+              placeholder="이동번호, SKU 코드, 창고명"
+            />
+          </label>
+
+          <div class="flex items-end">
+            <button type="button" class="h-10 border border-gray-300 px-4 text-xs font-black text-gray-700 transition hover:bg-gray-100" @click="resetFilters">
+              초기화
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <section class="border border-gray-200 bg-white shadow-sm">
+        <div class="flex items-center justify-between border-b border-gray-100 px-4 py-3">
+          <h2 class="text-sm font-black text-gray-900">이동 이력 리스트</h2>
+          <p class="text-[11px] font-black text-gray-500">총 {{ filteredRows.length }}건 · 최신순</p>
+        </div>
+
+        <div class="overflow-x-auto">
+          <table class="min-w-[1400px] w-full border-collapse text-left text-xs">
+            <thead class="bg-gray-50 text-[10px] uppercase tracking-[0.12em] text-gray-500">
+              <tr>
+                <th class="px-3 py-3 font-black">이동일시</th>
+                <th class="px-3 py-3 font-black">이동번호</th>
+                <th class="px-3 py-3 font-black">SKU 코드</th>
+                <th class="px-3 py-3 font-black">품목명</th>
+                <th class="px-3 py-3 font-black">출발 창고</th>
+                <th class="px-3 py-3 font-black">도착 창고</th>
+                <th class="px-3 py-3 text-right font-black">이동수량</th>
+                <th class="px-3 py-3 font-black">사유</th>
+                <th class="px-3 py-3 text-center font-black">처리상태</th>
+                <th class="px-3 py-3 font-black">담당자</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100">
+              <tr
+                v-for="row in filteredRows"
+                :key="row.transferNo"
+                class="cursor-pointer hover:bg-[#EBF5F5]/60"
+                @click="router.push({ name: 'hq-inventory-warehouse-transfer-history-detail', params: { transferNo: row.transferNo } })"
+              >
+                <td class="px-3 py-3 font-bold text-gray-600">{{ row.requestedAt }}</td>
+                <td class="px-3 py-3 font-mono font-bold text-gray-700">{{ row.transferNo }}</td>
+                <td class="px-3 py-3 font-mono font-bold text-gray-700">{{ row.skuCode }}</td>
+                <td class="px-3 py-3 font-black text-gray-900">{{ row.itemName }}</td>
+                <td class="px-3 py-3 font-bold text-gray-600">{{ row.fromWarehouseName }}</td>
+                <td class="px-3 py-3 font-bold text-gray-600">{{ row.toWarehouseName }}</td>
+                <td class="px-3 py-3 text-right font-black text-gray-900">{{ row.transferQty.toLocaleString() }}</td>
+                <td class="px-3 py-3 font-bold text-gray-600">{{ row.reason }}</td>
+                <td class="px-3 py-3 text-center">
+                  <span class="inline-flex min-w-14 justify-center px-2 py-1 text-[11px] font-black" :class="statusClass(row.status)">{{ row.status }}</span>
+                </td>
+                <td class="px-3 py-3 font-bold text-gray-600">{{ row.requestedBy }}</td>
+              </tr>
+
+              <tr v-if="filteredRows.length === 0">
+                <td colspan="10" class="px-4 py-10 text-center text-xs font-bold text-gray-400">
+                  조회 조건에 맞는 이동 내역이 없습니다.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  </AppLayout>
+</template>


### PR DESCRIPTION
## 📌 요약
- 본사 `재고 관리` 영역에 `창고간 재고 이동` 기능을 SKU 중심으로 정비하고, `창고간 재고 이동 내역 조회/상세` 화면을 신규 추가했습니다.
- 이동 실행 UX(하단 액션바 + 슬라이드업 시트)와 내역 조회 동선을 분리해 운영자가 이동 실행과 이력 확인을 각각 빠르게 처리할 수 있도록 개선했습니다.

<br><br>

## 🎯 작업 내용
- `창고간 재고 이동` 메인 페이지를 불균형 SKU 리스트 중심으로 구성하고 검색/필터/상태/불균형 점수 기반 조회를 구현했습니다.
- SKU 상세 이동 화면에서 창고 2개 선택, 이동 수량/사유/메모 입력, 유효성 검증, 예상 재고 표시, 더미 이동 실행(토스트 포함)을 구현했습니다.
- `재고 관리` 사이드바에 `창고간 재고 이동 내역` 메뉴를 추가하고, 이동 내역 조회 페이지(필터/검색/최신순 테이블)와 상세 페이지(메모 포함)를 연결했습니다.

<br><br>

## ✔️ 참고 사항
- 현재 이동/이력 데이터는 더미 기반이며, API 연동 시 데이터 소스 교체만으로 확장 가능하도록 화면 구조를 맞췄습니다.
- 라우트는 기존 이동 경로와 충돌 없이 분리(`warehouse-comparison`, `warehouse-transfer-history`)되어 기존 동선 회귀 영향을 최소화했습니다.

<br><br>

## ✔️ 관련 이슈

- Close #178

<br><br>
