### PR TITLE
refactor: 인프라 API를 stores/warehouses에서 /infrastructures 단일 구조로 전환

### DIFF
--- a/src/api/infrastructure.js
+++ b/src/api/infrastructure.js
@@ -1,41 +1,21 @@
 import api, { unwrap } from '@/api/axios.js'
 
-export async function getStores(params = {}) {
-  const res = await api.get('/api/hq/stores', { params })
+export async function getInfrastructures(params = {}) {
+  const res = await api.get('/api/hq/infrastructures', { params })
   return unwrap(res)
 }
 
-export async function getStoreByCode(code) {
-  const res = await api.get(`/api/hq/stores/${code}`)
+export async function getInfrastructureByCode(code) {
+  const res = await api.get(`/api/hq/infrastructures/${code}`)
   return unwrap(res)
 }
 
-export async function createStore(payload) {
-  const res = await api.post('/api/hq/stores', payload)
+export async function createInfrastructure(payload) {
+  const res = await api.post('/api/hq/infrastructures', payload)
   return unwrap(res)
 }
 
-export async function updateStore(storeCode, payload) {
-  const res = await api.patch(`/api/hq/stores/${storeCode}`, payload)
-  return unwrap(res)
-}
-
-export async function getWarehouses(params = {}) {
-  const res = await api.get('/api/hq/warehouses', { params })
-  return unwrap(res)
-}
-
-export async function getWarehouseByCode(code) {
-  const res = await api.get(`/api/hq/warehouses/${code}`)
-  return unwrap(res)
-}
-
-export async function createWarehouse(payload) {
-  const res = await api.post('/api/hq/warehouses', payload)
-  return unwrap(res)
-}
-
-export async function updateWarehouse(warehouseCode, payload) {
-  const res = await api.patch(`/api/hq/warehouses/${warehouseCode}`, payload)
+export async function updateInfrastructure(code, payload) {
+  const res = await api.patch(`/api/hq/infrastructures/${code}`, payload)
   return unwrap(res)
 }

--- a/src/stores/purchaseOrder.js
+++ b/src/stores/purchaseOrder.js
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import { purchaseOrderApi } from '@/api/purchaseOrder.js'
-import { getWarehouses } from '@/api/infrastructure.js'
+import { getInfrastructures } from '@/api/infrastructure.js'
 
 // ─── BE ↔ FE 매핑 헬퍼 ─────────────────────────────────────────────────────
 // BE (PurchaseOrder DetailRes/ListRes) ↔ FE store 형식 변환.
@@ -235,7 +235,7 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
     }
   })
 
-  // 창고 목록 — BE 에서 fetch (Warehouse 테이블, Long ID)
+  // 창고 목록 — BE infrastructure(type=WAREHOUSE)에서 fetch
   const warehouseList = ref([])
   const warehouses = computed(() =>
     warehouseList.value.map((w) => ({ id: w.id, name: w.name, code: w.code })),
@@ -319,7 +319,7 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
 
   async function fetchWarehouses() {
     try {
-      const list = await getWarehouses()
+      const list = await getInfrastructures({ type: 'WAREHOUSE' })
       warehouseList.value = Array.isArray(list) ? list : []
     } catch (e) {
       console.error('[purchaseOrder] fetchWarehouses 실패', e)

--- a/src/views/hq/HqInfrastructureManagementView.vue
+++ b/src/views/hq/HqInfrastructureManagementView.vue
@@ -5,12 +5,8 @@ import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
 import {
-  createStore,
-  createWarehouse,
-  getStores,
-  getWarehouses,
-  updateStore,
-  updateWarehouse,
+  createInfrastructure,
+  getInfrastructures,
 } from '@/api/infrastructure.js'
 
 const router = useRouter()
@@ -147,17 +143,17 @@ const korToStatus = {
 async function loadStores() {
   const status = storeStatusFilter.value === '전체' ? undefined : korToStatus[storeStatusFilter.value]
   const region = storeRegionFilter.value === '전체 지역' ? undefined : storeRegionFilter.value
-  const list = await getStores({ keyword: storeSearchTerm.value || undefined, region, status })
+  const list = await getInfrastructures({ type: 'STORE', keyword: storeSearchTerm.value || undefined, region, status })
   storeData.value = list.map((s) => ({
     code: s.code,
     id: s.code,
     name: s.name,
     region: s.region,
-    type: s.type === 'DIRECT' ? '직영점' : '가맹점',
+    type: s.storeType === 'DIRECT' ? '직영점' : '가맹점',
     manager: s.managerName,
     contact: s.contact,
     address: s.address,
-    warehouse: s.warehouseCode,
+    warehouse: s.mappedWarehouseCode,
     status: statusToKor[s.status] ?? s.status,
     stockCapacity: 1000,
     remainingStock: 700,
@@ -168,7 +164,7 @@ async function loadStores() {
 async function loadWarehouses() {
   const status = warehouseStatusFilter.value === '전체' ? undefined : korToStatus[warehouseStatusFilter.value]
   const region = warehouseRegionFilter.value === '전체 지역' ? undefined : warehouseRegionFilter.value
-  const list = await getWarehouses({ keyword: warehouseSearchTerm.value || undefined, region, status })
+  const list = await getInfrastructures({ type: 'WAREHOUSE', keyword: warehouseSearchTerm.value || undefined, region, status })
   warehouseData.value = list.map((w) => ({
     code: w.code,
     id: w.code,
@@ -208,14 +204,15 @@ async function quickCreateStore() {
   const name = prompt('매장명을 입력하세요')
   if (!name) return
   try {
-    await createStore({
+    await createInfrastructure({
+      locationType: 'STORE',
       name,
       region: '서울',
-      type: 'DIRECT',
+      storeType: 'DIRECT',
       managerName: '담당자',
       contact: '010-0000-0000',
       address: '서울시 강남구',
-      warehouseCode: warehouseData.value[0]?.code || 'WH-0001',
+      mappedWarehouseCode: warehouseData.value[0]?.code || 'WH-0001',
       status: 'ACTIVE',
     })
     await loadStores()
@@ -228,7 +225,8 @@ async function quickCreateWarehouse() {
   const name = prompt('창고명을 입력하세요')
   if (!name) return
   try {
-    await createWarehouse({
+    await createInfrastructure({
+      locationType: 'WAREHOUSE',
       name,
       region: '서울',
       managerName: '담당자',

--- a/src/views/hq/HqProductCreateView.vue
+++ b/src/views/hq/HqProductCreateView.vue
@@ -42,6 +42,26 @@ const productSideMenus = [
 const categoryTree = ref([])
 const COLOR_OPTIONS = ['검정', '흰색', '그레이', '네이비']
 const SIZE_OPTIONS = ['XS', 'S', 'M', 'L', 'XL']
+const MATERIAL_TYPE_OPTIONS = [
+  { label: '천연 단일 섬유', value: 'NATURAL_SINGLE' },
+  { label: '합성 섬유', value: 'SYNTHETIC' },
+  { label: '혼방', value: 'BLEND' },
+]
+const NATURAL_MATERIAL_OPTIONS = [
+  { code: 'COTTON', label: '면' },
+  { code: 'WOOL', label: '울' },
+  { code: 'CASHMERE', label: '캐시미어' },
+  { code: 'SILK', label: '실크' },
+  { code: 'LINEN', label: '린넨' },
+]
+const SYNTHETIC_MATERIAL_OPTIONS = [
+  { code: 'POLYESTER', label: '폴리에스터' },
+  { code: 'ACRYLIC', label: '아크릴' },
+  { code: 'POLYAMIDE', label: '나일론' },
+  { code: 'ELASTANE', label: '스판덱스' },
+]
+const ALL_MATERIAL_OPTIONS = [...NATURAL_MATERIAL_OPTIONS, ...SYNTHETIC_MATERIAL_OPTIONS]
+const MATERIAL_LABEL_BY_CODE = Object.fromEntries(ALL_MATERIAL_OPTIONS.map((option) => [option.code, option.label]))
 
 const productName = ref('')
 const parentCategory = ref('')
@@ -52,6 +72,12 @@ const selectedVendorCode = ref('')
 const vendorOptions = ref([])
 const warehouseSafetyStock = ref(0)
 const storeSafetyStock = ref(0)
+const materialType = ref('NATURAL_SINGLE')
+const singleMaterialCode = ref('COTTON')
+const blendCompositions = ref([
+  { materialCode: 'COTTON', ratio: 50 },
+  { materialCode: 'POLYESTER', ratio: 50 },
+])
 const regDate = ref(new Date().toISOString().slice(0, 10).replaceAll('-', '.'))
 const selectedColors = ref([])
 const selectedSizes = ref([])
@@ -91,6 +117,54 @@ const variantSummaryText = computed(() => {
   if (!selectedColors.value.length || !selectedSizes.value.length) return '-'
   return `색상(${selectedColors.value.join(', ')}) / 사이즈(${selectedSizes.value.join(', ')})`
 })
+const materialOptionsByType = computed(() => {
+  if (materialType.value === 'NATURAL_SINGLE') return NATURAL_MATERIAL_OPTIONS
+  if (materialType.value === 'SYNTHETIC') return SYNTHETIC_MATERIAL_OPTIONS
+  return ALL_MATERIAL_OPTIONS
+})
+const blendRatioTotal = computed(() =>
+  blendCompositions.value.reduce((sum, composition) => sum + Number(composition.ratio || 0), 0),
+)
+const isMaterialValid = computed(() => {
+  if (materialType.value === 'BLEND') {
+    if (blendCompositions.value.length < 2) return false
+    const usedCodes = new Set()
+    for (const composition of blendCompositions.value) {
+      if (!composition.materialCode || usedCodes.has(composition.materialCode)) return false
+      usedCodes.add(composition.materialCode)
+      if (Number(composition.ratio || 0) <= 0) return false
+    }
+    return blendRatioTotal.value === 100
+  }
+  return Boolean(singleMaterialCode.value)
+})
+const materialSummaryText = computed(() => {
+  if (materialType.value === 'BLEND') {
+    if (!blendCompositions.value.length) return '혼방'
+    const pieces = blendCompositions.value.map((composition) =>
+      `${MATERIAL_LABEL_BY_CODE[composition.materialCode] || composition.materialCode} ${Number(composition.ratio || 0)}%`,
+    )
+    return `혼방 (${pieces.join(' + ')})`
+  }
+  const groupLabel = MATERIAL_TYPE_OPTIONS.find((type) => type.value === materialType.value)?.label || '-'
+  const detailLabel = MATERIAL_LABEL_BY_CODE[singleMaterialCode.value] || '-'
+  return `${groupLabel} (${detailLabel} 100%)`
+})
+
+watch(materialType, (nextType) => {
+  if (nextType === 'NATURAL_SINGLE') {
+    singleMaterialCode.value = NATURAL_MATERIAL_OPTIONS[0].code
+    return
+  }
+  if (nextType === 'SYNTHETIC') {
+    singleMaterialCode.value = SYNTHETIC_MATERIAL_OPTIONS[0].code
+    return
+  }
+  blendCompositions.value = [
+    { materialCode: NATURAL_MATERIAL_OPTIONS[0].code, ratio: 50 },
+    { materialCode: SYNTHETIC_MATERIAL_OPTIONS[0].code, ratio: 50 },
+  ]
+})
 
 const canSubmitCreate = computed(() =>
   productName.value.trim() &&
@@ -99,6 +173,7 @@ const canSubmitCreate = computed(() =>
   Number(price.value) >= 0 &&
   Number(warehouseSafetyStock.value) >= 0 &&
   Number(storeSafetyStock.value) >= 0 &&
+  isMaterialValid.value &&
   isSelectedVendorActive.value &&
   isVariantValid.value,
 )
@@ -110,6 +185,7 @@ const canSubmitEdit = computed(() =>
   Number(price.value) >= 0 &&
   Number(warehouseSafetyStock.value) >= 0 &&
   Number(storeSafetyStock.value) >= 0 &&
+  isMaterialValid.value &&
   isSelectedVendorActive.value,
 )
 
@@ -135,6 +211,25 @@ function resolveCategoryCode() {
 function splitColorSize(optionValue) {
   const [color, size] = String(optionValue || '').split('|')
   return { color: color || '', size: size || '' }
+}
+
+function createMaterialCompositionsPayload() {
+  if (materialType.value === 'BLEND') {
+    return blendCompositions.value.map((composition) => ({
+      materialCode: composition.materialCode,
+      ratio: Number(composition.ratio || 0),
+    }))
+  }
+  return [{ materialCode: singleMaterialCode.value, ratio: 100 }]
+}
+
+function addBlendComposition() {
+  blendCompositions.value = [...blendCompositions.value, { materialCode: '', ratio: 0 }]
+}
+
+function removeBlendComposition(index) {
+  if (blendCompositions.value.length <= 2) return
+  blendCompositions.value = blendCompositions.value.filter((_, currentIndex) => currentIndex !== index)
 }
 
 async function loadSkus() {
@@ -194,6 +289,23 @@ async function loadProduct() {
   selectedVendorCode.value = product.mainVendorCode || ''
   warehouseSafetyStock.value = Number(product.warehouseSafetyStock || 0)
   storeSafetyStock.value = Number(product.storeSafetyStock || 0)
+  materialType.value = product.materialType || 'NATURAL_SINGLE'
+  if (materialType.value === 'BLEND') {
+    blendCompositions.value = (product.materialCompositions || []).map((composition) => ({
+      materialCode: composition.materialCode,
+      ratio: Number(composition.ratio || 0),
+    }))
+    if (!blendCompositions.value.length) {
+      blendCompositions.value = [
+        { materialCode: NATURAL_MATERIAL_OPTIONS[0].code, ratio: 50 },
+        { materialCode: SYNTHETIC_MATERIAL_OPTIONS[0].code, ratio: 50 },
+      ]
+    }
+  } else {
+    singleMaterialCode.value = product.materialCompositions?.[0]?.materialCode || (
+      materialType.value === 'SYNTHETIC' ? SYNTHETIC_MATERIAL_OPTIONS[0].code : NATURAL_MATERIAL_OPTIONS[0].code
+    )
+  }
 
   const parent = categoryTree.value.find((c) => (c.children || []).some((child) => child.code === product.categoryCode))
   if (parent) {
@@ -233,6 +345,8 @@ async function handleSubmit() {
         warehouseSafetyStock: Number(warehouseSafetyStock.value),
         storeSafetyStock: Number(storeSafetyStock.value),
         mainVendorCode: selectedVendorCode.value.trim(),
+        materialType: materialType.value,
+        materialCompositions: createMaterialCompositionsPayload(),
         status: statusMap[status.value] ?? 'ACTIVE',
       })
 
@@ -257,6 +371,8 @@ async function handleSubmit() {
         warehouseSafetyStock: Number(warehouseSafetyStock.value),
         storeSafetyStock: Number(storeSafetyStock.value),
         mainVendorCode: selectedVendorCode.value.trim(),
+        materialType: materialType.value,
+        materialCompositions: createMaterialCompositionsPayload(),
         status: statusMap[status.value] ?? 'ACTIVE',
       })
       const skuResult = await syncSkusBySelections()
@@ -450,6 +566,64 @@ onMounted(async () => {
                 </label>
               </div>
 
+              <div class="space-y-4 rounded-md border border-gray-300 bg-white p-4">
+                <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <label class="block text-[11px] font-black uppercase tracking-wide text-gray-500">
+                    소재 구분 <span class="text-red-500">*</span>
+                    <select v-model="materialType" class="mt-1.5 w-full border border-gray-300 bg-white px-3 py-2.5 text-sm text-gray-800 outline-none focus:border-[#004D3C]">
+                      <option v-for="type in MATERIAL_TYPE_OPTIONS" :key="type.value" :value="type.value">{{ type.label }}</option>
+                    </select>
+                  </label>
+                  <template v-if="materialType !== 'BLEND'">
+                    <label class="block text-[11px] font-black uppercase tracking-wide text-gray-500">
+                      소재 상세 <span class="text-red-500">*</span>
+                      <select v-model="singleMaterialCode" class="mt-1.5 w-full border border-gray-300 bg-white px-3 py-2.5 text-sm text-gray-800 outline-none focus:border-[#004D3C]">
+                        <option v-for="option in materialOptionsByType" :key="option.code" :value="option.code">{{ option.label }}</option>
+                      </select>
+                      <p class="mt-1 text-[10px] font-bold text-gray-400">단일 소재는 100%로 자동 반영됩니다.</p>
+                    </label>
+                  </template>
+                </div>
+
+                <div v-if="materialType === 'BLEND'" class="space-y-3">
+                  <div
+                    v-for="(composition, index) in blendCompositions"
+                    :key="`blend-${index}`"
+                    class="grid grid-cols-[minmax(0,1fr)_120px_88px] gap-2"
+                  >
+                    <select v-model="composition.materialCode" class="w-full border border-gray-300 bg-white px-3 py-2.5 text-sm text-gray-800 outline-none focus:border-[#004D3C]">
+                      <option value="">소재 선택</option>
+                      <option v-for="option in ALL_MATERIAL_OPTIONS" :key="option.code" :value="option.code">{{ option.label }}</option>
+                    </select>
+                    <input
+                      v-model.number="composition.ratio"
+                      type="number"
+                      min="0"
+                      max="100"
+                      class="w-full border border-gray-300 bg-white px-3 py-2.5 text-sm outline-none focus:border-[#004D3C]"
+                      placeholder="%"
+                    />
+                    <button
+                      type="button"
+                      class="border border-gray-300 bg-white px-3 py-2 text-xs font-black text-gray-600 hover:bg-gray-50 disabled:opacity-40"
+                      :disabled="blendCompositions.length <= 2"
+                      @click="removeBlendComposition(index)"
+                    >
+                      삭제
+                    </button>
+                  </div>
+                  <div class="flex items-center justify-between">
+                    <p class="text-[11px] font-bold" :class="blendRatioTotal === 100 ? 'text-emerald-600' : 'text-red-500'">
+                      혼방 비율 합계: {{ blendRatioTotal }}%
+                    </p>
+                    <button type="button" class="border border-gray-300 bg-white px-3 py-1.5 text-xs font-black text-gray-700 hover:bg-gray-50" @click="addBlendComposition">
+                      소재 추가
+                    </button>
+                  </div>
+                  <p class="text-[10px] font-bold text-gray-400">혼방은 소재 2개 이상, 비율 합계 100%를 만족해야 합니다.</p>
+                </div>
+              </div>
+
               <div class="!mt-4 rounded-md border border-gray-300 bg-white p-5">
                 <p class="text-[11px] font-black uppercase tracking-wide text-gray-500">
                   옵션 구성 <span v-if="!isEditMode" class="text-red-500">*</span>
@@ -551,6 +725,10 @@ onMounted(async () => {
               <div class="flex items-center justify-between border border-gray-100 bg-gray-50 px-3 py-2">
                 <span class="font-black text-gray-500">매장 공통 안전재고</span>
                 <span class="font-black text-gray-800">{{ Number(storeSafetyStock).toLocaleString() }}</span>
+              </div>
+              <div class="flex items-center justify-between gap-3 border border-gray-100 bg-gray-50 px-3 py-2">
+                <span class="font-black text-gray-500">소재</span>
+                <span class="text-right font-black text-gray-800">{{ materialSummaryText }}</span>
               </div>
               <div class="flex items-center justify-between border border-gray-100 bg-gray-50 px-3 py-2">
                 <span class="font-black text-gray-500">상태</span>

--- a/src/views/hq/HqStoreDetailView.vue
+++ b/src/views/hq/HqStoreDetailView.vue
@@ -4,7 +4,7 @@ import { useRoute, useRouter } from 'vue-router'
 import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
-import { getStoreByCode, updateStore } from '@/api/infrastructure.js'
+import { getInfrastructureByCode, updateInfrastructure } from '@/api/infrastructure.js'
 
 const route = useRoute()
 const router = useRouter()
@@ -83,7 +83,7 @@ async function loadStoreDetail() {
   isLoading.value = true
   loadError.value = ''
   try {
-    const found = await getStoreByCode(storeCode.value)
+    const found = await getInfrastructureByCode(storeCode.value)
     store.value = found || null
     resetEditForm()
   } catch (error) {
@@ -109,14 +109,15 @@ async function saveEdit() {
 
   isSaving.value = true
   try {
-    await updateStore(store.value.code, {
+    await updateInfrastructure(store.value.code, {
+      locationType: 'STORE',
       name: store.value.name,
       region: store.value.region,
-      type: store.value.type,
+      storeType: store.value.storeType,
       managerName,
       contact,
       address: store.value.address,
-      warehouseCode: store.value.warehouseCode,
+      mappedWarehouseCode: store.value.mappedWarehouseCode,
       status: editForm.value.status,
     })
 
@@ -225,7 +226,7 @@ onMounted(() => {
           <p class="flex items-center justify-between"><span class="font-bold text-gray-500">매장 코드</span><strong class="font-black text-gray-900">{{ store.code }}</strong></p>
           <p class="flex items-center justify-between"><span class="font-bold text-gray-500">매장명</span><strong class="font-black text-gray-900">{{ store.name }}</strong></p>
           <p class="flex items-center justify-between"><span class="font-bold text-gray-500">지역</span><strong class="font-black text-gray-900">{{ store.region }}</strong></p>
-          <p class="flex items-center justify-between"><span class="font-bold text-gray-500">유형</span><strong class="font-black text-gray-900">{{ typeToKor[store.type] || store.type }}</strong></p>
+          <p class="flex items-center justify-between"><span class="font-bold text-gray-500">유형</span><strong class="font-black text-gray-900">{{ typeToKor[store.storeType] || store.storeType }}</strong></p>
 
           <template v-if="!isEditMode">
             <p class="flex items-center justify-between"><span class="font-bold text-gray-500">담당자</span><strong class="font-black text-gray-900">{{ store.managerName }}</strong></p>
@@ -261,7 +262,7 @@ onMounted(() => {
             </label>
           </template>
 
-          <p class="flex items-center justify-between"><span class="font-bold text-gray-500">담당 창고</span><strong class="font-black text-gray-900">{{ store.warehouseCode }}</strong></p>
+          <p class="flex items-center justify-between"><span class="font-bold text-gray-500">담당 창고</span><strong class="font-black text-gray-900">{{ store.mappedWarehouseCode }}</strong></p>
           <p class="flex items-start justify-between gap-3"><span class="font-bold text-gray-500">주소</span><strong class="text-right font-black text-gray-900">{{ store.address }}</strong></p>
         </div>
       </section>

--- a/src/views/hq/HqWarehouseDetailView.vue
+++ b/src/views/hq/HqWarehouseDetailView.vue
@@ -4,7 +4,7 @@ import { useRoute, useRouter } from 'vue-router'
 import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
-import { getWarehouseByCode } from '@/api/infrastructure.js'
+import { getInfrastructureByCode } from '@/api/infrastructure.js'
 
 const route = useRoute()
 const router = useRouter()
@@ -52,7 +52,10 @@ async function loadWarehouseDetail() {
   isLoading.value = true
   loadError.value = ''
   try {
-    const found = await getWarehouseByCode(warehouseCode.value)
+    const found = await getInfrastructureByCode(warehouseCode.value)
+    if (found?.locationType !== 'WAREHOUSE') {
+      throw new Error('창고 정보가 아닙니다.')
+    }
     warehouse.value = found || null
   } catch (error) {
     loadError.value = error.message || '창고 정보를 불러오지 못했습니다.'


### PR DESCRIPTION
## 📌 요약
- 인프라 프론트 API를 기존 `stores/warehouses` 분리 호출에서 백엔드 통합 계약인 `/api/hq/infrastructures` 기반으로 전면 전환했습니다.

<br><br>

## 🎯 작업 내용
- `src/api/infrastructure.js`를 통합 API 함수(`getInfrastructures`, `getInfrastructureByCode`, `createInfrastructure`, `updateInfrastructure`)로 재구성
- `HqInfrastructureManagementView`, `HqStoreDetailView`, `HqWarehouseDetailView`의 조회/생성/수정 호출을 통합 API 스키마(`locationType`, `storeType`, `mappedWarehouseCode`, `capacity`)로 변경
- `src/stores/purchaseOrder.js`의 창고 목록 로딩을 `getInfrastructures({ type: 'WAREHOUSE' })`로 변경하고 빌드 검증(`npm run build`) 완료

<br><br>

## ✔️ 참고 사항
- 기존 라우트(`/hq/infrastructure/stores/:storeId`, `/hq/infrastructure/warehouses/:warehouseId`)와 화면 구조는 유지했습니다.
- 창고 상세 화면에서 `locationType !== 'WAREHOUSE'`인 경우 예외 처리하도록 방어 로직을 추가했습니다.

<br><br>

## ✔️ 관련 이슈

- Close #344

<br><br>
