### PR TITLE
feat: HQ 전사 재고 조회 화면 API 연동 및 SKU 옵션 표시를 color/size로 전환

### DIFF
--- a/src/api/inventory.js
+++ b/src/api/inventory.js
@@ -1,0 +1,11 @@
+import api, { unwrap } from '@/api/axios.js'
+
+export async function getCompanyWideInventories(params = {}) {
+  const res = await api.get('/api/hq/inventories/company-wide', { params })
+  return unwrap(res)
+}
+
+export async function getCompanyWideInventorySkus(itemCode, params = {}) {
+  const res = await api.get(`/api/hq/inventories/company-wide/${itemCode}/skus`, { params })
+  return unwrap(res)
+}

--- a/src/api/purchaseOrder.js
+++ b/src/api/purchaseOrder.js
@@ -76,7 +76,7 @@ export const purchaseOrderApi = {
    * warehouseCode 는 본 사이클 BE 가 사용하지 않음 (인벤토리 합류 후 stock 필터링용).
    * 응답: { masters: [{ vendorCode, vendorName, vendorProductCode, productCode, productName,
    *                     contractUnitPrice, minSkuUnitPrice, maxSkuUnitPrice,
-   *                     skus: [{ skuCode, optionName, optionValue, unitPrice }] }],
+   *                     skus: [{ skuCode, color, size, displayOption, unitPrice }] }],
    *         optionFacets: [{ name, values: [string] }] }
    */
   getCatalog: ({ vendorCode = '', warehouseCode = '' } = {}) => {

--- a/src/stores/purchaseOrder.js
+++ b/src/stores/purchaseOrder.js
@@ -54,8 +54,9 @@ function toFeItem(beItem) {
     productCode: beItem.productCode,
     productName: beItem.productName,
     skuCode: beItem.skuCode ?? '',
-    optionName: beItem.optionName ?? '',
-    optionValue: beItem.optionValue ?? '',
+    color: beItem.color ?? '',
+    size: beItem.size ?? '',
+    displayOption: beItem.displayOption ?? [beItem.color, beItem.size].filter(Boolean).join('/') ,
     quantity: beItem.quantity,
     unitPrice: beItem.unitPrice,
     subtotal: beItem.subtotal,
@@ -88,8 +89,9 @@ function toFeCatalogMaster(beMaster) {
     maxSkuUnitPrice: beMaster.maxSkuUnitPrice,
     skus: Array.isArray(beMaster.skus) ? beMaster.skus.map((s) => ({
       skuCode: s.skuCode,
-      optionName: s.optionName ?? '',
-      optionValue: s.optionValue ?? '',
+      color: s.color ?? '',
+      size: s.size ?? '',
+      displayOption: s.displayOption ?? [s.color, s.size].filter(Boolean).join('/') ,
       unitPrice: s.unitPrice,
     })) : [],
   }
@@ -253,7 +255,7 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
   // row 형식:
   //   { type: 'header', masterKey, vendorCode, vendorName, vendorProductCode, productCode,
   //     productName, contractUnitPrice, minSkuUnitPrice, maxSkuUnitPrice, skuCount }
-  //   { type: 'sku',    masterKey, skuCode, optionName, optionValue, unitPrice,
+  //   { type: 'sku',    masterKey, skuCode, color, size, displayOption, unitPrice,
   //     vendorCode, vendorName, vendorProductCode, productCode, productName }
   // 정렬 — vendorName 가나다 → productName 가나다 → SKU 는 BE id asc 순서 그대로
   const catalogSkuRows = computed(() => {
@@ -282,8 +284,9 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
           type: 'sku',
           masterKey: m.masterKey,
           skuCode: s.skuCode,
-          optionName: s.optionName,
-          optionValue: s.optionValue,
+          color: s.color,
+          size: s.size,
+          displayOption: s.displayOption,
           unitPrice: s.unitPrice,
           vendorCode: m.vendorCode,
           vendorName: m.vendorName,

--- a/src/views/hq/HqProductCreateView.vue
+++ b/src/views/hq/HqProductCreateView.vue
@@ -208,11 +208,6 @@ function resolveCategoryCode() {
   return child?.code || parent.code
 }
 
-function splitColorSize(optionValue) {
-  const [color, size] = String(optionValue || '').split('|')
-  return { color: color || '', size: size || '' }
-}
-
 function createMaterialCompositionsPayload() {
   if (materialType.value === 'BLEND') {
     return blendCompositions.value.map((composition) => ({
@@ -235,8 +230,8 @@ function removeBlendComposition(index) {
 async function loadSkus() {
   if (!isEditMode.value) return
   currentSkus.value = await getProductSkus(productCode.value)
-  selectedColors.value = [...new Set(currentSkus.value.map((s) => splitColorSize(s.optionValue).color).filter(Boolean))]
-  selectedSizes.value = [...new Set(currentSkus.value.map((s) => splitColorSize(s.optionValue).size).filter(Boolean))]
+  selectedColors.value = [...new Set(currentSkus.value.map((s) => s.color).filter(Boolean))]
+  selectedSizes.value = [...new Set(currentSkus.value.map((s) => s.size).filter(Boolean))]
 }
 
 async function toggleColor(color) {
@@ -252,31 +247,33 @@ async function toggleSize(size) {
 }
 
 async function syncSkusBySelections() {
-  const desiredOptionValues = new Set()
+  const desired = new Set()
   for (const color of selectedColors.value) {
     for (const size of selectedSizes.value) {
-      desiredOptionValues.add(`${color}|${size}`)
+      desired.add(`${color}|${size}`)
     }
   }
 
-  const currentOptionMap = new Map(currentSkus.value.map((sku) => [sku.optionValue, sku]))
-  const removeTargets = currentSkus.value.filter((sku) => !desiredOptionValues.has(sku.optionValue))
-  const addTargets = [...desiredOptionValues].filter((optionValue) => !currentOptionMap.has(optionValue))
+  const current = new Set(currentSkus.value.map((sku) => `${sku.color}|${sku.size}`))
+  const removeTargets = currentSkus.value.filter((sku) => !desired.has(`${sku.color}|${sku.size}`))
 
   if (removeTargets.length > 0) {
     await Promise.all(removeTargets.map((sku) => deleteProductSku(sku.skuCode)))
   }
 
-  if (addTargets.length > 0) {
+  const missing = [...desired].filter((key) => !current.has(key))
+  if (missing.length > 0) {
+    const colors = [...new Set(missing.map((m) => m.split('|')[0]))]
+    const sizes = [...new Set(missing.map((m) => m.split('|')[1]))]
     await createProductSkusBulk(productCode.value, {
-      optionName: 'COLOR_SIZE',
-      optionValues: addTargets,
+      colors,
+      sizes,
       unitPrice: Number(price.value),
       status: statusMap[status.value] ?? 'ACTIVE',
     })
   }
 
-  return { added: addTargets.length, removed: removeTargets.length }
+  return { added: missing.length, removed: removeTargets.length }
 }
 
 async function loadProduct() {
@@ -353,8 +350,8 @@ async function handleSubmit() {
       for (const color of selectedColors.value) {
         for (const size of selectedSizes.value) {
           await createProductSku(product.code, {
-            optionName: 'COLOR_SIZE',
-            optionValue: `${color}|${size}`,
+            color,
+            size,
             unitPrice: Number(price.value),
             status: statusMap[status.value] ?? 'ACTIVE',
           })

--- a/src/views/hq/HqProductSkuDetailView.vue
+++ b/src/views/hq/HqProductSkuDetailView.vue
@@ -30,17 +30,11 @@ const statusLabel = {
   INACTIVE: '비활성',
 }
 
-function splitColorSize(value) {
-  const [color, size] = String(value ?? '').split('|')
-  return { color: color || '-', size: size || '-' }
-}
-
 function openEdit(sku) {
-  const parsed = splitColorSize(sku.optionValue)
   editSkuCode.value = sku.skuCode
   editForm.value = {
-    color: parsed.color,
-    size: parsed.size,
+    color: sku.color || '-',
+    size: sku.size || '-',
     unitPrice: sku.unitPrice,
     status: sku.status,
   }
@@ -59,8 +53,8 @@ async function saveEdit(skuCode) {
     errorMessage.value = ''
     successMessage.value = ''
     await updateProductSku(skuCode, {
-      optionName: 'COLOR_SIZE',
-      optionValue: `${editForm.value.color}|${editForm.value.size}`,
+      color: editForm.value.color,
+      size: editForm.value.size,
       unitPrice: Number(editForm.value.unitPrice),
       status: editForm.value.status,
     })
@@ -172,7 +166,7 @@ onMounted(() => {
                     v-model="editForm.color"
                     class="w-full max-w-[96px] border border-gray-300 px-2 py-1.5 text-xs"
                   />
-                  <span v-else>{{ splitColorSize(sku.optionValue).color }}</span>
+                  <span v-else>{{ sku.color }}</span>
                 </td>
                 <td class="px-4 py-3 align-middle font-black text-gray-900">
                   <input
@@ -180,7 +174,7 @@ onMounted(() => {
                     v-model="editForm.size"
                     class="w-full max-w-[88px] border border-gray-300 px-2 py-1.5 text-xs"
                   />
-                  <span v-else>{{ splitColorSize(sku.optionValue).size }}</span>
+                  <span v-else>{{ sku.size }}</span>
                 </td>
                 <td class="px-4 py-3 align-middle text-right font-black text-gray-900">
                   <input

--- a/src/views/hq/HqPurchaseOrderCreateView.vue
+++ b/src/views/hq/HqPurchaseOrderCreateView.vue
@@ -188,17 +188,12 @@ function clearFacets() {
   for (const k of Object.keys(activeFacetFilters)) delete activeFacetFilters[k]
 }
 
-// SKU 의 옵션값을 axis 별 분해 (슬래시 합성)
 function skuMatchesFacets(row) {
   const filters = Object.entries(activeFacetFilters)
   if (filters.length === 0) return true
-  const axes = (row.optionName || '').split('/').map((s) => s.trim())
-  const values = (row.optionValue || '').split('/').map((s) => s.trim())
   for (const [axisName, valueSet] of filters) {
-    const idx = axes.indexOf(axisName)
-    // axis 가 이 SKU 에 없는 경우 — 매칭 실패 (다른 마스터의 axis)
-    if (idx === -1) return false
-    if (!valueSet.has(values[idx])) return false
+    const current = axisName === '색상' ? row.color : axisName === '사이즈' ? row.size : ''
+    if (!valueSet.has(current)) return false
   }
   return true
 }
@@ -326,7 +321,7 @@ const filteredRows = computed(() => {
   let skus = all.filter((r) => r.type === 'sku')
   if (kw) {
     skus = skus.filter((r) =>
-      [r.vendorName, r.productName, r.productCode, r.skuCode, r.optionName, r.optionValue]
+      [r.vendorName, r.productName, r.productCode, r.skuCode, r.color, r.size, r.displayOption]
         .some((s) => (s ?? '').toLowerCase().includes(kw)),
     )
   }
@@ -348,7 +343,7 @@ const filteredRows = computed(() => {
       break
     case 'nameAsc':
       skus = [...skus].sort((a, b) =>
-        a.productName.localeCompare(b.productName, 'ko') || a.optionValue.localeCompare(b.optionValue, 'ko'),
+        a.productName.localeCompare(b.productName, 'ko') || (a.displayOption || '').localeCompare((b.displayOption || ''), 'ko'),
       )
       break
     default:
@@ -585,8 +580,9 @@ function pushSku(row, qty) {
       vendorId: row.vendorCode,
       vendorName: row.vendorName,
       skuCode: row.skuCode,
-      optionName: row.optionName,
-      optionValue: row.optionValue,
+      color: row.color,
+      size: row.size,
+      displayOption: row.displayOption,
       unitPrice: row.unitPrice,
       quantity: qty,
     })
@@ -737,8 +733,9 @@ async function confirmSubmitOrder() {
     productCode: i.productCode,
     productName: i.productName,
     skuCode: i.skuCode,
-    optionName: i.optionName,
-    optionValue: i.optionValue,
+    color: i.color,
+    size: i.size,
+    displayOption: i.displayOption,
     unitPrice: i.unitPrice,
     quantity: i.quantity,
     subtotal: i.unitPrice * i.quantity,
@@ -803,8 +800,9 @@ function initEditMode() {
     productCode: i.productCode,
     productName: i.productName,
     skuCode: i.skuCode ?? '',
-    optionName: i.optionName ?? '',
-    optionValue: i.optionValue ?? '',
+    color: i.color ?? '',
+    size: i.size ?? '',
+    displayOption: i.displayOption ?? [i.color, i.size].filter(Boolean).join('/'),
     vendorId: order.vendorId,
     vendorName: order.vendorName,
     unitPrice: i.unitPrice,
@@ -1147,8 +1145,7 @@ const AlertTriangleIcon = IconBase([
                       />
                     </td>
                     <td class="px-2 py-2 align-middle">
-                      <div class="text-xs font-bold text-gray-800">{{ row.optionValue }}</div>
-                      <div v-if="row.optionName" class="text-[10px] text-gray-400">{{ row.optionName }}</div>
+                      <div class="text-xs font-bold text-gray-800">{{ row.displayOption }}</div>
                     </td>
                     <td class="px-2 py-2 text-[11px] text-gray-500 align-middle">{{ row.skuCode }}</td>
                     <td class="px-2 py-2 text-right font-bold text-[#004D3C] align-middle">
@@ -1282,8 +1279,8 @@ const AlertTriangleIcon = IconBase([
                 <div class="flex items-start justify-between gap-2">
                   <div class="min-w-0 flex-1">
                     <p class="text-xs font-black text-gray-800">{{ item.productName }}</p>
-                    <p v-if="item.optionValue" class="text-[10px] font-bold text-[#004D3C]">
-                      {{ item.optionValue }}
+                    <p v-if="item.displayOption" class="text-[10px] font-bold text-[#004D3C]">
+                      {{ item.displayOption }}
                     </p>
                     <p class="text-[10px] text-gray-400">
                       {{ item.skuCode || item.productCode }} · ₩{{ item.unitPrice.toLocaleString() }}

--- a/src/views/hq/HqPurchaseOrderView.vue
+++ b/src/views/hq/HqPurchaseOrderView.vue
@@ -561,11 +561,8 @@ const TruckIcon = IconBase([
                   <tr v-for="item in poStore.selectedOrder.items" :key="item.skuCode || item.productId">
                     <td class="px-2 py-2 align-top">
                       <div class="font-bold text-gray-800">{{ item.productName }}</div>
-                      <div v-if="item.optionValue" class="mt-0.5 text-[11px] font-bold text-[#004D3C]">
-                        {{ item.optionValue }}
-                        <span v-if="item.optionName" class="ml-1 font-normal text-gray-400">
-                          ({{ item.optionName }})
-                        </span>
+                      <div v-if="item.displayOption" class="mt-0.5 text-[11px] font-bold text-[#004D3C]">
+                        {{ item.displayOption }}
                       </div>
                       <div v-if="item.skuCode" class="text-[10px] text-gray-400">
                         {{ item.skuCode }}

--- a/src/views/hq/inventory/HqCompanyWideInventorySkuDetailView.vue
+++ b/src/views/hq/inventory/HqCompanyWideInventorySkuDetailView.vue
@@ -1,9 +1,10 @@
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
+import { getCompanyWideInventorySkus } from '@/api/inventory.js'
 
 const route = useRoute()
 const router = useRouter()
@@ -14,10 +15,9 @@ const inventoryMenus = roleMenus.hq.find(menu => menu.label === '재고 관리')
 
 const activeTopMenu = computed(() => '재고 관리')
 const activeSideMenu = ref('전사 재고 조회')
-
-const colorOptions = ['검정', '흰색', '그레이', '아이보리']
-const colorCodeMap = { 검정: 'BLK', 흰색: 'WHT', 그레이: 'GRY', 아이보리: 'IVR' }
-const sizeOptions = ['XS', 'S', 'M', 'L', 'XL']
+const loadError = ref('')
+const isLoading = ref(false)
+const skuRows = ref([])
 
 const itemCode = computed(() => String(route.params.itemCode ?? route.query.itemCode ?? ''))
 const itemName = computed(() => String(route.query.itemName ?? '선택 품목'))
@@ -43,34 +43,6 @@ const filterScopeLabel = computed(() =>
   filterLocations.value.length > 0 ? `${filterLocationType.value} 기준` : `전체${filterLocationType.value}`,
 )
 
-const seed = computed(() =>
-  `${itemCode.value}-${locationName.value}`.split('').reduce((sum, char) => sum + char.charCodeAt(0), 0),
-)
-
-const skuRows = computed(() =>
-  colorOptions.flatMap((color, colorIndex) =>
-    sizeOptions.map((size, sizeIndex) => {
-      const actualStock = 14 + ((seed.value + colorIndex * 19 + sizeIndex * 7) % 85)
-      const reservedStock = (seed.value + colorIndex * 11 + sizeIndex * 5) % 14
-      const availableStock = Math.max(actualStock - reservedStock, 0)
-      const safetyStock = 20 + (sizeIndex % 3) * 6
-      const status = availableStock === 0 ? '품절' : availableStock < safetyStock ? '부족' : '정상'
-      const updatedAt = `2026.04.${String(25 - (colorIndex % 3)).padStart(2, '0')} ${String(10 + sizeIndex).padStart(2, '0')}:40`
-
-      return {
-        skuCode: `${itemCode.value}-${colorCodeMap[color]}-${size}`,
-        color,
-        size,
-        actualStock,
-        availableStock,
-        safetyStock,
-        status,
-        updatedAt,
-      }
-    }),
-  ),
-)
-
 const statusClass = (status) => ({
   정상: 'bg-[#EBF5F5] text-black',
   부족: 'bg-amber-50 text-amber-700',
@@ -86,6 +58,29 @@ const backQuery = computed(() => ({
   search: typeof route.query.search === 'string' ? route.query.search : undefined,
 }))
 
+async function loadSkuDetails() {
+  isLoading.value = true
+  loadError.value = ''
+  try {
+    const type = filterLocationType.value === '창고' ? 'WAREHOUSE' : 'STORE'
+    const payload = {
+      locationType: type,
+      parentCategory: typeof route.query.parent === 'string' ? route.query.parent : undefined,
+      childCategory: typeof route.query.child === 'string' ? route.query.child : undefined,
+      keyword: typeof route.query.search === 'string' ? route.query.search : undefined,
+    }
+    const rows = await getCompanyWideInventorySkus(itemCode.value, payload)
+    skuRows.value = Array.isArray(rows)
+      ? rows.map(r => ({ ...r, updatedAt: r.updatedAt ? new Date(r.updatedAt).toLocaleString('ko-KR', { hour12: false }) : '-' }))
+      : []
+  } catch (e) {
+    loadError.value = e.message || 'SKU 재고 상세 조회에 실패했습니다.'
+    skuRows.value = []
+  } finally {
+    isLoading.value = false
+  }
+}
+
 function goBackToInventory() {
   router.push({
     name: 'hq-inventory-company-wide',
@@ -97,6 +92,10 @@ function handleLogout() {
   auth.logout()
   router.push('/login')
 }
+
+onMounted(() => {
+  loadSkuDetails()
+})
 </script>
 
 <template>

--- a/src/views/hq/inventory/HqCompanyWideInventoryView.vue
+++ b/src/views/hq/inventory/HqCompanyWideInventoryView.vue
@@ -1,9 +1,10 @@
 <script setup>
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
+import { getCompanyWideInventories } from '@/api/inventory.js'
 
 const router = useRouter()
 const route = useRoute()
@@ -22,6 +23,8 @@ const selectedStatus = ref('')
 const searchTerm = ref('')
 const isLocationDropdownOpen = ref(false)
 const locationDropdownRef = ref(null)
+const isLoading = ref(false)
+const loadError = ref('')
 
 const categoryMap = {
   상의: ['반팔', '긴팔', '셔츠', '니트', '후드티'],
@@ -30,36 +33,20 @@ const categoryMap = {
   아우터: ['패딩', '후드집업', '자켓', '가디건'],
 }
 
-const locationOptions = {
-  매장: ['강남 플래그십', '홍대 스토어', '성수 쇼룸', '부산 센텀점', '대구 동성로점'],
-  창고: ['인천 제1창고', '이천 풀필먼트', '부산 물류창고', '대전 허브창고'],
-}
-
 const locationTypeOptions = ['매장', '창고']
-
-const inventoryData = [
-  { itemCode: 'SPA-TOP-001', parentCategory: '상의', childCategory: '반팔', itemName: '코튼 베이직 반팔 티셔츠', locationType: '매장', locationName: '강남 플래그십', actualStock: 184, availableStock: 172, safetyStock: 60, status: '정상', updatedAt: '2026.04.22 09:20' },
-  { itemCode: 'SPA-TOP-002', parentCategory: '상의', childCategory: '긴팔', itemName: '슬림핏 긴팔 티셔츠', locationType: '매장', locationName: '홍대 스토어', actualStock: 38, availableStock: 32, safetyStock: 45, status: '부족', updatedAt: '2026.04.22 09:10' },
-  { itemCode: 'SPA-TOP-003', parentCategory: '상의', childCategory: '셔츠', itemName: '오버핏 옥스포드 셔츠', locationType: '창고', locationName: '인천 제1창고', actualStock: 420, availableStock: 402, safetyStock: 120, status: '정상', updatedAt: '2026.04.22 08:50' },
-  { itemCode: 'SPA-TOP-004', parentCategory: '상의', childCategory: '니트', itemName: '라운드넥 소프트 니트', locationType: '창고', locationName: '이천 풀필먼트', actualStock: 0, availableStock: 0, safetyStock: 80, status: '품절', updatedAt: '2026.04.22 08:30' },
-  { itemCode: 'SPA-TOP-005', parentCategory: '상의', childCategory: '후드티', itemName: '헤비웨이트 로고 후드티', locationType: '매장', locationName: '성수 쇼룸', actualStock: 76, availableStock: 68, safetyStock: 50, status: '정상', updatedAt: '2026.04.22 08:15' },
-  { itemCode: 'SPA-PNT-001', parentCategory: '바지', childCategory: '청바지', itemName: '스트레이트 워싱 데님', locationType: '매장', locationName: '부산 센텀점', actualStock: 28, availableStock: 21, safetyStock: 35, status: '부족', updatedAt: '2026.04.21 18:40' },
-  { itemCode: 'SPA-PNT-002', parentCategory: '바지', childCategory: '반바지', itemName: '라이트 코튼 쇼츠', locationType: '창고', locationName: '부산 물류창고', actualStock: 310, availableStock: 296, safetyStock: 90, status: '정상', updatedAt: '2026.04.21 18:10' },
-  { itemCode: 'SPA-PNT-003', parentCategory: '바지', childCategory: '긴바지', itemName: '와이드 밴딩 팬츠', locationType: '매장', locationName: '대구 동성로점', actualStock: 0, availableStock: 0, safetyStock: 30, status: '품절', updatedAt: '2026.04.21 17:35' },
-  { itemCode: 'SPA-PNT-004', parentCategory: '바지', childCategory: '츄리닝', itemName: '데일리 조거 트레이닝 팬츠', locationType: '창고', locationName: '대전 허브창고', actualStock: 144, availableStock: 130, safetyStock: 70, status: '정상', updatedAt: '2026.04.21 16:55' },
-  { itemCode: 'SPA-SKT-001', parentCategory: '치마', childCategory: '미니스커트', itemName: 'A라인 데님 미니스커트', locationType: '매장', locationName: '강남 플래그십', actualStock: 52, availableStock: 47, safetyStock: 40, status: '정상', updatedAt: '2026.04.21 15:45' },
-  { itemCode: 'SPA-SKT-002', parentCategory: '치마', childCategory: '롱스커트', itemName: '플리츠 롱스커트', locationType: '창고', locationName: '인천 제1창고', actualStock: 24, availableStock: 18, safetyStock: 55, status: '부족', updatedAt: '2026.04.21 15:20' },
-  { itemCode: 'SPA-OUT-001', parentCategory: '아우터', childCategory: '패딩', itemName: '라이트 숏 패딩', locationType: '창고', locationName: '이천 풀필먼트', actualStock: 98, availableStock: 92, safetyStock: 45, status: '정상', updatedAt: '2026.04.21 14:30' },
-  { itemCode: 'SPA-OUT-002', parentCategory: '아우터', childCategory: '후드집업', itemName: '스웨트 후드 집업', locationType: '매장', locationName: '홍대 스토어', actualStock: 17, availableStock: 12, safetyStock: 30, status: '부족', updatedAt: '2026.04.21 13:50' },
-  { itemCode: 'SPA-OUT-003', parentCategory: '아우터', childCategory: '자켓', itemName: '싱글 브레스트 자켓', locationType: '매장', locationName: '성수 쇼룸', actualStock: 64, availableStock: 58, safetyStock: 25, status: '정상', updatedAt: '2026.04.21 13:15' },
-  { itemCode: 'SPA-OUT-004', parentCategory: '아우터', childCategory: '가디건', itemName: '브이넥 니트 가디건', locationType: '창고', locationName: '대전 허브창고', actualStock: 0, availableStock: 0, safetyStock: 35, status: '품절', updatedAt: '2026.04.21 12:40' },
-]
+const locationOptionsRaw = ref([])
+const inventoryData = ref([])
 
 const childCategoryOptions = computed(() =>
   selectedParentCategory.value ? categoryMap[selectedParentCategory.value] : [],
 )
 
-const currentLocationOptions = computed(() => locationOptions[locationType.value])
+const currentLocationOptions = computed(() => {
+  const current = locationType.value === '창고' ? 'WAREHOUSE' : 'STORE'
+  return locationOptionsRaw.value
+    .filter(l => l.locationType === current)
+    .map(l => l.name)
+})
 
 const parseQueryList = (value) => {
   if (typeof value !== 'string') return []
@@ -76,9 +63,7 @@ const initializeFiltersFromQuery = () => {
   searchTerm.value = typeof route.query.search === 'string' ? route.query.search : ''
 
   const queryLocations = parseQueryList(route.query.locations)
-  selectedLocations.value = queryLocations.filter(location =>
-    locationOptions[locationType.value].includes(location),
-  )
+  selectedLocations.value = queryLocations
 }
 
 initializeFiltersFromQuery()
@@ -96,54 +81,10 @@ const hiddenLocationCount = computed(() =>
   selectedLocations.value.length >= 3 ? selectedLocations.value.length - 1 : 0,
 )
 
-const locationScopedInventory = computed(() => {
-  const keyword = searchTerm.value.trim().toLowerCase()
-
-  return inventoryData.filter((item) => {
-    const matchesType = item.locationType === locationType.value
-    const matchesLocation = selectedLocations.value.length === 0 || selectedLocations.value.includes(item.locationName)
-    const matchesParentCategory = !selectedParentCategory.value || item.parentCategory === selectedParentCategory.value
-    const matchesChildCategory = !selectedChildCategory.value || item.childCategory === selectedChildCategory.value
-    const matchesKeyword = !keyword || [item.itemCode, item.itemName, item.locationName].join(' ').toLowerCase().includes(keyword)
-
-    return matchesType && matchesLocation && matchesParentCategory && matchesChildCategory && matchesKeyword
-  })
+const filteredInventory = computed(() => {
+  if (!selectedStatus.value) return inventoryData.value
+  return inventoryData.value.filter(item => item.status === selectedStatus.value)
 })
-
-const aggregatedInventory = computed(() => {
-  const grouped = new Map()
-
-  locationScopedInventory.value.forEach((item) => {
-    const existing = grouped.get(item.itemCode)
-    if (!existing) {
-      grouped.set(item.itemCode, {
-        itemCode: item.itemCode,
-        parentCategory: item.parentCategory,
-        childCategory: item.childCategory,
-        itemName: item.itemName,
-        actualStock: item.actualStock,
-        availableStock: item.availableStock,
-        safetyStock: item.safetyStock,
-        updatedAt: item.updatedAt,
-      })
-      return
-    }
-
-    existing.actualStock += item.actualStock
-    existing.availableStock += item.availableStock
-    existing.safetyStock += item.safetyStock
-    if (item.updatedAt > existing.updatedAt) existing.updatedAt = item.updatedAt
-  })
-
-  return [...grouped.values()].map((item) => ({
-    ...item,
-    status: item.availableStock === 0 ? '품절' : item.availableStock < item.safetyStock ? '부족' : '정상',
-  }))
-})
-
-const filteredInventory = computed(() =>
-  aggregatedInventory.value.filter((item) => !selectedStatus.value || item.status === selectedStatus.value),
-)
 
 const locationSummary = computed(() => {
   if (selectedLocations.value.length === 0) return `전체 ${locationType.value}`
@@ -181,6 +122,58 @@ const removeLocation = (location) => {
   selectedLocations.value = selectedLocations.value.filter(selectedLocation => selectedLocation !== location)
 }
 
+const mapLocationNamesToIds = () => {
+  const typeCode = locationType.value === '창고' ? 'WAREHOUSE' : 'STORE'
+  const nameSet = new Set(selectedLocations.value)
+  return locationOptionsRaw.value
+    .filter(l => l.locationType === typeCode && (nameSet.size === 0 || nameSet.has(l.name)))
+    .map(l => l.id)
+}
+
+async function fetchCompanyWideInventory() {
+  isLoading.value = true
+  loadError.value = ''
+  try {
+    const typeCode = locationType.value === '창고' ? 'WAREHOUSE' : 'STORE'
+    const locationIds = mapLocationNamesToIds()
+    const payload = {
+      locationType: typeCode,
+      parentCategory: selectedParentCategory.value || undefined,
+      childCategory: selectedChildCategory.value || undefined,
+      keyword: searchTerm.value || undefined,
+    }
+    if (selectedLocations.value.length > 0) payload.locationIds = locationIds
+
+    const res = await getCompanyWideInventories(payload)
+    const items = Array.isArray(res?.items) ? res.items : []
+    const options = Array.isArray(res?.locationOptions) ? res.locationOptions : []
+
+    locationOptionsRaw.value = options.map(o => ({
+      id: o.id,
+      code: o.code,
+      name: o.name,
+      locationType: o.code?.startsWith('WH-') ? 'WAREHOUSE' : 'STORE',
+    }))
+
+    inventoryData.value = items.map(item => ({
+      itemCode: item.itemCode,
+      parentCategory: item.parentCategory,
+      childCategory: item.childCategory,
+      itemName: item.itemName,
+      actualStock: item.actualStock,
+      availableStock: item.availableStock,
+      safetyStock: item.safetyStock,
+      status: item.status,
+      updatedAt: item.updatedAt ? new Date(item.updatedAt).toLocaleString('ko-KR', { hour12: false }) : '-',
+    }))
+  } catch (e) {
+    loadError.value = e.message || '전사 재고 조회에 실패했습니다.'
+    inventoryData.value = []
+  } finally {
+    isLoading.value = false
+  }
+}
+
 const moveToSkuDetail = (item) => {
   router.push({
     name: 'hq-inventory-sku-detail',
@@ -208,8 +201,13 @@ const handleDocumentClick = (event) => {
   }
 }
 
+watch([locationType, selectedParentCategory, selectedChildCategory, selectedStatus, searchTerm, selectedLocations], () => {
+  fetchCompanyWideInventory()
+})
+
 onMounted(() => {
   document.addEventListener('click', handleDocumentClick)
+  fetchCompanyWideInventory()
 })
 
 onBeforeUnmount(() => {


### PR DESCRIPTION
## 📌 요약
- HQ 전사 재고 조회/상세 화면을 API 연동으로 전환하고, 프론트 SKU 옵션 처리 기준을 `color/size`로 통일했습니다.

<br><br>

## 🎯 작업 내용
- 전사 재고 조회/상세 화면에서 더미 데이터 제거 후 실데이터 API 연동
- SKU 관련 화면(제품 등록/수정, 발주 생성/상세, 스토어)에서 `optionName/optionValue` 참조 제거 및 `color/size/displayOption` 기준으로 전환
- 인프라 통합 구조에 맞춰 연관 호출 정리(`/stores`, `/warehouses` 분리 의존 제거)

<br><br>

## ✔️ 참고 사항
- `npm run build` 통과
- 기존 라우트/화면 구조는 유지하고 내부 데이터 계약만 신규 API에 맞게 변경

<br><br>

## ✔️ 관련 이슈

- Close #346

<br><br>
