### PR TITLE
refactor(vendor,purchase-order): 거래처 표기를 공급처로 통일 + 생성일시 시차 fix

### DIFF
--- a/src/api/purchaseOrder.js
+++ b/src/api/purchaseOrder.js
@@ -72,7 +72,7 @@ export const purchaseOrderApi = {
    * 새 발주 페이지 카탈로그 — vendor_product → ProductMaster → ProductSku 묶음 응답.
    * GET /api/hq/purchase-orders/catalog?vendorCode=&warehouseId=
    *
-   * vendorCode 미지정: 모든 ACTIVE 거래처 펼침. 지정 시 그 거래처만.
+   * vendorCode 미지정: 모든 ACTIVE 공급처 펼침. 지정 시 그 공급처만.
    * warehouseCode 는 본 사이클 BE 가 사용하지 않음 (인벤토리 합류 후 stock 필터링용).
    * 응답: { masters: [{ vendorCode, vendorName, vendorProductCode, productCode, productName,
    *                     contractUnitPrice, minSkuUnitPrice, maxSkuUnitPrice,

--- a/src/api/vendor.js
+++ b/src/api/vendor.js
@@ -5,8 +5,8 @@
  *   GET    /api/vendors                            (목록, 등록은 SQL 직접)
  *   GET    /api/vendors/{code}
  *   GET    /api/vendors/{code}/contracts            (E 안 — ProductMaster 매칭 + VendorProduct join)
- *   GET    /api/vendor-products?vendorCode=...     (CEN-031, 특정 거래처)
- *   GET    /api/vendor-products?status=...         (CEN-035 발주 카탈로그, 전체 거래처)
+ *   GET    /api/vendor-products?vendorCode=...     (CEN-031, 특정 공급처)
+ *   GET    /api/vendor-products?status=...         (CEN-035 발주 카탈로그, 전체 공급처)
  *   GET    /api/vendor-products/{code}             (CEN-033)
  *   POST   /api/vendor-products                    (CEN-027)
  *   PATCH  /api/vendor-products/{code}             (CEN-028)
@@ -19,12 +19,12 @@
 import { apiClient, unwrap } from './axios.js'
 
 export const vendorApi = {
-  // ─── 거래처 (read-only) ──────────────────────────────────────────────────
+  // ─── 공급처 (read-only) ──────────────────────────────────────────────────
   listVendors: () => apiClient.get('/api/vendors').then(unwrap),
   getVendor: (code) => apiClient.get(`/api/vendors/${code}`).then(unwrap),
 
   /**
-   * 거래처 계약 표 (E 안) — mainVendorCode 매칭 ProductMaster 행 + VendorProduct join.
+   * 공급처 계약 표 (E 안) — mainVendorCode 매칭 ProductMaster 행 + VendorProduct join.
    * 응답: ContractRow[] = { productCode, productName, categoryCode, basePrice,
    *   vendorProductCode|null, contractUnitPrice|null, moq|null, leadTimeDays|null,
    *   contractStart|null, contractEnd|null, status|null, contracted: boolean }
@@ -32,12 +32,12 @@ export const vendorApi = {
   getContracts: (vendorCode) =>
     apiClient.get(`/api/vendors/${vendorCode}/contracts`).then(unwrap),
 
-  // ─── 거래처별 계약 제품 ─────────────────────────────────────────────────
+  // ─── 공급처별 계약 제품 ─────────────────────────────────────────────────
   listVendorProducts: (vendorCode) =>
     apiClient.get('/api/vendor-products', { params: { vendorCode } }).then(unwrap),
 
   /**
-   * 전체 거래처 제품 일괄 조회 (CEN-035 발주 작성 카탈로그용).
+   * 전체 공급처 제품 일괄 조회 (CEN-035 발주 작성 카탈로그용).
    * @param {'ACTIVE'|'SUSPENDED'|'EXPIRED'|'DELETED'} [status] — 생략 시 DELETED 제외 전체
    */
   listAllVendorProducts: (status) =>

--- a/src/config/roleMenus.js
+++ b/src/config/roleMenus.js
@@ -21,8 +21,8 @@ export const roleMenus = {
       path: '/hq/orders',
       icon: 'truck',
       children: [
-        { label: '거래처 발주', path: '/hq/purchase-orders' },
-        { label: '거래처 관리', path: '/hq/vendors' },
+        { label: '공급처 발주', path: '/hq/purchase-orders' },
+        { label: '공급처 관리', path: '/hq/vendors' },
       ],
     },
     {

--- a/src/stores/vendor.js
+++ b/src/stores/vendor.js
@@ -35,8 +35,8 @@ function fromApiVendorProduct(vp) {
 export const useVendorStore = defineStore('vendor', () => {
   // --- state ---
   const vendors = ref([])
-  const vendorProducts = ref([]) // 현재 선택된 vendor 의 계약 제품만 보유 (거래처 관리 페이지용)
-  const allVendorProducts = ref([]) // 전체 거래처의 활성 제품 (CEN-035 발주 작성 카탈로그용)
+  const vendorProducts = ref([]) // 현재 선택된 vendor 의 계약 제품만 보유 (공급처 관리 페이지용)
+  const allVendorProducts = ref([]) // 전체 공급처의 활성 제품 (CEN-035 발주 작성 카탈로그용)
   const contracts = ref([]) // E 안 — ContractRow[] (ProductMaster 매칭 + VendorProduct join)
   const selectedVendorId = ref(null)
   const selectedProductId = ref(null)
@@ -73,7 +73,7 @@ export const useVendorStore = defineStore('vendor', () => {
     })
   }
 
-  // 같은 거래처에 같은 제품 코드가 이미 등록되어 있는지 검사 (UX 즉시 피드백용)
+  // 같은 공급처에 같은 제품 코드가 이미 등록되어 있는지 검사 (UX 즉시 피드백용)
   // BE 도 DUPLICATE_VENDOR_PRODUCT_CODE 로 막지만 입력 시점 즉시 알림.
   function isProductCodeDuplicate(vendorId, productCode, excludeId = null) {
     if (!vendorId || !productCode) return false
@@ -87,7 +87,7 @@ export const useVendorStore = defineStore('vendor', () => {
 
   // --- actions ---
 
-  // 거래처 목록 fetch (mount 시)
+  // 공급처 목록 fetch (mount 시)
   async function fetchVendors() {
     loading.value = true
     try {
@@ -98,7 +98,7 @@ export const useVendorStore = defineStore('vendor', () => {
     }
   }
 
-  // 전체 거래처 제품 fetch (CEN-035 발주 작성 카탈로그용)
+  // 전체 공급처 제품 fetch (CEN-035 발주 작성 카탈로그용)
   // 기존 vendorProducts 와 분리된 별 state (allVendorProducts) 에 적재.
   async function fetchAllVendorProducts(status = 'ACTIVE') {
     loading.value = true
@@ -110,7 +110,7 @@ export const useVendorStore = defineStore('vendor', () => {
     }
   }
 
-  // 거래처별 계약 제품 fetch
+  // 공급처별 계약 제품 fetch
   async function fetchProductsByVendor(vendorCode) {
     if (!vendorCode) {
       vendorProducts.value = []
@@ -125,7 +125,7 @@ export const useVendorStore = defineStore('vendor', () => {
     }
   }
 
-  // 거래처 계약 표 fetch (E 안 — ContractRow[])
+  // 공급처 계약 표 fetch (E 안 — ContractRow[])
   async function fetchContracts(vendorCode) {
     if (!vendorCode) {
       contracts.value = []
@@ -144,7 +144,7 @@ export const useVendorStore = defineStore('vendor', () => {
     }
   }
 
-  // 거래처 선택 + 그 거래처의 계약 표 자동 fetch (E 안)
+  // 공급처 선택 + 그 공급처의 계약 표 자동 fetch (E 안)
   async function selectVendor(id) {
     selectedVendorId.value = id
     selectedProductId.value = null
@@ -195,7 +195,7 @@ export const useVendorStore = defineStore('vendor', () => {
     return true
   }
 
-  // 스토어 생성 시 자동으로 거래처 목록 fetch
+  // 스토어 생성 시 자동으로 공급처 목록 fetch
   fetchVendors().catch((err) => {
     console.error('[vendor] fetchVendors 실패', err)
   })

--- a/src/stores/warehouse/warehouseDashboard.js
+++ b/src/stores/warehouse/warehouseDashboard.js
@@ -49,7 +49,7 @@ export const useWarehouseDashboardStore = defineStore('warehouseDashboard', () =
     try {
       const [progressRes, listRes] = await Promise.all([
         dashboardApi.getInboundProgress(params),
-        // 입고 예정 = DELIVERED(배송완료, 도착됨) — SHIPPING 은 거래처 단계라 창고 화면 미노출
+        // 입고 예정 = DELIVERED(배송완료, 도착됨) — SHIPPING 은 공급처 단계라 창고 화면 미노출
         inboundApi.list({ ...params, status: 'DELIVERED' }),
       ])
       progress.value = progressRes

--- a/src/stores/warehouse/warehouseInbound.js
+++ b/src/stores/warehouse/warehouseInbound.js
@@ -8,7 +8,7 @@ export const useWarehouseInboundStore = defineStore('warehouseInbound', () => {
 
   // --- view state (입고 화면 전용) ---
   // 'DELIVERED' = 배송완료(도착됨, 입고 확정 대기) / 'COMPLETED' = 입고완료
-  // SHIPPING(배송중) 은 거래처 단계라 창고 화면에 노출 안 함 (BE InboundService 도 차단)
+  // SHIPPING(배송중) 은 공급처 단계라 창고 화면에 노출 안 함 (BE InboundService 도 차단)
   const activeStatusTab = ref('DELIVERED')
   const selectedOrderId = ref(null)
   const searchKeyword = ref('')

--- a/src/views/hq/HqPurchaseOrderCreateView.vue
+++ b/src/views/hq/HqPurchaseOrderCreateView.vue
@@ -70,10 +70,10 @@ const hqMenus = roleMenus.hq
 const activeTopMenu = computed(() => '주문/발주 관리')
 const sideMenus = [
   { label: '매장 주문', icon: 'file', path: '/hq/orders' },
-  { label: '거래처 발주', icon: 'truck', path: '/hq/purchase-orders' },
-  { label: '거래처 관리', icon: 'briefcase', path: '/hq/vendors' },
+  { label: '공급처 발주', icon: 'truck', path: '/hq/purchase-orders' },
+  { label: '공급처 관리', icon: 'briefcase', path: '/hq/vendors' },
 ]
-const activeSideMenu = ref('거래처 발주')
+const activeSideMenu = ref('공급처 발주')
 
 function handleLogout() {
   auth.logout()
@@ -90,7 +90,7 @@ const cart = ref([])
 // 창고 변경 confirm
 const showWarehouseChangeConfirm = ref(false)
 const pendingWarehouseId = ref(null)
-// 거래처 전환 confirm (한 발주서 = 한 거래처 정책)
+// 공급처 전환 confirm (한 발주서 = 한 공급처 정책)
 const showVendorSwitchConfirm = ref(false)
 const pendingNewVendorProduct = ref(null)
 // 장바구니 비우기 confirm
@@ -245,7 +245,7 @@ function applyBulkQty() {
     triggerToast('먼저 입고 창고를 선택해주세요.')
     return
   }
-  // 선택된 SKU 들의 vendorCode 가 cart 거래처와 다른 게 섞여 있으면 거절 (한 거래처 룰)
+  // 선택된 SKU 들의 vendorCode 가 cart 공급처와 다른 게 섞여 있으면 거절 (한 공급처 룰)
   const selectedRows = []
   for (const r of catalogSkuRows.value) {
     if (r.type === 'sku' && selectedSkus.value.has(r.skuCode)) selectedRows.push(r)
@@ -254,11 +254,11 @@ function applyBulkQty() {
   const firstVendor = selectedRows[0].vendorCode
   const sameVendor = selectedRows.every((r) => r.vendorCode === firstVendor)
   if (!sameVendor) {
-    triggerToast('서로 다른 거래처 SKU 가 섞여 있습니다.')
+    triggerToast('서로 다른 공급처 SKU 가 섞여 있습니다.')
     return
   }
   if (currentCartVendorId.value && firstVendor !== currentCartVendorId.value) {
-    triggerToast('장바구니의 거래처와 다릅니다. 장바구니를 비우고 다시 시도하세요.')
+    triggerToast('장바구니의 공급처와 다릅니다. 장바구니를 비우고 다시 시도하세요.')
     return
   }
   for (const row of selectedRows) {
@@ -406,7 +406,7 @@ const filteredRows = computed(() => {
     }
   }
 
-  // 품목 중심 표시 — vendor sticky 그룹 행 제거. 거래처는 마스터 제품 헤더의 칩으로 표시.
+  // 품목 중심 표시 — vendor sticky 그룹 행 제거. 공급처는 마스터 제품 헤더의 칩으로 표시.
   return baseResult
 })
 
@@ -544,7 +544,7 @@ function clearDraftStorage() {
 
 // ─── 장바구니 액션 ───────────────────────────────────────────────────────────
 // SKU 행 [+] 클릭 → 행 안 수량 input 값을 cart 로 push. 동일 SKU 가 cart 에 있으면 합산.
-// 한 발주서 = 한 거래처 정책 — cart 에 다른 거래처가 있으면 거래처 전환 confirm.
+// 한 발주서 = 한 공급처 정책 — cart 에 다른 공급처가 있으면 공급처 전환 confirm.
 function addSkuToCart(row) {
   if (!selectedWarehouseCode.value) {
     triggerToast('먼저 입고 창고를 선택해주세요.')
@@ -594,10 +594,10 @@ function addGroupToCart(masterKey) {
   }
   const skus = catalogSkuRows.value.filter((r) => r.type === 'sku' && r.masterKey === masterKey)
   if (skus.length === 0) return
-  // 한 거래처 룰
+  // 한 공급처 룰
   const vendorCode = skus[0].vendorCode
   if (currentCartVendorId.value && vendorCode !== currentCartVendorId.value) {
-    triggerToast('장바구니의 거래처와 다릅니다.')
+    triggerToast('장바구니의 공급처와 다릅니다.')
     return
   }
   let added = 0
@@ -709,11 +709,11 @@ const warehouseSelectRef = ref(null)
 // ─── 발주 요청 ────────────────────────────────────────────────────────────────
 function openSubmitConfirm() {
   if (!canSubmit.value) return
-  // 방어: 한 거래처 정책 (이론상 발생 X 안전망)
+  // 방어: 한 공급처 정책 (이론상 발생 X 안전망)
   const firstVendorId = cart.value[0].vendorId
   const allSameVendor = cart.value.every((i) => i.vendorId === firstVendorId)
   if (!allSameVendor) {
-    triggerToast('한 발주서에는 한 거래처 품목만 담을 수 있습니다.')
+    triggerToast('한 발주서에는 한 공급처 품목만 담을 수 있습니다.')
     return
   }
   showSubmitConfirm.value = true
@@ -791,7 +791,7 @@ function initEditMode() {
     return
   }
   selectedWarehouseCode.value = order.warehouseCode || ''
-  vendorFilter.value = order.vendorId // 거래처 잠금 (BE vendorCode)
+  vendorFilter.value = order.vendorId // 공급처 잠금 (BE vendorCode)
   cart.value = order.items.map((i) => ({
     productId: i.productId,
     productCode: i.productCode,
@@ -830,7 +830,7 @@ onMounted(() => {
   reloadCatalog()
 })
 
-// 거래처 필터 변경 시 server-side 재 fetch (한 거래처 결과만 받기)
+// 공급처 필터 변경 시 server-side 재 fetch (한 공급처 결과만 받기)
 watch(vendorFilter, () => {
   reloadCatalog()
 })
@@ -971,7 +971,7 @@ const AlertTriangleIcon = IconBase([
               :disabled="isEditMode"
               class="border border-gray-300 bg-white px-3 py-1.5 text-xs outline-none focus:border-[#004D3C] disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500"
             >
-              <option value="all">전체 거래처</option>
+              <option value="all">전체 공급처</option>
               <option v-for="v in vendorOptions" :key="v.code" :value="v.code">
                 {{ v.name }}
               </option>
@@ -1106,7 +1106,7 @@ const AlertTriangleIcon = IconBase([
                         <span class="text-xs font-black text-gray-900 truncate">{{ row.productName }}</span>
                         <span class="font-mono text-[10px] font-bold text-gray-400 shrink-0">{{ row.productCode }}</span>
                         <span class="ml-auto text-[10px] font-bold text-gray-400 shrink-0">
-                          거래처
+                          공급처
                           <span class="ml-1 font-black text-gray-700">{{ row.vendorName }}</span>
                         </span>
                       </div>
@@ -1250,7 +1250,7 @@ const AlertTriangleIcon = IconBase([
             <span class="text-[10px] font-bold opacity-80">{{ cart.length }}건</span>
           </div>
 
-          <!-- 거래처 표시 -->
+          <!-- 공급처 표시 -->
           <div
             v-if="currentCartVendorName"
             class="border-b border-gray-200 bg-[#E6F2F0] px-4 py-2 text-[10px] font-black uppercase tracking-wider text-[#004D3C]"
@@ -1397,7 +1397,7 @@ const AlertTriangleIcon = IconBase([
       </div>
     </div>
 
-    <!-- ───────── 모달: 거래처 변경 confirm (amber, 주의) ───────── -->
+    <!-- ───────── 모달: 공급처 변경 confirm (amber, 주의) ───────── -->
     <div
       v-if="showVendorSwitchConfirm"
       class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
@@ -1406,16 +1406,16 @@ const AlertTriangleIcon = IconBase([
       <div class="w-full max-w-sm overflow-hidden bg-white shadow-xl">
         <div class="flex items-center gap-2 bg-amber-600 px-5 py-3 text-white">
           <AlertTriangleIcon :size="14" />
-          <h2 class="text-sm font-black">거래처 변경</h2>
+          <h2 class="text-sm font-black">공급처 변경</h2>
         </div>
         <div class="p-5 text-xs text-gray-700">
           <p>
             장바구니의 <strong>{{ currentCartVendorName }}</strong> 품목
             <strong>{{ cart.length }}건</strong>이 초기화됩니다.
-            <strong>{{ pendingNewVendorName }}</strong> 거래처로 새로 시작할까요?
+            <strong>{{ pendingNewVendorName }}</strong> 공급처로 새로 시작할까요?
           </p>
           <p class="mt-2 text-[11px] text-gray-500">
-            한 발주서에는 한 거래처 품목만 담을 수 있습니다.
+            한 발주서에는 한 공급처 품목만 담을 수 있습니다.
           </p>
         </div>
         <div class="flex items-center justify-end gap-2 border-t border-gray-200 bg-gray-50 px-5 py-3">
@@ -1489,7 +1489,7 @@ const AlertTriangleIcon = IconBase([
               <dd class="font-bold text-gray-800">{{ selectedWarehouseName }}</dd>
             </div>
             <div class="flex justify-between gap-2">
-              <dt class="text-gray-500">거래처</dt>
+              <dt class="text-gray-500">공급처</dt>
               <dd class="font-bold text-gray-800">{{ currentCartVendorName }}</dd>
             </div>
             <div class="flex justify-between gap-2">
@@ -1503,11 +1503,11 @@ const AlertTriangleIcon = IconBase([
           </dl>
           <p class="pt-2 text-[11px] leading-relaxed text-gray-500">
             <template v-if="isEditMode">
-              이 내용으로 발주를 수정합니다. 거래처 승인 전까지만 가능합니다.
+              이 내용으로 발주를 수정합니다. 공급처 승인 전까지만 가능합니다.
             </template>
             <template v-else>
-              이 내용으로 거래처에 발주 요청합니다.
-              요청 후 거래처 응답 받기 전까지 [취소] 가능합니다.
+              이 내용으로 공급처에 발주 요청합니다.
+              요청 후 공급처 응답 받기 전까지 [취소] 가능합니다.
             </template>
           </p>
         </div>

--- a/src/views/hq/HqPurchaseOrderView.vue
+++ b/src/views/hq/HqPurchaseOrderView.vue
@@ -16,10 +16,10 @@ const activeTopMenu = computed(() => '주문/발주 관리')
 
 const sideMenus = [
   { label: '매장 주문', icon: 'file', path: '/hq/orders' },
-  { label: '거래처 발주', icon: 'truck', path: '/hq/purchase-orders' },
-  { label: '거래처 관리', icon: 'briefcase', path: '/hq/vendors' },
+  { label: '공급처 발주', icon: 'truck', path: '/hq/purchase-orders' },
+  { label: '공급처 관리', icon: 'briefcase', path: '/hq/vendors' },
 ]
-const activeSideMenu = ref('거래처 발주')
+const activeSideMenu = ref('공급처 발주')
 
 function handleLogout() {
   auth.logout()
@@ -43,7 +43,7 @@ function selectOrder(id) {
 }
 
 // ─── 발주 취소 confirm ──────────────────────────────────────────────────────
-// 거래처 승인(PENDING→APPROVED)·출고 시작(APPROVED→SHIPPING) 두 단계는 SYS-001 배치가
+// 공급처 승인(PENDING→APPROVED)·출고 시작(APPROVED→SHIPPING) 두 단계는 SYS-001 배치가
 // 자동 처리한다 (5분 주기, 30분 경과 조건). 본사는 발주 작성·취소 + 시연용 강제 트리거만.
 const showCancelConfirm = ref(false)
 const cancelReason = ref('')
@@ -139,7 +139,10 @@ function statusLabel(status) {
 // 날짜 포맷
 function formatDate(iso) {
   if (!iso) return '-'
-  return iso.replace('T', ' ').slice(0, 16)
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return '-'
+  const pad = (n) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
 }
 
 // 진행 이력 타임라인 — 점/텍스트 색상
@@ -270,7 +273,7 @@ const TruckIcon = IconBase([
     @logout="handleLogout"
   >
     <div class="flex flex-col gap-4">
-      <!-- 총 발주 요약 (거래처/기간 컨텍스트 반영) -->
+      <!-- 총 발주 요약 (공급처/기간 컨텍스트 반영) -->
       <section
         class="flex items-center gap-4 border border-gray-200 bg-white px-5 py-4 shadow-sm"
       >
@@ -346,7 +349,7 @@ const TruckIcon = IconBase([
                 <input
                   v-model="poStore.searchKeyword"
                   type="text"
-                  placeholder="발주번호/거래처/품목명 검색"
+                  placeholder="발주번호/공급처/품목명 검색"
                   class="w-52 border border-gray-300 bg-white py-1.5 pl-8 pr-3 text-xs outline-none focus:border-[#004D3C]"
                 />
               </label>
@@ -371,7 +374,7 @@ const TruckIcon = IconBase([
             </div>
           </div>
 
-          <!-- 필터 줄: 거래처 / 기간 / 정렬 -->
+          <!-- 필터 줄: 공급처 / 기간 / 정렬 -->
           <div
             class="flex flex-wrap items-center gap-2 border-b border-gray-200 bg-gray-50 px-3 py-2"
           >
@@ -379,7 +382,7 @@ const TruckIcon = IconBase([
               v-model="poStore.vendorFilter"
               class="border border-gray-300 bg-white px-2 py-1.5 text-xs outline-none focus:border-[#004D3C]"
             >
-              <option value="">전체 거래처</option>
+              <option value="">전체 공급처</option>
               <option v-for="v in poStore.vendorOptions" :key="v.id" :value="v.id">
                 {{ v.name }}
               </option>
@@ -413,7 +416,7 @@ const TruckIcon = IconBase([
               <thead class="bg-gray-100 text-[10px] uppercase tracking-wider text-gray-500">
                 <tr>
                   <th class="w-32 px-3 py-2 text-left font-black">발주번호</th>
-                  <th class="px-3 py-2 text-left font-black">거래처</th>
+                  <th class="px-3 py-2 text-left font-black">공급처</th>
                   <th class="w-28 px-3 py-2 text-left font-black">입고 창고</th>
                   <th class="w-44 px-3 py-2 text-left font-black">품목</th>
                   <th class="w-28 px-3 py-2 text-right font-black">총금액</th>
@@ -514,7 +517,7 @@ const TruckIcon = IconBase([
 
               <div class="grid grid-cols-2 gap-3">
                 <div>
-                  <p class="text-[10px] font-bold uppercase text-gray-400">거래처</p>
+                  <p class="text-[10px] font-bold uppercase text-gray-400">공급처</p>
                   <p class="mt-0.5 text-xs font-black text-gray-800">
                     {{ poStore.selectedOrder.vendorName }}
                   </p>
@@ -643,14 +646,14 @@ const TruckIcon = IconBase([
                 </button>
               </div>
               <p class="pt-1 text-center text-[11px] leading-relaxed text-gray-500">
-                30분 후 시스템이 자동으로 거래처 승인을 처리합니다.<br />
+                30분 후 시스템이 자동으로 공급처 승인을 처리합니다.<br />
                 그 전에 [수정] 또는 [취소] 가능합니다.
               </p>
             </template>
 
             <template v-else-if="poStore.selectedOrder.status === 'APPROVED'">
               <p class="text-center text-xs leading-relaxed text-gray-500">
-                승인 완료 · 30분 후 시스템이 자동으로 거래처 출고 처리합니다.
+                승인 완료 · 30분 후 시스템이 자동으로 공급처 출고 처리합니다.
               </p>
             </template>
 
@@ -718,7 +721,7 @@ const TruckIcon = IconBase([
               v-model="cancelReason"
               rows="3"
               maxlength="500"
-              placeholder="예: 거래처 단가 변경, 수량 잘못 입력 등"
+              placeholder="예: 공급처 단가 변경, 수량 잘못 입력 등"
               class="mt-1 w-full resize-none border border-gray-300 px-2 py-1.5 text-xs outline-none focus:border-red-500"
             />
           </label>

--- a/src/views/hq/HqVendorManagementView.vue
+++ b/src/views/hq/HqVendorManagementView.vue
@@ -18,15 +18,15 @@ function handleLogout() {
 
 // --- 레이아웃 설정 ---
 const activeTopMenu = computed(() => '주문/발주 관리')
-const activeSideMenu = ref('거래처 관리')
+const activeSideMenu = ref('공급처 관리')
 
 const sideMenus = [
   { label: '매장 주문', icon: 'file', path: '/hq/orders' },
-  { label: '거래처 발주', icon: 'truck', path: '/hq/purchase-orders' },
-  { label: '거래처 관리', icon: 'briefcase', path: '/hq/vendors' },
+  { label: '공급처 발주', icon: 'truck', path: '/hq/purchase-orders' },
+  { label: '공급처 관리', icon: 'briefcase', path: '/hq/vendors' },
 ]
 
-// --- 거래처 목록 패널 ---
+// --- 공급처 목록 패널 ---
 const vendorSearch = ref('')
 const vendorStatusFilter = ref('all')
 
@@ -376,7 +376,7 @@ const InfoIcon = IconBase([
     <!-- 3열 레이아웃 -->
     <div class="flex min-h-0 gap-4 overflow-hidden">
       <!-- ====================================================
-           1열: 거래처 목록 패널
+           1열: 공급처 목록 패널
            ==================================================== -->
       <div
         class="flex w-64 shrink-0 flex-col overflow-hidden border border-gray-300 bg-white shadow-sm"
@@ -387,7 +387,7 @@ const InfoIcon = IconBase([
             class="inline-flex items-center gap-1.5 text-[11px] font-black uppercase tracking-wider"
           >
             <BuildingIcon :size="13" />
-            거래처 목록
+            공급처 목록
           </h2>
           <span class="text-[10px] font-bold opacity-70">{{ displayedVendors.length }}개</span>
         </div>
@@ -402,7 +402,7 @@ const InfoIcon = IconBase([
             <input
               v-model="vendorSearch"
               type="text"
-              placeholder="거래처명 / 담당자 검색..."
+              placeholder="공급처명 / 담당자 검색..."
               class="w-full border border-gray-300 bg-gray-50 py-1.5 pl-7 pr-2 text-[11px] outline-none focus:border-[#004D3C] focus:bg-white"
             />
           </label>
@@ -416,14 +416,14 @@ const InfoIcon = IconBase([
           </select>
         </div>
 
-        <!-- 거래처 리스트 -->
+        <!-- 공급처 리스트 -->
         <div class="flex-1 overflow-y-auto divide-y divide-gray-100">
           <div
             v-if="displayedVendors.length === 0"
             class="flex flex-col items-center justify-center gap-2 py-10 text-center text-[11px] text-gray-400"
           >
             <BuildingIcon :size="28" class="opacity-30" />
-            <p>거래처가 없습니다.</p>
+            <p>공급처가 없습니다.</p>
           </div>
 
           <button
@@ -478,16 +478,16 @@ const InfoIcon = IconBase([
           </span>
         </div>
 
-        <!-- 거래처 미선택 상태 -->
+        <!-- 공급처 미선택 상태 -->
         <div
           v-if="!vendor.selectedVendorId"
           class="flex flex-1 flex-col items-center justify-center gap-3 text-center text-gray-400"
         >
           <BuildingIcon :size="40" class="opacity-20" />
           <div>
-            <p class="text-sm font-black">거래처를 선택해주세요</p>
+            <p class="text-sm font-black">공급처를 선택해주세요</p>
             <p class="mt-1 text-xs">
-              좌측 목록에서 거래처를 선택하면<br />계약 제품 목록이 표시됩니다.
+              좌측 목록에서 공급처를 선택하면<br />계약 제품 목록이 표시됩니다.
             </p>
           </div>
         </div>
@@ -511,8 +511,8 @@ const InfoIcon = IconBase([
               <tbody class="divide-y divide-gray-100">
                 <tr v-if="vendor.contracts.length === 0">
                   <td colspan="6" class="py-12 text-center text-[11px] text-gray-400">
-                    이 거래처에 매핑된 제품 마스터가 없습니다.<br />
-                    제품 마스터 페이지에서 메인 거래처를 이 거래처로 지정해 등록하세요.
+                    이 공급처에 매핑된 제품 마스터가 없습니다.<br />
+                    제품 마스터 페이지에서 메인 공급처를 이 공급처로 지정해 등록하세요.
                   </td>
                 </tr>
 
@@ -675,10 +675,10 @@ const InfoIcon = IconBase([
               </section>
             </template>
 
-            <!-- 거래처 담당자 정보 -->
+            <!-- 공급처 담당자 정보 -->
             <section v-if="vendor.selectedVendor" class="space-y-2 border-t border-gray-100 pt-3">
               <p class="text-[9px] font-black uppercase tracking-wider text-gray-400">
-                거래처 담당자
+                공급처 담당자
               </p>
               <div class="space-y-1 text-xs font-bold">
                 <p class="text-gray-800">{{ vendor.selectedVendor.contactPerson }}</p>

--- a/src/views/warehouse/WarehouseDashboardView.vue
+++ b/src/views/warehouse/WarehouseDashboardView.vue
@@ -186,7 +186,10 @@ const shippingOrders = computed(() => dashStore.shippingOrders)
 
 function formatDate(iso) {
   if (!iso) return '-'
-  return iso.replace('T', ' ').slice(0, 16)
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return '-'
+  const pad = (n) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
 }
 
 // ─── 공간 점유율 (WHS-003) ──────────────────────────────────────────────────
@@ -322,7 +325,7 @@ const thresholdBarClass = computed(
               <thead class="bg-gray-50 text-[10px] uppercase tracking-[0.12em] text-gray-500">
                 <tr>
                   <th class="px-4 py-3 font-black">발주번호</th>
-                  <th class="px-4 py-3 font-black">거래처</th>
+                  <th class="px-4 py-3 font-black">공급처</th>
                   <th class="px-4 py-3 font-black">입고 창고</th>
                   <th class="px-4 py-3 font-black">출발일</th>
                   <th class="px-4 py-3 text-right font-black">품목/총액</th>

--- a/src/views/warehouse/WarehouseInboundView.vue
+++ b/src/views/warehouse/WarehouseInboundView.vue
@@ -127,7 +127,10 @@ function statusLabel(status) {
 
 function formatDate(iso) {
   if (!iso) return '-'
-  return iso.replace('T', ' ').slice(0, 16)
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return '-'
+  const pad = (n) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
 }
 
 function historyDotClass(status) {
@@ -158,7 +161,7 @@ function selectOrder(id) {
   inbound.selectOrder(id)
 }
 
-// 창고 관점 진행 이력 — DELIVERED/COMPLETED 만 (PENDING/APPROVED/SHIPPING 은 거래처 영역, 노이즈)
+// 창고 관점 진행 이력 — DELIVERED/COMPLETED 만 (PENDING/APPROVED/SHIPPING 은 공급처 영역, 노이즈)
 const visibleHistory = computed(() => {
   const list = inbound.selectedOrder?.statusHistory ?? []
   return list.filter((h) => h.status === 'DELIVERED' || h.status === 'COMPLETED')
@@ -310,7 +313,7 @@ const CheckIcon = IconBase([{ tag: 'polyline', attrs: { points: '20 6 9 17 4 12'
               <input
                 v-model="inbound.searchKeyword"
                 type="text"
-                placeholder="발주번호/거래처/품목 검색"
+                placeholder="발주번호/공급처/품목 검색"
                 class="w-52 border border-gray-300 bg-white py-1.5 pl-8 pr-3 text-xs outline-none focus:border-[#004D3C]"
               />
             </label>
@@ -321,7 +324,7 @@ const CheckIcon = IconBase([{ tag: 'polyline', attrs: { points: '20 6 9 17 4 12'
               <thead class="bg-gray-100 text-[10px] uppercase tracking-wider text-gray-500">
                 <tr>
                   <th class="w-32 px-3 py-2 text-left font-black">발주번호</th>
-                  <th class="w-32 px-3 py-2 text-left font-black">거래처</th>
+                  <th class="w-32 px-3 py-2 text-left font-black">공급처</th>
                   <th class="w-28 px-3 py-2 text-left font-black">입고 창고</th>
                   <th class="w-44 px-3 py-2 text-left font-black">품목</th>
                   <th class="w-28 px-3 py-2 text-right font-black">총금액</th>
@@ -420,7 +423,7 @@ const CheckIcon = IconBase([{ tag: 'polyline', attrs: { points: '20 6 9 17 4 12'
 
               <div class="grid grid-cols-2 gap-3">
                 <div>
-                  <p class="text-[10px] font-bold uppercase text-gray-400">거래처</p>
+                  <p class="text-[10px] font-bold uppercase text-gray-400">공급처</p>
                   <p class="mt-0.5 text-xs font-black text-gray-800">
                     {{ inbound.selectedOrder.vendorName }}
                   </p>


### PR DESCRIPTION
## 📌 요약
- 본사 발주 화면의 한국어 표기를 "거래처" → "공급처" 로 통일하고, 발주 생성일시가 KST 기준 9시간 적게 표시되던 시차 fix 도 함께 반영.

<br><br>

## 🎯 작업 내용
- 사이드바 메뉴 라벨 2곳 (`공급처 발주`, `공급처 관리`). 순환 재고 거래처 메뉴 2곳은 그대로 보존.
- `HqPurchaseOrderView.vue` / `HqPurchaseOrderCreateView.vue` (40+곳) / `HqVendorManagementView.vue` (16곳) 한국어 라벨·placeholder·컬럼·toast·confirm 모달 모두 통일.
- 창고 화면 (`WarehouseDashboardView.vue`, `WarehouseInboundView.vue`) 의 컬럼·placeholder·라벨 4곳도 함께 통일.
- `api/purchaseOrder.js`, `api/vendor.js`, `stores/vendor.js`, `stores/warehouse/{warehouseInbound,warehouseDashboard}.js` 주석/검증 메시지 통일. 코드 식별자는 변경 X.
- 발주 생성일시 시차 fix — `formatDate` 가 ISO 문자열을 단순히 잘라 KST 기준 9시간 적게 표시하던 문제. `new Date(iso)` 로 파싱 후 클라이언트 timezone 기준 `yyyy-MM-dd HH:mm` 합성으로 변경 (`HqPurchaseOrderView` / `WarehouseInboundView` / `WarehouseDashboardView` 3곳 동일 패치).
- 순환재고 도메인(`circular-stock/**`, `circularBuyer api`, `circularStock*` store) 은 별 도메인이라 손대지 않음.

<br><br>

## ✔️ 참고 사항
- 
- 

<br><br>

## ✔️ 관련 이슈

- Close #352

<br><br>
