### PR TITLE
refactor: 창고간 재고 이동 프로세스 개선

### DIFF
--- a/src/constants/hqWarehouseTransferData.js
+++ b/src/constants/hqWarehouseTransferData.js
@@ -5,20 +5,26 @@ export const transferSkuCatalog = [
   { skuCode: 'PRD-PNT-SH-002-GRY-M', itemCode: 'PRD-PNT-SH-002', itemName: '라이트 코튼 쇼츠', color: '그레이', size: 'M', category: '바지 > 반바지' },
   { skuCode: 'PRD-SKT-LS-002-BLK-M', itemCode: 'PRD-SKT-LS-002', itemName: '플리츠 롱스커트', color: '검정', size: 'M', category: '치마 > 롱스커트' },
   { skuCode: 'PRD-OUT-PD-001-NVY-XL', itemCode: 'PRD-OUT-PD-001', itemName: '라이트 숏 패딩', color: '네이비', size: 'XL', category: '아우터 > 패딩' },
+  { skuCode: 'PRD-TOP-KN-004-CRM-M', itemCode: 'PRD-TOP-KN-004', itemName: '소프트 라운드 니트', color: '크림', size: 'M', category: '상의 > 니트' },
+  { skuCode: 'PRD-TOP-HD-002-GRN-L', itemCode: 'PRD-TOP-HD-002', itemName: '헤비웨이트 후드티', color: '그린', size: 'L', category: '상의 > 맨투맨/후드' },
+  { skuCode: 'PRD-PNT-DN-003-BLU-30', itemCode: 'PRD-PNT-DN-003', itemName: '슬림 데님 팬츠', color: '블루', size: '30', category: '바지 > 데님' },
+  { skuCode: 'PRD-OUT-JP-005-BLK-L', itemCode: 'PRD-OUT-JP-005', itemName: '윈드브레이커 점퍼', color: '검정', size: 'L', category: '아우터 > 점퍼' },
+  { skuCode: 'PRD-DRS-MD-001-IVO-S', itemCode: 'PRD-DRS-MD-001', itemName: '미디 셔츠 원피스', color: '아이보리', size: 'S', category: '원피스 > 미디' },
+  { skuCode: 'PRD-ACC-BG-007-BRN-F', itemCode: 'PRD-ACC-BG-007', itemName: '캔버스 토트백', color: '브라운', size: 'FREE', category: '잡화 > 가방' },
 ]
 
 export const warehouseInventoryMap = {
   'PRD-TOP-SS-001-BLK-S': [
-    { warehouseCode: 'WH-ICN-01', warehouseName: '인천 제1창고', location: '인천 서구', onHandStock: 128, reservedStock: 12, safetyStock: 40, updatedAt: '2026.04.30 09:30' },
-    { warehouseCode: 'WH-ICH-01', warehouseName: '이천 풀필먼트', location: '경기 이천시', onHandStock: 22, reservedStock: 4, safetyStock: 30, updatedAt: '2026.04.30 09:12' },
+    { warehouseCode: 'WH-ICN-01', warehouseName: '인천 제1창고', location: '인천 서구', onHandStock: 122, reservedStock: 14, safetyStock: 40, updatedAt: '2026.04.30 09:30' },
+    { warehouseCode: 'WH-ICH-01', warehouseName: '이천 풀필먼트', location: '경기 이천시', onHandStock: 26, reservedStock: 6, safetyStock: 32, updatedAt: '2026.04.30 09:12' },
     { warehouseCode: 'WH-BSN-01', warehouseName: '부산 물류창고', location: '부산 강서구', onHandStock: 0, reservedStock: 0, safetyStock: 25, updatedAt: '2026.04.30 08:55' },
-    { warehouseCode: 'WH-DJN-01', warehouseName: '대전 허브창고', location: '대전 유성구', onHandStock: 54, reservedStock: 6, safetyStock: 20, updatedAt: '2026.04.30 08:40' },
+    { warehouseCode: 'WH-DJN-01', warehouseName: '대전 허브창고', location: '대전 유성구', onHandStock: 50, reservedStock: 5, safetyStock: 20, updatedAt: '2026.04.30 08:40' },
   ],
   'PRD-TOP-SS-001-WHT-M': [
-    { warehouseCode: 'WH-ICN-01', warehouseName: '인천 제1창고', location: '인천 서구', onHandStock: 98, reservedStock: 8, safetyStock: 35, updatedAt: '2026.04.30 09:25' },
-    { warehouseCode: 'WH-ICH-01', warehouseName: '이천 풀필먼트', location: '경기 이천시', onHandStock: 14, reservedStock: 4, safetyStock: 28, updatedAt: '2026.04.30 09:00' },
-    { warehouseCode: 'WH-BSN-01', warehouseName: '부산 물류창고', location: '부산 강서구', onHandStock: 42, reservedStock: 4, safetyStock: 22, updatedAt: '2026.04.30 08:35' },
-    { warehouseCode: 'WH-DJN-01', warehouseName: '대전 허브창고', location: '대전 유성구', onHandStock: 18, reservedStock: 6, safetyStock: 18, updatedAt: '2026.04.30 08:20' },
+    { warehouseCode: 'WH-ICN-01', warehouseName: '인천 제1창고', location: '인천 서구', onHandStock: 96, reservedStock: 10, safetyStock: 35, updatedAt: '2026.04.30 09:25' },
+    { warehouseCode: 'WH-ICH-01', warehouseName: '이천 풀필먼트', location: '경기 이천시', onHandStock: 15, reservedStock: 3, safetyStock: 26, updatedAt: '2026.04.30 09:00' },
+    { warehouseCode: 'WH-BSN-01', warehouseName: '부산 물류창고', location: '부산 강서구', onHandStock: 44, reservedStock: 5, safetyStock: 22, updatedAt: '2026.04.30 08:35' },
+    { warehouseCode: 'WH-DJN-01', warehouseName: '대전 허브창고', location: '대전 유성구', onHandStock: 20, reservedStock: 8, safetyStock: 20, updatedAt: '2026.04.30 08:20' },
   ],
   'PRD-TOP-SH-003-NVY-L': [
     { warehouseCode: 'WH-ICN-01', warehouseName: '인천 제1창고', location: '인천 서구', onHandStock: 72, reservedStock: 6, safetyStock: 20, updatedAt: '2026.04.30 09:18' },
@@ -27,9 +33,9 @@ export const warehouseInventoryMap = {
     { warehouseCode: 'WH-DJN-01', warehouseName: '대전 허브창고', location: '대전 유성구', onHandStock: 8, reservedStock: 2, safetyStock: 14, updatedAt: '2026.04.30 08:10' },
   ],
   'PRD-PNT-SH-002-GRY-M': [
-    { warehouseCode: 'WH-ICN-01', warehouseName: '인천 제1창고', location: '인천 서구', onHandStock: 45, reservedStock: 5, safetyStock: 18, updatedAt: '2026.04.30 09:08' },
-    { warehouseCode: 'WH-ICH-01', warehouseName: '이천 풀필먼트', location: '경기 이천시', onHandStock: 6, reservedStock: 2, safetyStock: 15, updatedAt: '2026.04.30 08:49' },
-    { warehouseCode: 'WH-BSN-01', warehouseName: '부산 물류창고', location: '부산 강서구', onHandStock: 24, reservedStock: 4, safetyStock: 14, updatedAt: '2026.04.30 08:22' },
+    { warehouseCode: 'WH-ICN-01', warehouseName: '인천 제1창고', location: '인천 서구', onHandStock: 43, reservedStock: 7, safetyStock: 18, updatedAt: '2026.04.30 09:08' },
+    { warehouseCode: 'WH-ICH-01', warehouseName: '이천 풀필먼트', location: '경기 이천시', onHandStock: 6, reservedStock: 2, safetyStock: 16, updatedAt: '2026.04.30 08:49' },
+    { warehouseCode: 'WH-BSN-01', warehouseName: '부산 물류창고', location: '부산 강서구', onHandStock: 26, reservedStock: 6, safetyStock: 14, updatedAt: '2026.04.30 08:22' },
     { warehouseCode: 'WH-DJN-01', warehouseName: '대전 허브창고', location: '대전 유성구', onHandStock: 0, reservedStock: 0, safetyStock: 12, updatedAt: '2026.04.30 08:05' },
   ],
   'PRD-SKT-LS-002-BLK-M': [
@@ -44,10 +50,101 @@ export const warehouseInventoryMap = {
     { warehouseCode: 'WH-BSN-01', warehouseName: '부산 물류창고', location: '부산 강서구', onHandStock: 5, reservedStock: 2, safetyStock: 12, updatedAt: '2026.04.30 08:16' },
     { warehouseCode: 'WH-DJN-01', warehouseName: '대전 허브창고', location: '대전 유성구', onHandStock: 0, reservedStock: 0, safetyStock: 10, updatedAt: '2026.04.30 08:01' },
   ],
+  'PRD-TOP-KN-004-CRM-M': [
+    { warehouseCode: 'WH-ICN-01', warehouseName: '인천 제1창고', location: '인천 서구', onHandStock: 34, reservedStock: 8, safetyStock: 20, updatedAt: '2026.04.30 09:21' },
+    { warehouseCode: 'WH-ICH-01', warehouseName: '이천 풀필먼트', location: '경기 이천시', onHandStock: 11, reservedStock: 4, safetyStock: 15, updatedAt: '2026.04.30 09:02' },
+    { warehouseCode: 'WH-BSN-01', warehouseName: '부산 물류창고', location: '부산 강서구', onHandStock: 7, reservedStock: 1, safetyStock: 12, updatedAt: '2026.04.30 08:39' },
+    { warehouseCode: 'WH-DJN-01', warehouseName: '대전 허브창고', location: '대전 유성구', onHandStock: 4, reservedStock: 0, safetyStock: 10, updatedAt: '2026.04.30 08:14' },
+  ],
+  'PRD-TOP-HD-002-GRN-L': [
+    { warehouseCode: 'WH-ICN-01', warehouseName: '인천 제1창고', location: '인천 서구', onHandStock: 82, reservedStock: 6, safetyStock: 20, updatedAt: '2026.04.30 09:16' },
+    { warehouseCode: 'WH-ICH-01', warehouseName: '이천 풀필먼트', location: '경기 이천시', onHandStock: 39, reservedStock: 4, safetyStock: 18, updatedAt: '2026.04.30 08:53' },
+    { warehouseCode: 'WH-BSN-01', warehouseName: '부산 물류창고', location: '부산 강서구', onHandStock: 27, reservedStock: 2, safetyStock: 16, updatedAt: '2026.04.30 08:29' },
+    { warehouseCode: 'WH-DJN-01', warehouseName: '대전 허브창고', location: '대전 유성구', onHandStock: 20, reservedStock: 2, safetyStock: 15, updatedAt: '2026.04.30 08:09' },
+  ],
+  'PRD-PNT-DN-003-BLU-30': [
+    { warehouseCode: 'WH-ICN-01', warehouseName: '인천 제1창고', location: '인천 서구', onHandStock: 28, reservedStock: 8, safetyStock: 18, updatedAt: '2026.04.30 09:11' },
+    { warehouseCode: 'WH-ICH-01', warehouseName: '이천 풀필먼트', location: '경기 이천시', onHandStock: 10, reservedStock: 2, safetyStock: 12, updatedAt: '2026.04.30 08:50' },
+    { warehouseCode: 'WH-BSN-01', warehouseName: '부산 물류창고', location: '부산 강서구', onHandStock: 14, reservedStock: 5, safetyStock: 14, updatedAt: '2026.04.30 08:26' },
+    { warehouseCode: 'WH-DJN-01', warehouseName: '대전 허브창고', location: '대전 유성구', onHandStock: 8, reservedStock: 1, safetyStock: 11, updatedAt: '2026.04.30 08:07' },
+  ],
+  'PRD-OUT-JP-005-BLK-L': [
+    { warehouseCode: 'WH-ICN-01', warehouseName: '인천 제1창고', location: '인천 서구', onHandStock: 70, reservedStock: 10, safetyStock: 24, updatedAt: '2026.04.30 09:09' },
+    { warehouseCode: 'WH-ICH-01', warehouseName: '이천 풀필먼트', location: '경기 이천시', onHandStock: 18, reservedStock: 4, safetyStock: 18, updatedAt: '2026.04.30 08:47' },
+    { warehouseCode: 'WH-BSN-01', warehouseName: '부산 물류창고', location: '부산 강서구', onHandStock: 12, reservedStock: 3, safetyStock: 16, updatedAt: '2026.04.30 08:23' },
+    { warehouseCode: 'WH-DJN-01', warehouseName: '대전 허브창고', location: '대전 유성구', onHandStock: 9, reservedStock: 1, safetyStock: 14, updatedAt: '2026.04.30 08:06' },
+  ],
+  'PRD-DRS-MD-001-IVO-S': [
+    { warehouseCode: 'WH-ICN-01', warehouseName: '인천 제1창고', location: '인천 서구', onHandStock: 52, reservedStock: 8, safetyStock: 20, updatedAt: '2026.04.30 09:04' },
+    { warehouseCode: 'WH-ICH-01', warehouseName: '이천 풀필먼트', location: '경기 이천시', onHandStock: 20, reservedStock: 5, safetyStock: 14, updatedAt: '2026.04.30 08:40' },
+    { warehouseCode: 'WH-BSN-01', warehouseName: '부산 물류창고', location: '부산 강서구', onHandStock: 18, reservedStock: 4, safetyStock: 12, updatedAt: '2026.04.30 08:19' },
+    { warehouseCode: 'WH-DJN-01', warehouseName: '대전 허브창고', location: '대전 유성구', onHandStock: 13, reservedStock: 3, safetyStock: 10, updatedAt: '2026.04.30 08:04' },
+  ],
+  'PRD-ACC-BG-007-BRN-F': [
+    { warehouseCode: 'WH-ICN-01', warehouseName: '인천 제1창고', location: '인천 서구', onHandStock: 16, reservedStock: 6, safetyStock: 14, updatedAt: '2026.04.30 09:01' },
+    { warehouseCode: 'WH-ICH-01', warehouseName: '이천 풀필먼트', location: '경기 이천시', onHandStock: 8, reservedStock: 3, safetyStock: 11, updatedAt: '2026.04.30 08:36' },
+    { warehouseCode: 'WH-BSN-01', warehouseName: '부산 물류창고', location: '부산 강서구', onHandStock: 6, reservedStock: 2, safetyStock: 10, updatedAt: '2026.04.30 08:15' },
+    { warehouseCode: 'WH-DJN-01', warehouseName: '대전 허브창고', location: '대전 유성구', onHandStock: 4, reservedStock: 1, safetyStock: 9, updatedAt: '2026.04.30 08:00' },
+  ],
+}
+
+const WAREHOUSE_MASTER = [
+  { warehouseCode: 'WH-ICN-01', warehouseName: '인천 제1창고', location: '인천 서구' },
+  { warehouseCode: 'WH-ICH-01', warehouseName: '이천 풀필먼트', location: '경기 이천시' },
+  { warehouseCode: 'WH-BSN-01', warehouseName: '부산 물류창고', location: '부산 강서구' },
+  { warehouseCode: 'WH-DJN-01', warehouseName: '대전 허브창고', location: '대전 유성구' },
+  { warehouseCode: 'WH-GMP-01', warehouseName: '김포 냉장센터', location: '경기 김포시' },
+  { warehouseCode: 'WH-SUW-01', warehouseName: '수원 통합창고', location: '경기 수원시' },
+  { warehouseCode: 'WH-GWJ-01', warehouseName: '광주 물류창고', location: '광주 광산구' },
+  { warehouseCode: 'WH-ULS-01', warehouseName: '울산 항만창고', location: '울산 남구' },
+  { warehouseCode: 'WH-CJU-01', warehouseName: '청주 크로스도킹', location: '충북 청주시' },
+  { warehouseCode: 'WH-JJU-01', warehouseName: '제주 지역허브', location: '제주 제주시' },
+]
+
+function hashSeed(s) {
+  let h = 5381
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) >>> 0
+  return h
+}
+
+function buildSyntheticRow(skuCode, warehouse) {
+  const seed = hashSeed(`${skuCode}|${warehouse.warehouseCode}`)
+  const safetyStock = 9 + (seed % 13) // 9~21
+  const shortageBucket = (seed >> 3) % 4 // 0~3
+
+  const availableStockByBucket = [
+    safetyStock + 16 + (seed % 18), // 여유
+    safetyStock + 2 + (seed % 8), // 경계 상단
+    Math.max(0, safetyStock - (3 + (seed % 6))), // 부족
+    Math.max(0, safetyStock - (9 + (seed % 8))), // 강한 부족
+  ]
+  const availableStock = Math.max(0, availableStockByBucket[shortageBucket])
+  const reservedStock = 1 + ((seed >> 7) % 7)
+  const onHandStock = availableStock + reservedStock
+  const minute = ((seed % 30) + 30).toString().padStart(2, '0')
+
+  return {
+    warehouseCode: warehouse.warehouseCode,
+    warehouseName: warehouse.warehouseName,
+    location: warehouse.location,
+    onHandStock,
+    reservedStock,
+    safetyStock,
+    updatedAt: `2026.04.30 07:${minute}`,
+  }
+}
+
+function enrichWarehouseRows(skuCode) {
+  const seededRows = warehouseInventoryMap[skuCode] || []
+  const rowByCode = new Map(seededRows.map((row) => [row.warehouseCode, row]))
+
+  return WAREHOUSE_MASTER.map((warehouse) => {
+    return rowByCode.get(warehouse.warehouseCode) ?? buildSyntheticRow(skuCode, warehouse)
+  })
 }
 
 export function buildWarehouseRows(skuCode) {
-  return (warehouseInventoryMap[skuCode] || []).map((row) => {
+  return enrichWarehouseRows(skuCode).map((row) => {
     const availableStock = Math.max(0, row.onHandStock - row.reservedStock)
     let status = '정상'
     if (availableStock <= 0) status = '품절'

--- a/src/constants/hqWarehouseTransferData.js
+++ b/src/constants/hqWarehouseTransferData.js
@@ -110,7 +110,7 @@ function hashSeed(s) {
 function buildSyntheticRow(skuCode, warehouse) {
   const seed = hashSeed(`${skuCode}|${warehouse.warehouseCode}`)
   const safetyStock = 9 + (seed % 13) // 9~21
-  const shortageBucket = (seed >> 3) % 4 // 0~3
+  const shortageBucket = (seed >>> 3) % 4 // 0~3
 
   const availableStockByBucket = [
     safetyStock + 16 + (seed % 18), // 여유
@@ -119,7 +119,7 @@ function buildSyntheticRow(skuCode, warehouse) {
     Math.max(0, safetyStock - (9 + (seed % 8))), // 강한 부족
   ]
   const availableStock = Math.max(0, availableStockByBucket[shortageBucket])
-  const reservedStock = 1 + ((seed >> 7) % 7)
+  const reservedStock = 1 + ((seed >>> 7) % 7)
   const onHandStock = availableStock + reservedStock
   const minute = ((seed % 30) + 30).toString().padStart(2, '0')
 

--- a/src/stores/hq/warehouseTransferCart.js
+++ b/src/stores/hq/warehouseTransferCart.js
@@ -1,0 +1,131 @@
+import { computed, ref } from 'vue'
+import { defineStore } from 'pinia'
+
+function makeLineId() {
+  return `WTC-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+function routeKeyOf(line) {
+  return `${line.fromWarehouseCode}=>${line.toWarehouseCode}`
+}
+
+export const useWarehouseTransferCartStore = defineStore('warehouseTransferCart', () => {
+  const lines = ref([])
+
+  const lineCount = computed(() => lines.value.length)
+
+  const groupedByRoute = computed(() => {
+    const map = new Map()
+
+    for (const line of lines.value) {
+      const key = routeKeyOf(line)
+      if (!map.has(key)) {
+        map.set(key, {
+          routeKey: key,
+          fromWarehouseCode: line.fromWarehouseCode,
+          fromWarehouseName: line.fromWarehouseName,
+          toWarehouseCode: line.toWarehouseCode,
+          toWarehouseName: line.toWarehouseName,
+          lines: [],
+          totalQty: 0,
+        })
+      }
+
+      const group = map.get(key)
+      group.lines.push(line)
+      group.totalQty += line.qty
+    }
+
+    return Array.from(map.values())
+  })
+
+  function addLine(payload) {
+    const duplicate = lines.value.find((line) =>
+      line.skuCode === payload.skuCode &&
+      line.fromWarehouseCode === payload.fromWarehouseCode &&
+      line.toWarehouseCode === payload.toWarehouseCode
+    )
+
+    if (duplicate) {
+      duplicate.qty += Number(payload.qty) || 0
+      duplicate.reason = payload.reason
+      duplicate.memo = payload.memo
+      return duplicate.lineId
+    }
+
+    const line = {
+      lineId: makeLineId(),
+      skuCode: payload.skuCode,
+      itemName: payload.itemName,
+      fromWarehouseCode: payload.fromWarehouseCode,
+      fromWarehouseName: payload.fromWarehouseName,
+      toWarehouseCode: payload.toWarehouseCode,
+      toWarehouseName: payload.toWarehouseName,
+      qty: Number(payload.qty) || 0,
+      reason: payload.reason || '',
+      memo: payload.memo || '',
+      addedAt: new Date().toISOString(),
+    }
+    lines.value.push(line)
+    return line.lineId
+  }
+
+  function updateLineQty(lineId, qty) {
+    const target = lines.value.find((line) => line.lineId === lineId)
+    if (!target) return false
+    const nextQty = Number(qty)
+    if (!Number.isFinite(nextQty) || nextQty < 1) return false
+    target.qty = Math.trunc(nextQty)
+    return true
+  }
+
+  function removeLine(lineId) {
+    lines.value = lines.value.filter((line) => line.lineId !== lineId)
+  }
+
+  function clearAll() {
+    lines.value = []
+  }
+
+  async function executeAll(executor) {
+    const grouped = groupedByRoute.value
+    const successLineIds = []
+    const failed = []
+
+    for (const group of grouped) {
+      for (const line of group.lines) {
+        const result = await executor(line, group)
+        if (result?.success) {
+          successLineIds.push(line.lineId)
+        } else {
+          failed.push({
+            lineId: line.lineId,
+            skuCode: line.skuCode,
+            message: result?.message || '실행 실패',
+          })
+        }
+      }
+    }
+
+    if (successLineIds.length) {
+      lines.value = lines.value.filter((line) => !successLineIds.includes(line.lineId))
+    }
+
+    return {
+      successCount: successLineIds.length,
+      failureCount: failed.length,
+      failed,
+    }
+  }
+
+  return {
+    lines,
+    lineCount,
+    groupedByRoute,
+    addLine,
+    updateLineQty,
+    removeLine,
+    clearAll,
+    executeAll,
+  }
+})

--- a/src/views/hq/inventory/HqWarehouseInventoryComparisonView.vue
+++ b/src/views/hq/inventory/HqWarehouseInventoryComparisonView.vue
@@ -174,7 +174,8 @@ function handleLogout() {
                 <th class="px-3 py-3 font-black">SKU 코드</th>
                 <th class="px-3 py-3 font-black">품목 코드</th>
                 <th class="px-3 py-3 font-black">품목명</th>
-                <th class="px-3 py-3 font-black">옵션</th>
+                <th class="px-3 py-3 font-black">색상</th>
+                <th class="px-3 py-3 font-black">사이즈</th>
                 <th class="px-3 py-3 font-black">카테고리</th>
                 <th class="px-3 py-3 text-right font-black">총 실재고</th>
                 <th class="px-3 py-3 text-right font-black">총 가용재고</th>
@@ -192,7 +193,8 @@ function handleLogout() {
                 <td class="px-3 py-3 font-mono font-bold text-gray-700">{{ row.skuCode }}</td>
                 <td class="px-3 py-3 font-mono font-bold text-gray-500">{{ row.itemCode }}</td>
                 <td class="px-3 py-3 font-black text-gray-900">{{ row.itemName }}</td>
-                <td class="px-3 py-3 font-bold text-gray-600">{{ row.color }}/{{ row.size }}</td>
+                <td class="px-3 py-3 font-bold text-gray-600">{{ row.color }}</td>
+                <td class="px-3 py-3 font-bold text-gray-600">{{ row.size }}</td>
                 <td class="px-3 py-3 font-bold text-gray-600">{{ row.category }}</td>
                 <td class="px-3 py-3 text-right font-black text-gray-900">{{ row.totalOnHand.toLocaleString() }}</td>
                 <td class="px-3 py-3 text-right font-black text-gray-900">{{ row.totalAvailable.toLocaleString() }}</td>
@@ -201,7 +203,7 @@ function handleLogout() {
               </tr>
 
               <tr v-if="filteredSkuRows.length === 0">
-                <td colspan="9" class="px-4 py-10 text-center text-xs font-bold text-gray-400">
+                <td colspan="10" class="px-4 py-10 text-center text-xs font-bold text-gray-400">
                   조건에 맞는 SKU가 없습니다.
                 </td>
               </tr>

--- a/src/views/hq/inventory/HqWarehouseInventoryComparisonView.vue
+++ b/src/views/hq/inventory/HqWarehouseInventoryComparisonView.vue
@@ -5,7 +5,7 @@ import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
 import { useWarehouseTransferCartStore } from '@/stores/hq/warehouseTransferCart.js'
-import { transferSkuCatalog, buildWarehouseRows, getImbalanceMetrics } from '@/constants/hqWarehouseTransferData.js'
+import { transferSkuCatalog, buildWarehouseRows } from '@/constants/hqWarehouseTransferData.js'
 
 const router = useRouter()
 const route = useRoute()
@@ -19,7 +19,6 @@ const activeSideMenu = ref('창고간 재고 이동')
 
 const searchTerm = ref(String(route.query.search || ''))
 const selectedCategory = ref(String(route.query.category || '전체'))
-const selectedStatus = ref(String(route.query.status || '전체'))
 const selectedWarehouseGroup = ref(String(route.query.warehouseGroup || '전체'))
 
 const categoryOptions = computed(() => ['전체', ...new Set(transferSkuCatalog.map(sku => sku.category))])
@@ -28,21 +27,32 @@ const warehouseGroupOptions = ['전체', '수도권', '충청권', '영남권']
 const warehouseGroupByCode = {
   'WH-ICN-01': '수도권',
   'WH-ICH-01': '수도권',
+  'WH-GMP-01': '수도권',
+  'WH-SUW-01': '수도권',
   'WH-DJN-01': '충청권',
+  'WH-CJU-01': '충청권',
   'WH-BSN-01': '영남권',
+  'WH-ULS-01': '영남권',
+  'WH-GWJ-01': '영남권',
+  'WH-JJU-01': '영남권',
 }
 
 const skuRows = computed(() => transferSkuCatalog.map((sku) => {
   const rows = buildWarehouseRows(sku.skuCode)
-  const metrics = getImbalanceMetrics(rows)
   const totalOnHand = rows.reduce((sum, row) => sum + row.onHandStock, 0)
   const totalAvailable = rows.reduce((sum, row) => sum + row.availableStock, 0)
+  const shortageWarehouseCount = rows.filter((row) => row.availableStock < row.safetyStock).length
+  const totalShortageQty = rows.reduce((sum, row) => {
+    if (row.availableStock >= row.safetyStock) return sum
+    return sum + (row.safetyStock - row.availableStock)
+  }, 0)
 
   return {
     ...sku,
     totalOnHand,
     totalAvailable,
-    ...metrics,
+    shortageWarehouseCount,
+    totalShortageQty,
     warehouseGroups: [...new Set(rows.map(row => warehouseGroupByCode[row.warehouseCode]).filter(Boolean))],
   }
 }))
@@ -53,20 +63,21 @@ const filteredSkuRows = computed(() => {
   return skuRows.value
     .filter((row) => {
       if (selectedCategory.value !== '전체' && row.category !== selectedCategory.value) return false
-      if (selectedStatus.value !== '전체' && row.status !== selectedStatus.value) return false
       if (selectedWarehouseGroup.value !== '전체' && !row.warehouseGroups.includes(selectedWarehouseGroup.value)) return false
       if (!keyword) return true
 
       return [row.skuCode, row.itemCode, row.itemName].join(' ').toLowerCase().includes(keyword)
     })
-    .sort((a, b) => b.imbalanceScore - a.imbalanceScore)
+    .sort((a, b) => {
+      if (b.shortageWarehouseCount !== a.shortageWarehouseCount) {
+        return b.shortageWarehouseCount - a.shortageWarehouseCount
+      }
+      if (b.totalShortageQty !== a.totalShortageQty) {
+        return b.totalShortageQty - a.totalShortageQty
+      }
+      return a.skuCode.localeCompare(b.skuCode)
+    })
 })
-
-const statusClass = (status) => ({
-  정상: 'bg-[#EBF5F5] text-black',
-  주의: 'bg-amber-50 text-amber-700',
-  불균형: 'bg-red-50 text-red-700',
-})[status] ?? 'bg-gray-100 text-gray-600'
 
 const moveToSkuDetail = (sku) => {
   router.push({
@@ -75,7 +86,6 @@ const moveToSkuDetail = (sku) => {
     query: {
       search: searchTerm.value || undefined,
       category: selectedCategory.value !== '전체' ? selectedCategory.value : undefined,
-      status: selectedStatus.value !== '전체' ? selectedStatus.value : undefined,
       warehouseGroup: selectedWarehouseGroup.value !== '전체' ? selectedWarehouseGroup.value : undefined,
     },
   })
@@ -84,7 +94,6 @@ const moveToSkuDetail = (sku) => {
 const resetFilters = () => {
   searchTerm.value = ''
   selectedCategory.value = '전체'
-  selectedStatus.value = '전체'
   selectedWarehouseGroup.value = '전체'
 }
 
@@ -116,10 +125,10 @@ function handleLogout() {
               장바구니 {{ cartStore.lineCount }}건
             </button>
           </div>
-          <p class="mt-1 text-xs font-bold text-gray-500">불균형 SKU를 우선 확인하고 상세에서 장바구니를 구성해 이동을 실행합니다.</p>
+          <p class="mt-1 text-xs font-bold text-gray-500">부족 창고가 많은 SKU를 우선 확인하고 상세에서 장바구니를 구성해 이동을 실행합니다.</p>
         </div>
 
-        <div class="grid gap-2 md:grid-cols-2 xl:grid-cols-[1.2fr_0.9fr_0.9fr_0.9fr_auto]">
+        <div class="grid gap-2 md:grid-cols-2 xl:grid-cols-[1.2fr_0.9fr_0.9fr_auto]">
           <label class="flex flex-col gap-1">
             <span class="text-[11px] font-bold text-gray-500">검색</span>
             <input
@@ -134,16 +143,6 @@ function handleLogout() {
             <span class="text-[11px] font-bold text-gray-500">카테고리</span>
             <select v-model="selectedCategory" class="h-10 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none focus:border-[#004D3C]">
               <option v-for="category in categoryOptions" :key="category" :value="category">{{ category }}</option>
-            </select>
-          </label>
-
-          <label class="flex flex-col gap-1">
-            <span class="text-[11px] font-bold text-gray-500">불균형 상태</span>
-            <select v-model="selectedStatus" class="h-10 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none focus:border-[#004D3C]">
-              <option value="전체">전체</option>
-              <option value="불균형">불균형</option>
-              <option value="주의">주의</option>
-              <option value="정상">정상</option>
             </select>
           </label>
 
@@ -179,8 +178,8 @@ function handleLogout() {
                 <th class="px-3 py-3 font-black">카테고리</th>
                 <th class="px-3 py-3 text-right font-black">총 실재고</th>
                 <th class="px-3 py-3 text-right font-black">총 가용재고</th>
-                <th class="px-3 py-3 text-right font-black">불균형 점수</th>
-                <th class="px-3 py-3 text-center font-black">상태</th>
+                <th class="px-3 py-3 text-right font-black">부족 창고 수</th>
+                <th class="px-3 py-3 text-right font-black">순부족 수량</th>
               </tr>
             </thead>
             <tbody class="divide-y divide-gray-100">
@@ -197,10 +196,8 @@ function handleLogout() {
                 <td class="px-3 py-3 font-bold text-gray-600">{{ row.category }}</td>
                 <td class="px-3 py-3 text-right font-black text-gray-900">{{ row.totalOnHand.toLocaleString() }}</td>
                 <td class="px-3 py-3 text-right font-black text-gray-900">{{ row.totalAvailable.toLocaleString() }}</td>
-                <td class="px-3 py-3 text-right font-black text-gray-900">{{ row.imbalanceScore.toLocaleString() }}</td>
-                <td class="px-3 py-3 text-center">
-                  <span class="inline-flex min-w-14 justify-center px-2 py-1 text-[11px] font-black" :class="statusClass(row.status)">{{ row.status }}</span>
-                </td>
+                <td class="px-3 py-3 text-right font-black text-gray-900">{{ row.shortageWarehouseCount.toLocaleString() }}개</td>
+                <td class="px-3 py-3 text-right font-black text-gray-900">{{ row.totalShortageQty.toLocaleString() }}개</td>
               </tr>
 
               <tr v-if="filteredSkuRows.length === 0">

--- a/src/views/hq/inventory/HqWarehouseInventoryComparisonView.vue
+++ b/src/views/hq/inventory/HqWarehouseInventoryComparisonView.vue
@@ -4,11 +4,13 @@ import { useRouter, useRoute } from 'vue-router'
 import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
+import { useWarehouseTransferCartStore } from '@/stores/hq/warehouseTransferCart.js'
 import { transferSkuCatalog, buildWarehouseRows, getImbalanceMetrics } from '@/constants/hqWarehouseTransferData.js'
 
 const router = useRouter()
 const route = useRoute()
 const auth = useAuthStore()
+const cartStore = useWarehouseTransferCartStore()
 const hqMenus = roleMenus.hq
 const inventoryMenus = roleMenus.hq.find(menu => menu.label === '재고 관리')?.children ?? []
 
@@ -104,8 +106,17 @@ function handleLogout() {
       <section class="border border-gray-200 bg-white p-4 shadow-sm">
         <div class="mb-4">
           <p class="text-[10px] font-black uppercase tracking-[0.18em] text-gray-400">Inventory</p>
-          <h1 class="mt-1 text-lg font-black text-gray-900">창고간 재고 이동</h1>
-          <p class="mt-1 text-xs font-bold text-gray-500">불균형 SKU를 우선 확인하고 상세에서 창고 간 이동을 실행합니다.</p>
+          <div class="mt-1 flex flex-wrap items-center justify-between gap-2">
+            <h1 class="text-lg font-black text-gray-900">창고간 재고 이동</h1>
+            <button
+              type="button"
+              class="h-8 border border-gray-300 px-3 text-[11px] font-black text-gray-700 transition hover:bg-gray-100"
+              @click="router.push({ name: 'hq-inventory-warehouse-transfer-history' })"
+            >
+              장바구니 {{ cartStore.lineCount }}건
+            </button>
+          </div>
+          <p class="mt-1 text-xs font-bold text-gray-500">불균형 SKU를 우선 확인하고 상세에서 장바구니를 구성해 이동을 실행합니다.</p>
         </div>
 
         <div class="grid gap-2 md:grid-cols-2 xl:grid-cols-[1.2fr_0.9fr_0.9fr_0.9fr_auto]">

--- a/src/views/hq/inventory/HqWarehouseSkuTransferDetailView.vue
+++ b/src/views/hq/inventory/HqWarehouseSkuTransferDetailView.vue
@@ -4,11 +4,13 @@ import { useRoute, useRouter } from 'vue-router'
 import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
+import { useWarehouseTransferCartStore } from '@/stores/hq/warehouseTransferCart.js'
 import { transferSkuCatalog, buildWarehouseRows } from '@/constants/hqWarehouseTransferData.js'
 
 const route = useRoute()
 const router = useRouter()
 const auth = useAuthStore()
+const cartStore = useWarehouseTransferCartStore()
 const hqMenus = roleMenus.hq
 const inventoryMenus = roleMenus.hq.find(menu => menu.label === '재고 관리')?.children ?? []
 
@@ -20,7 +22,9 @@ const transferQty = ref('')
 const transferReason = ref('재고 불균형 해소')
 const transferNote = ref('')
 const sheetOpen = ref(false)
+const cartDrawerOpen = ref(false)
 const toastMessage = ref('')
+const toastShowHistoryAction = ref(false)
 let toastTimer = null
 
 const selectedSku = computed(() => transferSkuCatalog.find(sku => sku.skuCode === route.params.skuCode) ?? null)
@@ -37,6 +41,8 @@ watch(selectedSku, (sku) => {
 
 const selectedWarehouses = computed(() => warehouseRows.value.filter(row => selectedWarehouseCodes.value.includes(row.warehouseCode)))
 const canTransfer = computed(() => selectedWarehouses.value.length === 2)
+const cartGroups = computed(() => cartStore.groupedByRoute)
+const cartLineCount = computed(() => cartStore.lineCount)
 
 const fromWarehouse = computed(() => {
   if (!canTransfer.value) return null
@@ -61,10 +67,10 @@ const transferValidationMessage = computed(() => {
   return ''
 })
 
-const canSubmitTransfer = computed(() => !transferValidationMessage.value)
+const canAddToCart = computed(() => !transferValidationMessage.value)
 
 const expectedStocks = computed(() => {
-  if (!canSubmitTransfer.value) return null
+  if (!canAddToCart.value) return null
   const qty = Number(transferQty.value)
 
   return {
@@ -98,37 +104,99 @@ const closeSheet = () => {
   sheetOpen.value = false
 }
 
-const submitTransfer = () => {
-  if (!canSubmitTransfer.value) return
+const openCartDrawer = () => {
+  cartDrawerOpen.value = true
+}
 
-  const qty = Number(transferQty.value)
-  const sourceWarehouseName = fromWarehouse.value?.warehouseName ?? ''
-  const targetWarehouseName = toWarehouse.value?.warehouseName ?? ''
-  const fromIndex = warehouseRows.value.findIndex(row => row.warehouseCode === fromWarehouse.value.warehouseCode)
-  const toIndex = warehouseRows.value.findIndex(row => row.warehouseCode === toWarehouse.value.warehouseCode)
+const closeCartDrawer = () => {
+  cartDrawerOpen.value = false
+}
 
-  if (fromIndex < 0 || toIndex < 0) return
-
-  warehouseRows.value[fromIndex].onHandStock -= qty
-  warehouseRows.value[fromIndex].availableStock -= qty
-  warehouseRows.value[toIndex].onHandStock += qty
-  warehouseRows.value[toIndex].availableStock += qty
-
+const resetTransferForm = () => {
   selectedWarehouseCodes.value = []
   transferQty.value = ''
   transferReason.value = '재고 불균형 해소'
   transferNote.value = ''
-  sheetOpen.value = false
-
-  showToast(`재고 이동 완료: ${sourceWarehouseName} → ${targetWarehouseName}`)
 }
 
-const showToast = (message) => {
+const addToCart = () => {
+  if (!canAddToCart.value || !selectedSku.value || !fromWarehouse.value || !toWarehouse.value) return
+
+  cartStore.addLine({
+    skuCode: selectedSku.value.skuCode,
+    itemName: selectedSku.value.itemName,
+    fromWarehouseCode: fromWarehouse.value.warehouseCode,
+    fromWarehouseName: fromWarehouse.value.warehouseName,
+    toWarehouseCode: toWarehouse.value.warehouseCode,
+    toWarehouseName: toWarehouse.value.warehouseName,
+    qty: Number(transferQty.value),
+    reason: transferReason.value,
+    memo: transferNote.value,
+  })
+
+  resetTransferForm()
+  sheetOpen.value = false
+  showToast('장바구니에 이동 항목을 추가했습니다.')
+}
+
+const applyTransferToRows = (line) => {
+  const fromIndex = warehouseRows.value.findIndex((row) => row.warehouseCode === line.fromWarehouseCode)
+  const toIndex = warehouseRows.value.findIndex((row) => row.warehouseCode === line.toWarehouseCode)
+
+  if (fromIndex < 0 || toIndex < 0) {
+    return { success: false, message: '현재 SKU 분포에 없는 창고 경로입니다.' }
+  }
+
+  const fromRow = warehouseRows.value[fromIndex]
+  const toRow = warehouseRows.value[toIndex]
+
+  if (line.qty > fromRow.availableStock) {
+    return { success: false, message: '출발 창고 가용재고가 부족합니다.' }
+  }
+
+  warehouseRows.value[fromIndex].onHandStock -= line.qty
+  warehouseRows.value[fromIndex].availableStock -= line.qty
+  warehouseRows.value[toIndex].onHandStock += line.qty
+  warehouseRows.value[toIndex].availableStock += line.qty
+
+  return { success: true }
+}
+
+const executeCartTransfers = async () => {
+  if (!cartLineCount.value) return
+
+  const result = await cartStore.executeAll(async (line) => applyTransferToRows(line))
+
+  if (result.failureCount === 0) {
+    showToast(`장바구니 실행 완료: ${result.successCount}건 처리됨`, true)
+    return
+  }
+
+  showToast(`부분 완료: 성공 ${result.successCount}건 / 실패 ${result.failureCount}건`)
+}
+
+const updateCartLineQty = (lineId, event) => {
+  const nextQty = Number(event.target.value)
+  if (!Number.isFinite(nextQty) || nextQty < 1) {
+    event.target.value = '1'
+    cartStore.updateLineQty(lineId, 1)
+    return
+  }
+  cartStore.updateLineQty(lineId, Math.trunc(nextQty))
+}
+
+const showToast = (message, showHistoryAction = false) => {
   toastMessage.value = message
+  toastShowHistoryAction.value = showHistoryAction
   if (toastTimer) clearTimeout(toastTimer)
   toastTimer = setTimeout(() => {
     toastMessage.value = ''
-  }, 2600)
+    toastShowHistoryAction.value = false
+  }, 3000)
+}
+
+const moveHistory = () => {
+  router.push({ name: 'hq-inventory-warehouse-transfer-history' })
 }
 
 const moveBack = () => {
@@ -163,7 +231,7 @@ function handleLogout() {
           <div>
             <p class="text-[10px] font-black uppercase tracking-[0.18em] text-gray-400">Inventory</p>
             <h1 class="mt-1 text-lg font-black text-gray-900">창고별 SKU 분포 상세</h1>
-            <p class="mt-1 text-xs font-bold text-gray-500">창고 2개를 선택한 뒤 하단 바에서 이동 정보를 입력하세요.</p>
+            <p class="mt-1 text-xs font-bold text-gray-500">창고 2개를 선택한 뒤 장바구니에 이동 항목을 담아 한 번에 실행하세요.</p>
           </div>
           <button type="button" class="h-9 border border-gray-300 px-4 text-xs font-black text-gray-700 hover:bg-gray-100" @click="moveBack">
             목록으로
@@ -253,6 +321,13 @@ function handleLogout() {
           </div>
           <button
             type="button"
+            class="flex h-10 shrink-0 items-center gap-1.5 border border-gray-300 px-4 text-xs font-black text-gray-700 transition hover:bg-gray-100"
+            @click="openCartDrawer"
+          >
+            장바구니 열기 ({{ cartLineCount }})
+          </button>
+          <button
+            type="button"
             class="ml-auto flex h-10 shrink-0 items-center gap-1.5 px-4 text-xs font-black transition"
             :class="canTransfer ? 'bg-[#004D3C] text-white hover:bg-[#00382c]' : 'cursor-not-allowed bg-gray-100 text-gray-400'"
             :disabled="!canTransfer"
@@ -272,7 +347,7 @@ function handleLogout() {
           <div class="w-full px-6 py-5 lg:px-8">
             <div class="mb-5 flex items-start justify-between gap-4 border-b border-gray-100 pb-4">
               <div>
-                <h2 class="text-base font-black text-gray-900">재고 이동 정보 입력</h2>
+                <h2 class="text-base font-black text-gray-900">장바구니 항목 입력</h2>
                 <p class="mt-1 text-[11px] font-bold text-gray-500">출발/도착 창고를 확인하고 이동 수량과 사유를 입력하세요.</p>
               </div>
               <button type="button" class="h-8 shrink-0 border border-gray-300 px-3 text-xs font-black text-gray-700 hover:bg-gray-100" @click="closeSheet">닫기</button>
@@ -358,14 +433,88 @@ function handleLogout() {
                   <button
                     type="button"
                     class="h-10 flex-1 px-4 text-xs font-black transition"
-                    :class="canSubmitTransfer ? 'bg-[#004D3C] text-white hover:bg-[#00382c]' : 'cursor-not-allowed bg-gray-100 text-gray-400'"
-                    :disabled="!canSubmitTransfer"
-                    @click="submitTransfer"
+                    :class="canAddToCart ? 'bg-[#004D3C] text-white hover:bg-[#00382c]' : 'cursor-not-allowed bg-gray-100 text-gray-400'"
+                    :disabled="!canAddToCart"
+                    @click="addToCart"
                   >
-                    재고 이동 실행
+                    장바구니 담기
                   </button>
                 </div>
               </div>
+            </div>
+          </div>
+        </section>
+      </div>
+
+      <div v-if="cartDrawerOpen" class="fixed inset-0 z-50">
+        <div class="absolute inset-0 bg-black/35" @click="closeCartDrawer" />
+        <section class="absolute right-0 top-0 h-full w-full max-w-[520px] overflow-y-auto border-l border-gray-200 bg-white shadow-2xl">
+          <div class="sticky top-0 z-10 border-b border-gray-100 bg-white px-5 py-4">
+            <div class="flex items-center justify-between gap-3">
+              <div>
+                <h2 class="text-base font-black text-gray-900">재고 이동 장바구니</h2>
+                <p class="mt-1 text-[11px] font-bold text-gray-500">총 {{ cartLineCount }}건</p>
+              </div>
+              <button type="button" class="h-8 border border-gray-300 px-3 text-xs font-black text-gray-700 hover:bg-gray-100" @click="closeCartDrawer">닫기</button>
+            </div>
+          </div>
+
+          <div class="space-y-4 p-5 pb-28">
+            <div v-if="cartLineCount === 0" class="border border-dashed border-gray-300 bg-gray-50 px-4 py-8 text-center text-xs font-bold text-gray-400">
+              장바구니가 비어 있습니다.
+            </div>
+
+            <article v-for="group in cartGroups" :key="group.routeKey" class="border border-gray-200 bg-white">
+              <header class="border-b border-gray-100 bg-gray-50 px-4 py-3">
+                <p class="text-xs font-black text-gray-900">{{ group.fromWarehouseName }} → {{ group.toWarehouseName }}</p>
+                <p class="mt-1 text-[11px] font-bold text-gray-500">{{ group.lines.length }}건 · 총 {{ group.totalQty.toLocaleString() }}개</p>
+              </header>
+
+              <div class="divide-y divide-gray-100">
+                <div v-for="line in group.lines" :key="line.lineId" class="space-y-2 px-4 py-3">
+                  <p class="text-[11px] font-black text-gray-800">{{ line.itemName }}</p>
+                  <p class="font-mono text-[11px] font-bold text-gray-500">{{ line.skuCode }}</p>
+                  <div class="flex items-center gap-2">
+                    <input
+                      :value="line.qty"
+                      type="number"
+                      min="1"
+                      class="h-8 w-24 border border-gray-300 px-2 text-xs font-black text-gray-900 outline-none focus:border-[#004D3C]"
+                      @change="updateCartLineQty(line.lineId, $event)"
+                    />
+                    <span class="text-[11px] font-bold text-gray-500">개</span>
+                    <button
+                      type="button"
+                      class="ml-auto h-8 border border-red-200 px-3 text-[11px] font-black text-red-600 hover:bg-red-50"
+                      @click="cartStore.removeLine(line.lineId)"
+                    >
+                      삭제
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </article>
+          </div>
+
+          <div class="fixed bottom-0 right-0 w-full max-w-[520px] border-t border-gray-200 bg-white px-5 py-3">
+            <div class="flex gap-2">
+              <button
+                type="button"
+                class="h-10 flex-1 border border-gray-300 px-4 text-xs font-black text-gray-700 hover:bg-gray-100"
+                :disabled="!cartLineCount"
+                @click="cartStore.clearAll()"
+              >
+                전체 비우기
+              </button>
+              <button
+                type="button"
+                class="h-10 flex-1 px-4 text-xs font-black transition"
+                :class="cartLineCount ? 'bg-[#004D3C] text-white hover:bg-[#00382c]' : 'cursor-not-allowed bg-gray-100 text-gray-400'"
+                :disabled="!cartLineCount"
+                @click="executeCartTransfers"
+              >
+                재고 이동 실행
+              </button>
             </div>
           </div>
         </section>
@@ -383,7 +532,15 @@ function handleLogout() {
       v-if="toastMessage"
       class="fixed bottom-20 right-5 z-50 border border-emerald-200 bg-emerald-50 px-4 py-2 text-xs font-black text-emerald-700 shadow-sm"
     >
-      {{ toastMessage }}
+      <p>{{ toastMessage }}</p>
+      <button
+        v-if="toastShowHistoryAction"
+        type="button"
+        class="mt-1 text-[11px] font-black text-emerald-800 underline"
+        @click="moveHistory"
+      >
+        이동내역 보기
+      </button>
     </div>
   </AppLayout>
 </template>

--- a/src/views/hq/inventory/HqWarehouseSkuTransferDetailView.vue
+++ b/src/views/hq/inventory/HqWarehouseSkuTransferDetailView.vue
@@ -21,6 +21,8 @@ const selectedWarehouseCodes = ref([])
 const transferQty = ref('')
 const transferReason = ref('재고 불균형 해소')
 const transferNote = ref('')
+const sortKey = ref('availableStock')
+const sortDirection = ref('desc')
 const sheetOpen = ref(false)
 const cartDrawerOpen = ref(false)
 const toastMessage = ref('')
@@ -36,8 +38,36 @@ watch(selectedSku, (sku) => {
   transferQty.value = ''
   transferReason.value = '재고 불균형 해소'
   transferNote.value = ''
+  sortKey.value = 'availableStock'
+  sortDirection.value = 'desc'
   sheetOpen.value = false
 }, { immediate: true })
+
+const statusWeight = {
+  품절: 3,
+  부족: 2,
+  정상: 1,
+}
+
+const sortedWarehouseRows = computed(() => {
+  const direction = sortDirection.value === 'desc' ? -1 : 1
+
+  return [...warehouseRows.value].sort((a, b) => {
+    let left = a[sortKey.value]
+    let right = b[sortKey.value]
+
+    if (sortKey.value === 'status') {
+      left = statusWeight[a.status] ?? 0
+      right = statusWeight[b.status] ?? 0
+    }
+
+    if (left !== right) {
+      return left > right ? direction * -1 : direction
+    }
+
+    return a.warehouseCode.localeCompare(b.warehouseCode)
+  })
+})
 
 const selectedWarehouses = computed(() => warehouseRows.value.filter(row => selectedWarehouseCodes.value.includes(row.warehouseCode)))
 const canTransfer = computed(() => selectedWarehouses.value.length === 2)
@@ -84,6 +114,21 @@ const statusClass = (status) => ({
   부족: 'bg-amber-50 text-amber-700',
   품절: 'bg-red-50 text-red-700',
 })[status] ?? 'bg-gray-100 text-gray-600'
+
+const toggleSort = (key) => {
+  if (sortKey.value !== key) {
+    sortKey.value = key
+    sortDirection.value = 'desc'
+    return
+  }
+
+  sortDirection.value = sortDirection.value === 'desc' ? 'asc' : 'desc'
+}
+
+const sortIndicator = (key) => {
+  if (sortKey.value !== key) return '△'
+  return sortDirection.value === 'desc' ? '▼' : '▲'
+}
 
 const toggleWarehouseSelection = (warehouseCode) => {
   if (selectedWarehouseCodes.value.includes(warehouseCode)) {
@@ -261,17 +306,37 @@ function handleLogout() {
                 <th class="px-3 py-3 font-black">창고 코드</th>
                 <th class="px-3 py-3 font-black">창고명</th>
                 <th class="px-3 py-3 font-black">위치</th>
-                <th class="px-3 py-3 text-right font-black">실재고</th>
-                <th class="px-3 py-3 text-right font-black">예약</th>
-                <th class="px-3 py-3 text-right font-black">가용</th>
+                <th class="px-3 py-3 text-right font-black">
+                  <button type="button" class="inline-flex items-center gap-1 hover:text-gray-700" @click="toggleSort('onHandStock')">
+                    실재고
+                    <span class="text-[10px]">{{ sortIndicator('onHandStock') }}</span>
+                  </button>
+                </th>
+                <th class="px-3 py-3 text-right font-black">
+                  <button type="button" class="inline-flex items-center gap-1 hover:text-gray-700" @click="toggleSort('reservedStock')">
+                    예약
+                    <span class="text-[10px]">{{ sortIndicator('reservedStock') }}</span>
+                  </button>
+                </th>
+                <th class="px-3 py-3 text-right font-black">
+                  <button type="button" class="inline-flex items-center gap-1 hover:text-gray-700" @click="toggleSort('availableStock')">
+                    가용
+                    <span class="text-[10px]">{{ sortIndicator('availableStock') }}</span>
+                  </button>
+                </th>
                 <th class="px-3 py-3 text-right font-black">안전재고</th>
-                <th class="px-3 py-3 text-center font-black">상태</th>
+                <th class="px-3 py-3 text-center font-black">
+                  <button type="button" class="inline-flex items-center gap-1 hover:text-gray-700" @click="toggleSort('status')">
+                    상태
+                    <span class="text-[10px]">{{ sortIndicator('status') }}</span>
+                  </button>
+                </th>
                 <th class="px-3 py-3 font-black">최종 업데이트</th>
               </tr>
             </thead>
             <tbody class="divide-y divide-gray-100">
               <tr
-                v-for="row in warehouseRows"
+                v-for="row in sortedWarehouseRows"
                 :key="row.warehouseCode"
                 class="cursor-pointer transition"
                 :class="selectedWarehouseCodes.includes(row.warehouseCode) ? 'bg-[#EBF5F5] font-bold' : 'hover:bg-[#EBF5F5]/60'"


### PR DESCRIPTION
## 📌 요약
- 본사 `창고간 재고 이동` 화면을 단건 실행 중심에서 장바구니 기반 다건 실행 흐름으로 개선했습니다.
- 이동 우선순위 판단 지표를 `부족 창고 수 / 순부족 수량` 중심으로 개편하고, 상세 테이블 정렬 UX 및 더미 데이터 품질을 함께 개선했습니다.

<br><br>

## 🎯 작업 내용
- `창고간 재고 이동 상세`에 장바구니 기능 추가
- `warehouseTransferCart` Pinia 스토어 추가 (라인 추가/수정/삭제/경로 그룹핑/일괄 실행)
- 기존 `재고 이동 실행`을 `장바구니 담기`로 전환, Drawer에서 그룹별 검토/실행 가능하도록 변경
- 실행 결과 토스트 및 `이동내역 보기` CTA 추가
- `창고간 재고 이동 목록` 지표 개편
- `불균형 점수` 제거, `부족 창고 수` 및 `순부족 수량` 기반 정렬/표시로 변경
- `옵션` 컬럼을 `색상`, `사이즈` 컬럼으로 분리
- `창고별 SKU 분포` 정렬 UX 개선
- `실재고/예약/가용/상태` 헤더 클릭 정렬(첫 클릭 desc, 재클릭 asc) 지원
- 상태 정렬 우선순위 적용(`품절 > 부족 > 정상`)
- 정렬 아이콘 통일(`▼/▲`, 비활성 `△`)
- 더미 데이터 확장 및 정합성 개선
- SKU 더미 추가, 창고를 4개 → 10개로 확장
- 자동 생성 로직 도입(누락 창고 데이터 보완)
- NaN 원인(`>>` 부호 시프트) 수정하여 수치 표시 안정화

<br><br>

## ✔️ 참고 사항
- 이번 변경은 프론트 중심 개선이며, 장바구니 일괄 실행은 현재 시뮬레이션 로직 기반입니다(백엔드 배치 API 미연동).

<br><br>

## ✔️ 관련 이슈

- Close #354

<br><br>
