### PR TITLE
refactor(circular-stock): 거래처 등록 폼 코드 입력 제거 (BE 자동 부여 연동)

### DIFF
--- a/src/stores/hq/circularStock/circularStockBuyers.js
+++ b/src/stores/hq/circularStock/circularStockBuyers.js
@@ -67,7 +67,6 @@ function fromApi(v) {
 
 function createEmptyBuyerForm() {
   return {
-    code: '',
     companyName: '',
     industryGroup: '',
     productTypes: [],
@@ -107,7 +106,6 @@ function materialFitLabel(value) {
 
 function normalizeBuyerPayload(payload) {
   return {
-    code: String(payload.code ?? '').trim(),
     companyName: String(payload.companyName ?? '').trim(),
     industryGroup: String(payload.industryGroup ?? '').trim(),
     productTypes: normalizeProductTypes(payload.productTypes),
@@ -119,24 +117,15 @@ function normalizeBuyerPayload(payload) {
   }
 }
 
-// FE 1차 검증 — BE 가 4001(REQUEST_ERROR) / 4401(DUPLICATE_CIRCULAR_BUYER_CODE) 로도 막지만 즉시 피드백 용도.
-function validateBuyerPayload(payload, existingBuyers, currentBuyerId = '') {
+// FE 1차 검증 — BE 가 4001(REQUEST_ERROR) 로도 막지만 즉시 피드백 용도. 거래처 코드는 BE 자동 부여라 검증 X.
+function validateBuyerPayload(payload) {
   const errors = {}
 
   if (!payload.companyName) errors.companyName = '업체명을 입력해주세요.'
-  if (!payload.code) errors.code = '거래처 코드를 입력해주세요.'
   if (!payload.industryGroup) errors.industryGroup = '산업군을 선택해주세요.'
   if (!payload.primaryMaterialFit) errors.primaryMaterialFit = '대표 소재 적합도를 선택해주세요.'
   if (!payload.managerName) errors.managerName = '담당자명을 입력해주세요.'
   if (!payload.phone) errors.phone = '연락처를 입력해주세요.'
-
-  const duplicateCode = existingBuyers.find(
-    (buyer) =>
-      buyer.code.toLowerCase() === payload.code.toLowerCase() && buyer.id !== currentBuyerId,
-  )
-  if (duplicateCode) {
-    errors.code = '이미 등록된 거래처 코드입니다.'
-  }
 
   return errors
 }
@@ -195,7 +184,7 @@ export const useCircularStockBuyerStore = defineStore('circularStockBuyers', () 
 
   async function createBuyer(payload) {
     const normalizedPayload = normalizeBuyerPayload(payload)
-    const errors = validateBuyerPayload(normalizedPayload, buyers.value)
+    const errors = validateBuyerPayload(normalizedPayload)
     if (Object.keys(errors).length > 0) {
       return { success: false, errors, message: '필수 입력값을 확인해주세요.' }
     }
@@ -217,15 +206,13 @@ export const useCircularStockBuyerStore = defineStore('circularStockBuyers', () 
     }
 
     const normalizedPayload = normalizeBuyerPayload(payload)
-    const errors = validateBuyerPayload(normalizedPayload, buyers.value, id)
+    const errors = validateBuyerPayload(normalizedPayload)
     if (Object.keys(errors).length > 0) {
       return { success: false, errors, message: '필수 입력값을 확인해주세요.' }
     }
 
     try {
-      // BE PATCH — code 는 path 에 있으니 body 에서 제외 (변경 불가).
-      const { code: _omit, ...updateBody } = normalizedPayload
-      const updated = await circularBuyerApi.update(currentBuyer.code, updateBody)
+      const updated = await circularBuyerApi.update(currentBuyer.code, normalizedPayload)
       const buyer = fromApi(updated)
       buyers.value = buyers.value.map((b) => (b.id === id ? buyer : b))
       return { success: true, buyer }

--- a/src/views/hq/circular-stock/HqCircularStockBuyerManagementView.vue
+++ b/src/views/hq/circular-stock/HqCircularStockBuyerManagementView.vue
@@ -72,7 +72,6 @@ function resetForm() {
 
 function fillFormFromBuyer(buyer) {
   form.value = {
-    code: buyer.code,
     companyName: buyer.companyName,
     industryGroup: buyer.industryGroup,
     productTypes: [...(buyer.productTypes ?? [])],
@@ -568,16 +567,14 @@ function handleLogout() {
                   }}</span>
                 </label>
 
-                <label class="flex flex-col gap-1.5">
+                <label v-if="panelMode === 'edit' && selectedBuyer" class="flex flex-col gap-1.5">
                   <span class="text-[11px] font-bold text-gray-500">거래처 코드</span>
                   <input
-                    v-model="form.code"
+                    :value="selectedBuyer.code"
                     type="text"
-                    class="h-11 border border-gray-300 bg-[#fafaf8] px-3 text-sm font-bold text-gray-900 outline-none focus:border-[#19352c] focus:bg-white"
+                    disabled
+                    class="h-11 cursor-not-allowed border border-gray-200 bg-gray-100 px-3 text-sm font-bold text-gray-500 outline-none"
                   />
-                  <span v-if="errors.code" class="text-[11px] font-bold text-red-500">{{
-                    errors.code
-                  }}</span>
                 </label>
               </section>
 


### PR DESCRIPTION
## 📌 요약
- BE 가 순환재고 거래처 코드를 `RCV-{NNN}` 으로 자동 부여하게 됨에 따라 FE 등록 폼에서 코드 입력 칸을 제거하고, 수정 모달에선 read-only 표시로 유지

<br><br>

## 🎯 작업 내용
- `HqCircularStockBuyerManagementView.vue` 등록 모드에서 거래처 코드 input 자체를 v-if 로 제거, 수정 모드에선 `selectedBuyer.code` 를 disabled input 으로 표시
- `fillFormFromBuyer` 의 `code` 라인 제거
- `circularStockBuyers.js` `createEmptyBuyerForm` / `normalizeBuyerPayload` 에서 `code` 키 제거
- `validateBuyerPayload` 의 코드 필수 검증 + 중복 검증 + `currentBuyerId` 인자 모두 삭제 (자동 부여라 의미 없음)
- `updateBuyer` 의 `{ code: _omit, ...updateBody }` destructure 정리 — payload 에 code 없어 그대로 전달

<br><br>

## ✔️ 참고 사항
- BE 변경(거래처 코드 자동 부여) 은 별도 PR (이슈 #174). 두 PR 함께 머지되어야 정상 동작
- `panelMode === 'edit'` 일 때만 거래처 코드 라벨 렌더 — 등록 모드에선 거래처 코드 자리가 빈 채로 grid 에 남는데, BE 자동 부여 메시지 안내가 필요해지면 후속에서 보강

<br><br>

## ✔️ 관련 이슈

- Close #376

<br><br>
