### PR TITLE
feat(circular-stock): 거래처 등록·수정 폼에 파트너 유형 선택 추가

### DIFF
--- a/src/stores/hq/circularStock/circularStockBuyers.js
+++ b/src/stores/hq/circularStock/circularStockBuyers.js
@@ -15,6 +15,14 @@ export const MATERIAL_FIT_OPTIONS = [
   { value: 'blended', label: '혼방' },
 ]
 
+// 사이클 2 — 파트너 유형 분류 데이터 (점수 가산 룰은 사이클 3 거래 이력 합류 후).
+export const PARTNER_TYPE_OPTIONS = [
+  { value: 'general', label: '일반' },
+  { value: 'local_small', label: '지역 소규모' },
+  { value: 'social_enterprise', label: '사회적기업' },
+]
+const PARTNER_TYPE_SET = new Set(PARTNER_TYPE_OPTIONS.map((o) => o.value))
+
 export const INDUSTRY_GROUP_OPTIONS = [
   '재생원사',
   '홈텍스타일',
@@ -60,6 +68,7 @@ function fromApi(v) {
     primaryMaterialFit: v.primaryMaterialFit,
     managerName: v.managerName,
     phone: v.phone,
+    partnerType: v.partnerType ?? 'general',
     createdAt: v.createdAt,
     updatedAt: v.updatedAt,
   }
@@ -75,6 +84,7 @@ function createEmptyBuyerForm() {
     primaryMaterialFit: '',
     managerName: '',
     phone: '',
+    partnerType: 'general',
   }
 }
 
@@ -104,7 +114,12 @@ function materialFitLabel(value) {
   return MATERIAL_FIT_OPTIONS.find((option) => option.value === value)?.label ?? '-'
 }
 
+function partnerTypeLabel(value) {
+  return PARTNER_TYPE_OPTIONS.find((option) => option.value === value)?.label ?? '-'
+}
+
 function normalizeBuyerPayload(payload) {
+  const partnerTypeRaw = String(payload.partnerType ?? 'general').trim()
   return {
     companyName: String(payload.companyName ?? '').trim(),
     industryGroup: String(payload.industryGroup ?? '').trim(),
@@ -114,6 +129,7 @@ function normalizeBuyerPayload(payload) {
     primaryMaterialFit: String(payload.primaryMaterialFit ?? '').trim(),
     managerName: String(payload.managerName ?? '').trim(),
     phone: String(payload.phone ?? '').trim(),
+    partnerType: partnerTypeRaw || 'general',
   }
 }
 
@@ -126,6 +142,9 @@ function validateBuyerPayload(payload) {
   if (!payload.primaryMaterialFit) errors.primaryMaterialFit = '대표 소재 적합도를 선택해주세요.'
   if (!payload.managerName) errors.managerName = '담당자명을 입력해주세요.'
   if (!payload.phone) errors.phone = '연락처를 입력해주세요.'
+  if (!PARTNER_TYPE_SET.has(payload.partnerType)) {
+    errors.partnerType = '파트너 유형을 선택해주세요.'
+  }
 
   return errors
 }
@@ -247,8 +266,10 @@ export const useCircularStockBuyerStore = defineStore('circularStockBuyers', () 
     error,
     MATERIAL_FIT_OPTIONS,
     INDUSTRY_GROUP_OPTIONS,
+    PARTNER_TYPE_OPTIONS,
     createEmptyBuyerForm,
     materialFitLabel,
+    partnerTypeLabel,
     getBuyerById,
     filteredBuyers,
     fetchAll,

--- a/src/views/hq/circular-stock/HqCircularStockBuyerManagementView.vue
+++ b/src/views/hq/circular-stock/HqCircularStockBuyerManagementView.vue
@@ -80,6 +80,7 @@ function fillFormFromBuyer(buyer) {
     primaryMaterialFit: buyer.primaryMaterialFit,
     managerName: buyer.managerName,
     phone: buyer.phone,
+    partnerType: buyer.partnerType ?? 'general',
   }
   productKeywordInput.value = ''
 }
@@ -134,10 +135,10 @@ function cancelEditMode() {
 }
 
 async function submitForm() {
-  const result =
-    panelMode.value === 'create'
-      ? await buyerStore.createBuyer(form.value)
-      : await buyerStore.updateBuyer(selectedBuyerId.value, form.value)
+  const isCreate = panelMode.value === 'create'
+  const result = isCreate
+    ? await buyerStore.createBuyer(form.value)
+    : await buyerStore.updateBuyer(selectedBuyerId.value, form.value)
 
   if (!result.success) {
     errors.value = result.errors ?? {}
@@ -147,11 +148,15 @@ async function submitForm() {
   }
 
   errors.value = {}
-  toastMessage.value =
-    panelMode.value === 'create'
-      ? '순환재고 거래처를 등록했습니다.'
-      : '순환재고 거래처 정보를 수정했습니다.'
+  toastMessage.value = isCreate
+    ? '순환재고 거래처를 등록했습니다.'
+    : '순환재고 거래처 정보를 수정했습니다.'
   toastTone.value = 'success'
+  // 등록 직후 좌측 리스트에서 새 거래처가 보이도록 검색어·필터 초기화.
+  if (isCreate) {
+    searchKeyword.value = ''
+    materialFitFilter.value = ''
+  }
   handleSelectBuyer(result.buyer.id)
 }
 
@@ -159,6 +164,12 @@ function materialFitBadgeClass(value) {
   if (value === 'natural-single') return 'bg-[#e5f4ec] text-[#1b6a47]'
   if (value === 'synthetic') return 'bg-[#e7eefb] text-[#2f578f]'
   if (value === 'blended') return 'bg-[#f9eadb] text-[#9b5d1b]'
+  return 'bg-gray-100 text-gray-500'
+}
+
+function partnerTypeBadgeClass(value) {
+  if (value === 'local_small') return 'bg-[#fef3c7] text-[#92400e]'
+  if (value === 'social_enterprise') return 'bg-[#ede9fe] text-[#5b21b6]'
   return 'bg-gray-100 text-gray-500'
 }
 
@@ -478,7 +489,7 @@ function handleLogout() {
               </button>
             </div>
 
-            <section class="grid gap-3 md:grid-cols-3">
+            <section class="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
               <div class="border border-[#e5ece8] bg-white px-3 py-3">
                 <p class="text-[11px] font-black text-gray-400">거래처 코드</p>
                 <p class="mt-1 text-sm font-black text-gray-900">{{ selectedBuyer.code }}</p>
@@ -493,6 +504,15 @@ function handleLogout() {
                 <p class="text-[11px] font-black text-gray-400">담당자 / 연락처</p>
                 <p class="mt-1 text-sm font-black text-gray-900">{{ selectedBuyer.managerName }}</p>
                 <p class="mt-1 text-sm font-bold text-gray-600">{{ selectedBuyer.phone }}</p>
+              </div>
+              <div class="border border-[#e5ece8] bg-white px-3 py-3">
+                <p class="text-[11px] font-black text-gray-400">파트너 유형</p>
+                <span
+                  class="mt-1 inline-flex w-fit px-2.5 py-1 text-[10px] font-black"
+                  :class="partnerTypeBadgeClass(selectedBuyer.partnerType)"
+                >
+                  {{ buyerStore.partnerTypeLabel(selectedBuyer.partnerType) }}
+                </span>
               </div>
             </section>
 
@@ -619,6 +639,27 @@ function handleLogout() {
                     class="text-[11px] font-bold text-red-500"
                     >{{ errors.primaryMaterialFit }}</span
                   >
+                </label>
+              </section>
+
+              <section class="grid gap-4 md:grid-cols-2">
+                <label class="flex flex-col gap-1.5">
+                  <span class="text-[11px] font-bold text-gray-500">파트너 유형</span>
+                  <select
+                    v-model="form.partnerType"
+                    class="h-11 border border-gray-300 bg-[#fafaf8] px-3 text-sm font-bold text-gray-900 outline-none focus:border-[#19352c] focus:bg-white"
+                  >
+                    <option
+                      v-for="option in buyerStore.PARTNER_TYPE_OPTIONS"
+                      :key="option.value"
+                      :value="option.value"
+                    >
+                      {{ option.label }}
+                    </option>
+                  </select>
+                  <span v-if="errors.partnerType" class="text-[11px] font-bold text-red-500">{{
+                    errors.partnerType
+                  }}</span>
                 </label>
               </section>
 


### PR DESCRIPTION
## 📌 요약
- 순환재고 거래처 등록·수정 폼에 파트너 유형(`partnerType`) selectbox 를 추가하고 디테일 패널에 뱃지로 노출. 등록 직후 좌측 리스트에서 새 거래처가 누락되는 UX 결함도 함께 수정

<br><br>

## 🎯 작업 내용
- `circularStockBuyers.js` `PARTNER_TYPE_OPTIONS` 상수 + `partnerTypeLabel` 헬퍼 추가, `fromApi`/`createEmptyBuyerForm`/`normalizeBuyerPayload`/`validateBuyerPayload` 에 `partnerType` 추가 (기본값 `general`)
- `HqCircularStockBuyerManagementView.vue` 등록·수정 폼 grid 에 파트너 유형 select 추가, `fillFormFromBuyer` 매핑 추가
- 디테일 패널 카드 영역을 3-cols → 4-cols 로 확장하고 파트너 유형 뱃지 카드 추가 — `partnerTypeBadgeClass` (앰버/보라/회색) 헬퍼로 색상 매핑
- 좌측 카드 리스트는 변경 없음 (소재 적합도 뱃지와 시각 혼잡 방지, 사이클 3 점수 뱃지 도입 시 함께 정리)
- 등록 성공 시 검색어 + 소재 적합도 필터 자동 초기화 — 등록 직전 활성화돼 있던 필터 때문에 새 거래처가 좌측에서 빠지는 문제 해결

<br><br>

## ✔️ 참고 사항
- BE 변경(`partner_type` 컬럼 + DTO + 검증) 은 별도 PR (이슈 #176). 두 PR 함께 머지되어야 정상 동작
- 점수 가산 룰은 거래 이력 도메인 합류 후 사이클 3에서

<br><br>

## ✔️ 관련 이슈

- Close #378

<br><br>
