### PR TITLE
fix(warehouse-inbound): 발주 상세 품목에 SKU 옵션(색/사이즈) 표시 추가

### DIFF
--- a/src/views/warehouse/inbound/WarehouseInboundView.vue
+++ b/src/views/warehouse/inbound/WarehouseInboundView.vue
@@ -470,7 +470,15 @@ const CheckIcon = IconBase([{ tag: 'polyline', attrs: { points: '20 6 9 17 4 12'
                 </thead>
                 <tbody class="divide-y divide-gray-100">
                   <tr v-for="item in inbound.selectedOrder.items" :key="item.id">
-                    <td class="px-2 py-2 font-bold text-gray-800">{{ item.productName }}</td>
+                    <td class="px-2 py-2 font-bold text-gray-800">
+                      <div>{{ item.productName }}</div>
+                      <div
+                        v-if="item.displayOption"
+                        class="mt-0.5 text-[10px] font-bold text-[#004D3C]"
+                      >
+                        {{ item.displayOption }}
+                      </div>
+                    </td>
                     <td class="px-2 py-2 text-right font-bold text-gray-700">
                       {{ item.quantity }}
                     </td>


### PR DESCRIPTION
## 📌 요약
- 창고 입고 화면 발주 상세 패널 품목 테이블이 마스터 제품명만 표시해 같은 마스터의 다른 SKU 끼리 구분 안 되던 문제 수정

<br><br>

## 🎯 작업 내용
- `WarehouseInboundView.vue` 우측 상세 패널 품목 테이블의 제품명 셀에 `item.displayOption` (색/사이즈) 작은 줄 추가
- 본사 발주 화면(`HqPurchaseOrderView.vue` 567-569) 의 SKU 표시 패턴과 동일하게 통일 — productName 아래에 `text-[10px] text-[#004D3C]` 작은 라벨

<br><br>

## ✔️ 참고 사항
- BE/store 매핑은 이미 SKU 단위로 들어와 있던 상태 (`PurchaseOrderItem.skuCode/color/size/displayOption`). view 렌더링만 누락이었음
- 모달의 "입고 후 재고 변화 미리보기" 는 `warehouseStock.getInboundPreview` 가 row 매핑 시 `displayOption` 미박음 — 본인 영역 외라 이번 PR 에서는 미포함

<br><br>

## ✔️ 관련 이슈

- 

<br><br>
