### PR TITLE
feat: Refresh Token BE 연동

### DIFF
--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -5,7 +5,7 @@ import axios from 'axios'
 // /api/** 를 BE(8080) 로 리버스 프록시. 운영 빌드는 동일 origin 또는 별도 게이트웨이.
 // VITE_API_BASE 환경변수로 override 가능 (다른 BE 호스트 가리킬 때).
 //
-// withCredentials: true — HttpOnly Cookie(Atoken) 자동 송수신.
+// withCredentials: true — HttpOnly Cookie(Atoken/Rtoken) 자동 송수신.
 // JWT는 BE의 LoginSuccessHandler 가 Set-Cookie 로 내려주고,
 // 이후 모든 요청에서 브라우저가 자동으로 동봉. JS에서 토큰 직접 접근 불가(XSS 방어).
 export const apiClient = axios.create({
@@ -14,21 +14,93 @@ export const apiClient = axios.create({
   withCredentials: true,
 })
 
+const REFRESH_URL = '/api/user/refresh'
+const LOGIN_PATHS = ['/login', '/dev-login', '/signup']
+const USER_STORAGE_KEY = 'stockit_user'
+
 /**
- * 응답 인터셉터: 401 응답 시 인증 만료/무효로 간주하고 로그인 페이지로 이동.
- * 쿠키는 BE 측에서 만료되거나 JwtAuthFilter 가 SecurityContext 설정 실패 시 401 반환.
+ * 인증 만료 시 호출 — 클라이언트 측 잔여 사용자 정보를 정리하고 로그인 페이지로 이동.
+ * authStore 직접 import 시 순환 의존이 생기므로 localStorage 만 정리한다.
+ */
+function forceLogout() {
+  try {
+    localStorage.removeItem(USER_STORAGE_KEY)
+    sessionStorage.removeItem('stockit:openTopMenus')
+  } catch {
+    // storage 접근 실패해도 라우팅은 진행
+  }
+  const path = window.location.pathname
+  if (!LOGIN_PATHS.some(p => path.includes(p))) {
+    window.location.href = '/login'
+  }
+}
+
+/**
+ * 동시 다발 401 요청에서 refresh 가 한 번만 호출되도록 단일 promise 공유.
+ * refresh 가 진행 중이면 후속 401 요청들은 같은 promise 를 await 한 뒤
+ * 각자 원본 요청을 재시도한다.
+ */
+let refreshPromise = null
+
+function callRefresh() {
+  if (!refreshPromise) {
+    refreshPromise = apiClient
+      .post(REFRESH_URL)
+      .finally(() => { refreshPromise = null })
+  }
+  return refreshPromise
+}
+
+/**
+ * 응답 인터셉터 — Refresh Token 자동 갱신.
+ *
+ * 흐름:
+ *   1) 정상 응답: 그대로 반환
+ *   2) 401 + 재시도 안 한 요청 + /refresh 자체 호출이 아님
+ *      → /api/user/refresh 호출 (Rtoken 쿠키로 새 Atoken 발급)
+ *      → 성공 시 원본 요청 재시도
+ *      → 실패 시 forceLogout (잔여 정보 정리 + /login 이동)
+ *   3) 그 외(이미 재시도한 401, /refresh 자체 401, 다른 에러)
+ *      → 401 이면 forceLogout, 나머지는 그대로 reject
+ *
+ * 무한 루프 방지:
+ *   - originalRequest._retry 플래그로 동일 요청 두 번째 401 차단
+ *   - /api/user/refresh 자체에서 401 발생 시 재시도하지 않음
  */
 apiClient.interceptors.response.use(
   (response) => response,
-  (error) => {
-    if (error?.response?.status === 401) {
-      // 무한 리다이렉트 방지 (/login, /dev-login, /signup 페이지에선 그대로)
-      const path = window.location.pathname
-      if (!path.includes('/login') && !path.includes('/signup')) {
-        window.location.href = '/login'
-      }
+  async (error) => {
+    const originalRequest = error?.config
+    const status = error?.response?.status
+
+    // 401 이 아니거나 config 가 없으면 그대로 전파
+    if (status !== 401 || !originalRequest) {
+      return Promise.reject(error)
     }
-    return Promise.reject(error)
+
+    // /refresh 자체에서 401 이면 즉시 강제 로그아웃 (무한 루프 차단)
+    if (originalRequest.url?.includes(REFRESH_URL)) {
+      forceLogout()
+      return Promise.reject(error)
+    }
+
+    // 이미 재시도한 요청이 또 401 이면 더 이상 시도하지 않음
+    if (originalRequest._retry) {
+      forceLogout()
+      return Promise.reject(error)
+    }
+
+    originalRequest._retry = true
+
+    try {
+      await callRefresh()
+      // refresh 성공 → 새 Atoken 쿠키로 원본 요청 재시도
+      return apiClient(originalRequest)
+    } catch (refreshErr) {
+      // refresh 실패 → 강제 로그아웃
+      forceLogout()
+      return Promise.reject(refreshErr)
+    }
   },
 )
 
@@ -49,4 +121,41 @@ export function unwrap(res) {
     throw new Error(msg)
   }
   return body.result
+}
+
+/**
+ * Axios 에러에서 사용자 표시용 한글 메시지 추출.
+ * 우선순위:
+ *   1) BE BaseResponse 의 message (4xx 응답에 포함된 한글)
+ *   2) HTTP 상태 코드별 기본 한글 메시지
+ *   3) 네트워크 단절 / 타임아웃 메시지
+ *   4) 폴백 일반 메시지
+ *
+ * @param {unknown} err - axios 또는 일반 Error
+ * @param {string} [fallback] - 위 분류에 안 잡혔을 때 표시할 메시지
+ * @returns {string}
+ */
+export function extractErrorMessage(err, fallback = '요청 처리 중 오류가 발생했습니다.') {
+  // 1) BE BaseResponse 의 한글 메시지
+  const beMessage = err?.response?.data?.message
+  if (beMessage) return beMessage
+
+  // 2) HTTP 상태 코드별 기본 메시지
+  const status = err?.response?.status
+  if (status) {
+    if (status === 400) return '요청 형식이 올바르지 않습니다.'
+    if (status === 401) return '인증이 필요합니다.'
+    if (status === 403) return '접근 권한이 없습니다.'
+    if (status === 404) return '요청한 자원을 찾을 수 없습니다.'
+    if (status === 408) return '요청 시간이 초과되었습니다.'
+    if (status === 409) return '요청이 충돌했습니다. 잠시 후 다시 시도해주세요.'
+    if (status >= 500) return '서버에서 오류가 발생했습니다. 잠시 후 다시 시도해주세요.'
+  }
+
+  // 3) 네트워크 단절 / 타임아웃 (response 없음)
+  if (err?.code === 'ECONNABORTED') return '응답 시간이 초과되었습니다. 네트워크 상태를 확인해주세요.'
+  if (err?.code === 'ERR_NETWORK' || !err?.response) return '서버에 연결할 수 없습니다. 네트워크 상태를 확인해주세요.'
+
+  // 4) 폴백
+  return fallback
 }

--- a/src/api/hq/account.js
+++ b/src/api/hq/account.js
@@ -6,6 +6,7 @@
  *   GET    /api/hq/account/pending                   (대기 회원 목록, HQ)
  *   POST   /api/hq/account/{id}/approve              (가입 승인, HQ)
  *   POST   /api/hq/account/{id}/reject               (가입 거절, HQ)
+ *   POST   /api/hq/account/{id}/withdraw             (탈퇴 처리, HQ)
  *
  * 응답: BaseResponse<T>. unwrap() 으로 result 만 추출.
  *
@@ -15,7 +16,7 @@
 import { apiClient, unwrap } from '../axios.js'
 
 export const accountApi = {
-  /** 전체 회원 목록 조회 (PENDING/APPROVED/REJECTED) */
+  /** 전체 회원 목록 조회 (PENDING/APPROVED/REJECTED/WITHDRAWN) */
   listAll: () => apiClient.get('/api/hq/account').then(unwrap),
 
   /** 대기 회원 목록 조회 */
@@ -26,4 +27,11 @@ export const accountApi = {
 
   /** 가입 신청 거절 */
   reject: (id) => apiClient.post(`/api/hq/account/${id}/reject`).then(unwrap),
+
+  /**
+   * 본사 관리자가 사용자 계정을 탈퇴 처리.
+   * 승인된(APPROVED) 사용자만 탈퇴 가능.
+   * BE 가 RefreshToken 모두 삭제 → 즉시 강제 로그아웃 효과.
+   */
+  withdraw: (id) => apiClient.post(`/api/hq/account/${id}/withdraw`).then(unwrap),
 }

--- a/src/api/user/auth.js
+++ b/src/api/user/auth.js
@@ -2,8 +2,9 @@
  * auth.js — 인증 BE 연동
  *
  * BE 엔드포인트:
- *   POST /api/user/login   — 사원코드/비밀번호 인증 → JWT 발급 (HttpOnly Cookie)
- *   POST /api/user/logout  — Atoken 쿠키 즉시 만료
+ *   POST /api/user/login    — 사원코드/비밀번호 인증 → Atoken/Rtoken 쿠키 발급
+ *   POST /api/user/refresh  — Rtoken 쿠키로 새 Atoken 발급 (Phase 4 자동 갱신)
+ *   POST /api/user/logout   — Atoken/Rtoken 쿠키 즉시 만료 + DB 의 Rtoken 삭제
  *
  * BE 로그인 응답 (BaseResponse<LoginRes>):
  *   result = {
@@ -12,6 +13,9 @@
  *     role: "HQ" | "STORE" | "WAREHOUSE"   // 대문자
  *   }
  *   // 토큰은 Body 가 아닌 Set-Cookie 헤더로 내려옴 (HttpOnly)
+ *
+ * NOTE: refresh 는 axios 인터셉터(axios.js)에서 401 발생 시 자동 호출되며,
+ *       명시적 수동 호출이 필요한 케이스(예: 진단/테스트)에 한해 authApi.refresh() 사용.
  */
 
 import { apiClient, unwrap } from '../axios.js'
@@ -25,7 +29,13 @@ export const authApi = {
   login: (req) => apiClient.post('/api/user/login', req).then(unwrap),
 
   /**
-   * 로그아웃 — BE가 Atoken 쿠키 즉시 만료시킴.
+   * Access Token 수동 재발급. 일반적으로는 axios 인터셉터가 자동 호출하므로
+   * 직접 사용할 일은 없음. result 는 null (BE 가 쿠키로만 응답).
+   */
+  refresh: () => apiClient.post('/api/user/refresh').then(unwrap),
+
+  /**
+   * 로그아웃 — BE가 Atoken/Rtoken 쿠키 즉시 만료 + DB Rtoken 삭제.
    */
   logout: () => apiClient.post('/api/user/logout').then(unwrap),
 }

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import { roleHomeMap } from '@/config/roleMenus.js'
 import { authApi } from '@/api/user/auth.js'
+import { extractErrorMessage } from '@/api/axios.js'
 
 // HttpOnly Cookie 방식이라 토큰은 JS에서 접근 불가.
 // localStorage 에는 사용자 정보(UI 표시용)만 저장.
@@ -92,7 +93,7 @@ export const useAuthStore = defineStore('auth', () => {
     } catch (err) {
       return {
         success: false,
-        message: err?.message ?? '사원번호 또는 비밀번호가 올바르지 않습니다.',
+        message: extractErrorMessage(err, '사원번호 또는 비밀번호가 올바르지 않습니다.'),
       }
     }
   }

--- a/src/views/hq/account/AccountListView.vue
+++ b/src/views/hq/account/AccountListView.vue
@@ -1,24 +1,23 @@
 <script setup>
-import { ref, computed, reactive } from 'vue'
+import { ref, computed, reactive, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import {
   Users,
   Search,
   RotateCcw,
   X,
-  Pencil,
-  Save,
   AlertCircle,
   CheckCircle2,
   LogOut,
-  ShieldAlert,
+  Building2,
   Store,
   Warehouse,
-  Crown,
 } from 'lucide-vue-next'
 import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
+import { accountApi } from '@/api/hq/account.js'
+import { extractErrorMessage } from '@/api/axios.js'
 
 const router = useRouter()
 const auth = useAuthStore()
@@ -36,48 +35,105 @@ function handleLogout() {
   router.push('/login')
 }
 
-// ── 목업 데이터
-const members = ref([
-  { id: 'MB-001', name: '이민준', email: 'minjun@stockit.com', phone: '010-1234-5678', birthdate: '1990-03-15', role: 'STORE_OWNER', position: '점장', storeCode: 'ST003', storeName: '판교 테크노점', contractStart: '2026-01-01', contractEnd: '2027-01-01', joinedAt: '2026-01-03', active: true },
-  { id: 'MB-002', name: '박지수', email: 'jisoo@stockit.com', phone: '010-9876-5432', birthdate: '1988-11-02', role: 'WAREHOUSE', position: '창고 책임자', storeCode: 'ST005', storeName: '인천 제1물류센터', contractStart: '2026-02-01', contractEnd: '2027-02-01', joinedAt: '2026-02-04', active: true },
-  { id: 'MB-003', name: '김도현', email: 'dohyun@stockit.com', phone: '010-5555-1234', birthdate: '1992-07-28', role: 'STORE_OWNER', position: '점장', storeCode: 'ST002', storeName: '성수 직영점', contractStart: '2026-01-15', contractEnd: '2027-01-15', joinedAt: '2026-01-17', active: true },
-  { id: 'MB-004', name: '최수연', email: 'sooyeon@stockit.com', phone: '010-3333-7890', birthdate: '1985-05-19', role: 'STORE_OWNER', position: '부점장', storeCode: 'ST007', storeName: '부산 중앙창고', contractStart: '2025-06-01', contractEnd: '2026-06-01', joinedAt: '2025-06-03', active: false },
-  { id: 'MB-005', name: '이선엽', email: 'sunyeop@stockit.com', phone: '010-2222-3333', birthdate: '1991-09-11', role: 'MASTER', position: '중앙관리자', storeCode: '—', storeName: '본사', contractStart: '2024-01-01', contractEnd: '2026-12-31', joinedAt: '2024-01-02', active: true },
-  { id: 'MB-006', name: '박범수', email: 'bumsoo@stockit.com', phone: '010-4444-5555', birthdate: '1987-02-23', role: 'WAREHOUSE', position: '창고 책임자', storeCode: 'ST001', storeName: '강남 서초점', contractStart: '2026-03-01', contractEnd: '2027-03-01', joinedAt: '2026-03-02', active: true },
-])
+// ── BE 응답 매핑 (HQ/STORE/WAREHOUSE)
+const roleLabel = (r) => ({
+  HQ: '본사 관리자',
+  STORE: '매장 관리자',
+  WAREHOUSE: '물류 창고 관리자',
+})[r] ?? r
+
+const roleStyle = (r) => ({
+  HQ:        'bg-[#eef7f4] text-[#004D3C] border border-[#cfe2dc]',
+  STORE:     'bg-blue-50 text-blue-700 border border-blue-200',
+  WAREHOUSE: 'bg-purple-50 text-purple-700 border border-purple-200',
+})[r] ?? 'bg-gray-100 text-gray-600'
+
+const roleIcon = (r) => ({
+  HQ: Building2,
+  STORE: Store,
+  WAREHOUSE: Warehouse,
+})[r] ?? Users
+
+const statusLabel = (s) => ({
+  PENDING: '승인 대기',
+  APPROVED: '활성',
+  REJECTED: '거절됨',
+  WITHDRAWN: '탈퇴',
+})[s] ?? s
+
+const statusStyle = (s) => ({
+  PENDING:   'bg-amber-50 text-amber-700 border border-amber-200',
+  APPROVED:  'bg-emerald-50 text-emerald-700 border border-emerald-200',
+  REJECTED:  'bg-red-50 text-red-700 border border-red-200',
+  WITHDRAWN: 'bg-gray-100 text-gray-500 border border-gray-300',
+})[s] ?? 'bg-gray-100 text-gray-600'
+
+/** ISO → 'YYYY-MM-DD HH:mm' */
+const formatDateTime = (iso) => {
+  if (!iso) return '-'
+  const d = new Date(iso)
+  if (isNaN(d.getTime())) return iso
+  const pad = (n) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+// ── BE 회원 목록 (활성 + 탈퇴만 표시 — 승인 대기/거절은 회원가입 승인 페이지에서 처리)
+const VISIBLE_STATUSES = ['APPROVED', 'WITHDRAWN']
+
+const members = ref([])
+const loading = ref(false)
+const loadError = ref('')
+
+async function loadAccounts() {
+  loading.value = true
+  loadError.value = ''
+  try {
+    const list = await accountApi.listAll()
+    // PENDING / REJECTED 제외
+    members.value = list.filter(m => VISIBLE_STATUSES.includes(m.status))
+  } catch (err) {
+    loadError.value = extractErrorMessage(err, '계정 목록을 불러오지 못했습니다.')
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(() => loadAccounts())
+
+// ── 통계 (활성 / 탈퇴만)
+const stats = computed(() => {
+  const total = members.value.length
+  const approved = members.value.filter(m => m.status === 'APPROVED').length
+  const withdrawn = members.value.filter(m => m.status === 'WITHDRAWN').length
+  return { total, approved, withdrawn }
+})
 
 // ── 필터
-const filter = reactive({ email: '', role: '', active: '' })
+const filter = reactive({ keyword: '', role: '', status: '' })
 const PAGE_SIZE = 10
 const currentPage = ref(1)
 
 const roleOptions = [
   { value: '', label: '전체 권한' },
-  { value: 'STORE_OWNER', label: '직영점 점주' },
+  { value: 'HQ', label: '본사 관리자' },
+  { value: 'STORE', label: '매장 관리자' },
   { value: 'WAREHOUSE', label: '물류 창고 관리자' },
-  { value: 'MASTER', label: '마스터' },
 ]
-const activeOptions = [
+const statusOptions = [
   { value: '', label: '전체 상태' },
-  { value: 'true', label: '활성' },
-  { value: 'false', label: '비활성 (탈퇴)' },
+  { value: 'APPROVED', label: '활성' },
+  { value: 'WITHDRAWN', label: '탈퇴' },
 ]
-
-const roleLabel = (r) => ({ STORE_OWNER: '직영점 점주', WAREHOUSE: '물류 창고 관리자', MASTER: '마스터' })[r] ?? r
-
-const roleStyle = (r) => ({
-  STORE_OWNER: 'bg-blue-50 text-blue-700 border border-blue-200',
-  WAREHOUSE:   'bg-purple-50 text-purple-700 border border-purple-200',
-  MASTER:      'bg-[#eef7f4] text-[#004D3C] border border-[#cfe2dc]',
-})[r] ?? 'bg-gray-100 text-gray-600'
-
-const roleIcon = (r) => ({ STORE_OWNER: Store, WAREHOUSE: Warehouse, MASTER: Crown })[r] ?? Users
 
 const filtered = computed(() =>
   members.value.filter(m => {
-    if (filter.email && !m.email.includes(filter.email.trim())) return false
+    if (filter.keyword) {
+      const kw = filter.keyword.trim().toLowerCase()
+      const haystack = `${m.name ?? ''} ${m.email ?? ''} ${m.employeeCode ?? ''}`.toLowerCase()
+      if (!haystack.includes(kw)) return false
+    }
     if (filter.role && m.role !== filter.role) return false
-    if (filter.active !== '' && m.active !== (filter.active === 'true')) return false
+    if (filter.status && m.status !== filter.status) return false
     return true
   })
 )
@@ -90,66 +146,48 @@ const paginated = computed(() => {
 })
 
 function resetFilter() {
-  filter.email = ''
+  filter.keyword = ''
   filter.role = ''
-  filter.active = ''
+  filter.status = ''
   currentPage.value = 1
 }
 
 // ── 상세 패널
 const selected = ref(null)
-const isEditing = ref(false)
-const editForm = reactive({ role: '', position: '', active: true })
-const editErrors = reactive({ position: '' })
 const withdrawConfirm = ref(false)
-const saveSuccess = ref(false)
+const withdrawing = ref(false)
+const actionMessage = ref('')   // 성공 메시지
 
 function openDetail(member) {
   selected.value = member
-  isEditing.value = false
   withdrawConfirm.value = false
-  saveSuccess.value = false
-  Object.assign(editForm, { role: member.role, position: member.position, active: member.active })
+  actionMessage.value = ''
 }
 
 function closeDetail() {
   selected.value = null
-  isEditing.value = false
   withdrawConfirm.value = false
-  saveSuccess.value = false
+  actionMessage.value = ''
 }
 
-function startEdit() {
-  isEditing.value = true
-  saveSuccess.value = false
-  editErrors.position = ''
-  Object.assign(editForm, { role: selected.value.role, position: selected.value.position, active: selected.value.active })
-}
-
-function cancelEdit() {
-  isEditing.value = false
-  editErrors.position = ''
-}
-
-function saveEdit() {
-  editErrors.position = ''
-  if (!editForm.position.trim()) {
-    editErrors.position = '직책을 입력해주세요.'
-    return
+/** 탈퇴 처리 — BE 호출 후 목록 갱신 */
+async function confirmWithdraw() {
+  if (!selected.value || withdrawing.value) return
+  withdrawing.value = true
+  try {
+    const result = await accountApi.withdraw(selected.value.id)
+    actionMessage.value = `${result.name} 님이 탈퇴 처리되었습니다.`
+    // 로컬 상태 갱신
+    selected.value.status = 'WITHDRAWN'
+    selected.value.processedAt = result.processedAt
+    // 목록 재조회
+    await loadAccounts()
+    withdrawConfirm.value = false
+  } catch (err) {
+    alert(extractErrorMessage(err, '탈퇴 처리에 실패했습니다.'))
+  } finally {
+    withdrawing.value = false
   }
-  selected.value.role = editForm.role
-  selected.value.position = editForm.position
-  selected.value.active = editForm.active
-  isEditing.value = false
-  saveSuccess.value = true
-}
-
-function confirmWithdraw() {
-  if (!selected.value) return
-  selected.value.active = false
-  editForm.active = false
-  withdrawConfirm.value = false
-  saveSuccess.value = false
 }
 </script>
 
@@ -171,13 +209,13 @@ function confirmWithdraw() {
         </h2>
         <div class="flex items-center gap-2">
           <div class="inline-flex items-center gap-1.5 border border-gray-200 bg-gray-50 px-2 py-1 text-[11px] font-medium text-gray-500">
-            전체 <span class="font-bold text-gray-800">{{ members.length }}</span>명
+            전체 <span class="font-bold text-gray-800">{{ stats.total }}</span>명
           </div>
           <div class="inline-flex items-center gap-1.5 border border-emerald-200 bg-emerald-50 px-2 py-1 text-[11px] font-medium text-emerald-700">
-            활성 <span class="font-bold">{{ members.filter(m => m.active).length }}</span>
+            활성 <span class="font-bold">{{ stats.approved }}</span>
           </div>
           <div class="inline-flex items-center gap-1.5 border border-gray-200 bg-gray-50 px-2 py-1 text-[11px] font-medium text-gray-400">
-            비활성 <span class="font-bold">{{ members.filter(m => !m.active).length }}</span>
+            탈퇴 <span class="font-bold">{{ stats.withdrawn }}</span>
           </div>
         </div>
       </section>
@@ -187,10 +225,10 @@ function confirmWithdraw() {
         <div class="relative flex items-center">
           <Search :size="13" class="absolute left-2.5 text-gray-400 pointer-events-none" />
           <input
-            v-model="filter.email"
+            v-model="filter.keyword"
             type="text"
-            placeholder="이메일 검색"
-            class="h-9 w-52 rounded-none border border-gray-300 bg-gray-50 pl-8 pr-3 text-[13px] text-gray-800 outline-none transition placeholder:text-gray-400 focus:border-[#004D3C] focus:bg-white"
+            placeholder="이름/이메일/사원코드 검색"
+            class="h-9 w-64 rounded-none border border-gray-300 bg-gray-50 pl-8 pr-3 text-[13px] text-gray-800 outline-none transition placeholder:text-gray-400 focus:border-[#004D3C] focus:bg-white"
             @input="currentPage = 1"
           />
         </div>
@@ -202,11 +240,11 @@ function confirmWithdraw() {
           <option v-for="o in roleOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
         </select>
         <select
-          v-model="filter.active"
+          v-model="filter.status"
           class="h-9 rounded-none border border-gray-300 bg-gray-50 px-3 text-[13px] text-gray-700 outline-none transition focus:border-[#004D3C] focus:bg-white"
           @change="currentPage = 1"
         >
-          <option v-for="o in activeOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
+          <option v-for="o in statusOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
         </select>
         <button
           type="button"
@@ -219,8 +257,16 @@ function confirmWithdraw() {
         <span class="text-[12px] font-medium text-gray-400">{{ filtered.length }}건</span>
       </section>
 
+      <!-- 로딩 / 에러 -->
+      <div v-if="loading" class="border border-gray-300 bg-white p-12 text-center text-[13px] text-gray-500">
+        목록을 불러오는 중...
+      </div>
+      <div v-else-if="loadError" class="border border-red-200 bg-red-50 p-4 text-[13px] text-red-600">
+        {{ loadError }}
+      </div>
+
       <!-- 테이블 카드 -->
-      <section class="border border-gray-300 bg-white shadow-sm">
+      <section v-else class="border border-gray-300 bg-white shadow-sm">
         <div class="flex items-center justify-between gap-3 border-b border-gray-200 px-3 py-2.5">
           <h3 class="inline-flex items-center gap-2 text-sm font-medium text-gray-800">
             <Users :size="16" />
@@ -230,16 +276,15 @@ function confirmWithdraw() {
         </div>
 
         <div class="overflow-auto">
-          <table class="w-full min-w-[760px] text-[13px]">
+          <table class="w-full min-w-[820px] text-[13px]">
             <thead class="bg-gray-50 text-[11px] uppercase text-gray-500">
               <tr>
-                <th class="px-3 py-2.5 text-left font-bold">계정 ID</th>
+                <th class="px-3 py-2.5 text-left font-bold">사원코드</th>
                 <th class="px-3 py-2.5 text-left font-bold">이름</th>
                 <th class="px-3 py-2.5 text-left font-bold">이메일</th>
                 <th class="px-3 py-2.5 text-left font-bold">권한</th>
-                <th class="px-3 py-2.5 text-left font-bold">직책</th>
-                <th class="px-3 py-2.5 text-left font-bold">담당 매장</th>
-                <th class="px-3 py-2.5 text-left font-bold">가입일</th>
+                <th class="px-3 py-2.5 text-left font-bold">담당 지점</th>
+                <th class="px-3 py-2.5 text-left font-bold">신청일</th>
                 <th class="px-3 py-2.5 text-left font-bold">상태</th>
               </tr>
             </thead>
@@ -249,38 +294,33 @@ function confirmWithdraw() {
                 :key="m.id"
                 class="cursor-pointer transition-colors hover:bg-gray-50/50"
                 :class="{
-                  'opacity-50': !m.active,
+                  'opacity-60': m.status === 'WITHDRAWN' || m.status === 'REJECTED',
                   'bg-[#eef7f4] hover:bg-[#e4f2ef]': selected?.id === m.id
                 }"
                 @click="openDetail(m)"
               >
-                <td class="px-3 py-2.5 text-gray-400">{{ m.id }}</td>
+                <td class="px-3 py-2.5 text-gray-500">{{ m.employeeCode ?? '-' }}</td>
                 <td class="px-3 py-2.5 font-semibold text-gray-800">{{ m.name }}</td>
                 <td class="px-3 py-2.5 text-gray-600">{{ m.email }}</td>
                 <td class="px-3 py-2.5">
-                  <span
-                    class="inline-flex items-center gap-1 rounded-full px-2 py-1 text-[11px] font-medium"
-                    :class="roleStyle(m.role)"
-                  >
+                  <span class="inline-flex items-center gap-1 rounded-full px-2 py-1 text-[11px] font-medium" :class="roleStyle(m.role)">
                     <component :is="roleIcon(m.role)" :size="11" />
                     {{ roleLabel(m.role) }}
                   </span>
                 </td>
-                <td class="px-3 py-2.5 text-gray-600">{{ m.position }}</td>
                 <td class="px-3 py-2.5 text-gray-600">
-                  <span class="mr-1.5 border border-gray-200 bg-gray-50 px-1.5 py-0.5 text-[11px] font-medium text-gray-500">{{ m.storeCode }}</span>
-                  {{ m.storeName }}
+                  <span class="mr-1.5 border border-gray-200 bg-gray-50 px-1.5 py-0.5 text-[11px] font-medium text-gray-500">{{ m.locationCode }}</span>
+                  {{ m.locationName }}
                 </td>
-                <td class="px-3 py-2.5 text-gray-500">{{ m.joinedAt }}</td>
+                <td class="px-3 py-2.5 text-gray-500">{{ formatDateTime(m.appliedAt) }}</td>
                 <td class="px-3 py-2.5">
-                  <span class="inline-flex items-center gap-1.5 text-[12px] font-medium" :class="m.active ? 'text-emerald-600' : 'text-gray-400'">
-                    <span class="h-1.5 w-1.5 rounded-full" :class="m.active ? 'bg-emerald-500' : 'bg-gray-300'" />
-                    {{ m.active ? '활성' : '비활성' }}
+                  <span class="inline-flex items-center gap-1 rounded-full px-2 py-1 text-[11px] font-medium" :class="statusStyle(m.status)">
+                    {{ statusLabel(m.status) }}
                   </span>
                 </td>
               </tr>
               <tr v-if="paginated.length === 0">
-                <td colspan="8" class="px-3 py-10 text-center text-[13px] text-gray-400">조회된 계정이 없습니다.</td>
+                <td colspan="7" class="px-3 py-10 text-center text-[13px] text-gray-400">조회된 계정이 없습니다.</td>
               </tr>
             </tbody>
           </table>
@@ -289,7 +329,10 @@ function confirmWithdraw() {
         <!-- 페이지네이션 -->
         <div class="flex items-center justify-between border-t border-gray-200 bg-gray-50 px-3 py-2">
           <span class="text-[11px] font-medium text-gray-400">
-            {{ (currentPage - 1) * PAGE_SIZE + 1 }}–{{ Math.min(currentPage * PAGE_SIZE, filtered.length) }} / 전체 {{ filtered.length }}건
+            <template v-if="filtered.length > 0">
+              {{ (currentPage - 1) * PAGE_SIZE + 1 }}–{{ Math.min(currentPage * PAGE_SIZE, filtered.length) }} / 전체 {{ filtered.length }}건
+            </template>
+            <template v-else>0건</template>
           </span>
           <div class="flex items-center gap-1">
             <button
@@ -330,7 +373,9 @@ function confirmWithdraw() {
           <!-- 헤더 -->
           <div class="flex shrink-0 items-start justify-between border-b border-gray-200 bg-gray-50 px-4 py-3">
             <div>
-              <p class="text-[11px] font-bold uppercase tracking-widest text-gray-400">{{ selected.id }} · 계정 상세</p>
+              <p class="text-[11px] font-bold uppercase tracking-widest text-gray-400">
+                {{ selected.employeeCode ?? '미발급' }} · 계정 상세
+              </p>
               <h2 class="mt-1 text-[18px] font-bold text-gray-900">{{ selected.name }}</h2>
             </div>
             <button
@@ -345,23 +390,29 @@ function confirmWithdraw() {
           <!-- 본문 -->
           <div class="flex flex-1 flex-col gap-5 overflow-y-auto p-4">
 
-            <!-- 저장 성공 -->
-            <div v-if="saveSuccess" class="flex items-center gap-2 border border-emerald-200 bg-emerald-50 px-3 py-2.5 text-[13px] font-medium text-emerald-700">
+            <!-- 처리 성공 메시지 -->
+            <div v-if="actionMessage" class="flex items-center gap-2 border border-emerald-200 bg-emerald-50 px-3 py-2.5 text-[13px] font-medium text-emerald-700">
               <CheckCircle2 :size="15" />
-              계정 정보가 수정되었습니다.
+              {{ actionMessage }}
             </div>
 
-            <!-- 비활성 경고 -->
-            <div v-if="!selected.active" class="flex items-center gap-2 border border-red-200 bg-red-50 px-3 py-2.5 text-[13px] font-medium text-red-600">
+            <!-- 탈퇴 경고 -->
+            <div v-if="selected.status === 'WITHDRAWN'" class="flex items-center gap-2 border border-red-200 bg-red-50 px-3 py-2.5 text-[13px] font-medium text-red-600">
               <AlertCircle :size="15" />
-              탈퇴 처리된 계정입니다. 수정이 제한됩니다.
+              탈퇴 처리된 계정입니다.
             </div>
 
             <!-- 기본 정보 -->
             <div>
               <p class="mb-2 text-[11px] font-bold uppercase tracking-widest text-gray-400">기본 정보</p>
               <div class="divide-y divide-gray-100 border border-gray-200">
-                <div v-for="(val, key) in { '이메일': selected.email, '전화번호': selected.phone, '생년월일': selected.birthdate, '가입일': selected.joinedAt }"
+                <div v-for="(val, key) in {
+                    '이메일': selected.email,
+                    '전화번호': selected.phoneNumber,
+                    '사원 코드': selected.employeeCode ?? '미발급',
+                    '신청일': formatDateTime(selected.appliedAt),
+                    '처리일': formatDateTime(selected.processedAt),
+                  }"
                   :key="key"
                   class="flex items-center gap-3 px-3 py-2.5">
                   <span class="w-20 shrink-0 text-[11px] font-medium text-gray-400">{{ key }}</span>
@@ -370,34 +421,25 @@ function confirmWithdraw() {
               </div>
             </div>
 
-            <!-- 담당 매장 -->
+            <!-- 담당 지점 -->
             <div>
-              <p class="mb-2 text-[11px] font-bold uppercase tracking-widest text-gray-400">담당 매장</p>
+              <p class="mb-2 text-[11px] font-bold uppercase tracking-widest text-gray-400">담당 지점</p>
               <div class="divide-y divide-gray-100 border border-gray-200">
                 <div class="flex items-center gap-3 px-3 py-2.5">
-                  <span class="w-20 shrink-0 text-[11px] font-medium text-gray-400">매장 코드</span>
-                  <span class="border border-gray-200 bg-gray-50 px-2 py-0.5 text-[11px] font-medium text-gray-600">{{ selected.storeCode }}</span>
+                  <span class="w-20 shrink-0 text-[11px] font-medium text-gray-400">지점 코드</span>
+                  <span class="border border-gray-200 bg-gray-50 px-2 py-0.5 text-[11px] font-medium text-gray-600">{{ selected.locationCode }}</span>
                 </div>
                 <div class="flex items-center gap-3 px-3 py-2.5">
-                  <span class="w-20 shrink-0 text-[11px] font-medium text-gray-400">매장명</span>
-                  <span class="text-[13px] text-gray-800">{{ selected.storeName }}</span>
-                </div>
-                <div class="flex items-center gap-3 px-3 py-2.5">
-                  <span class="w-20 shrink-0 text-[11px] font-medium text-gray-400">계약 기간</span>
-                  <span class="text-[13px] text-gray-800">{{ selected.contractStart }} ~ {{ selected.contractEnd }}</span>
+                  <span class="w-20 shrink-0 text-[11px] font-medium text-gray-400">지점명</span>
+                  <span class="text-[13px] text-gray-800">{{ selected.locationName }}</span>
                 </div>
               </div>
             </div>
 
-            <!-- 수정 가능 항목 -->
+            <!-- 권한 / 상태 -->
             <div>
-              <div class="mb-2 flex items-center justify-between">
-                <p class="text-[11px] font-bold uppercase tracking-widest text-gray-400">권한 / 직책</p>
-                <span class="text-[10px] font-medium text-gray-400">마스터만 수정 가능</span>
-              </div>
-
-              <!-- 읽기 모드 -->
-              <div v-if="!isEditing" class="divide-y divide-gray-100 border border-gray-200">
+              <p class="mb-2 text-[11px] font-bold uppercase tracking-widest text-gray-400">권한 / 상태</p>
+              <div class="divide-y divide-gray-100 border border-gray-200">
                 <div class="flex items-center gap-3 px-3 py-2.5">
                   <span class="w-20 shrink-0 text-[11px] font-medium text-gray-400">권한</span>
                   <span class="inline-flex items-center gap-1 rounded-full px-2 py-1 text-[11px] font-medium" :class="roleStyle(selected.role)">
@@ -406,66 +448,48 @@ function confirmWithdraw() {
                   </span>
                 </div>
                 <div class="flex items-center gap-3 px-3 py-2.5">
-                  <span class="w-20 shrink-0 text-[11px] font-medium text-gray-400">직책</span>
-                  <span class="text-[13px] text-gray-800">{{ selected.position }}</span>
-                </div>
-                <div class="flex items-center gap-3 px-3 py-2.5">
                   <span class="w-20 shrink-0 text-[11px] font-medium text-gray-400">상태</span>
-                  <span class="inline-flex items-center gap-1.5 text-[12px] font-medium" :class="selected.active ? 'text-emerald-600' : 'text-gray-400'">
-                    <span class="h-1.5 w-1.5 rounded-full" :class="selected.active ? 'bg-emerald-500' : 'bg-gray-300'" />
-                    {{ selected.active ? '활성' : '비활성 (탈퇴)' }}
+                  <span class="inline-flex items-center gap-1 rounded-full px-2 py-1 text-[11px] font-medium" :class="statusStyle(selected.status)">
+                    {{ statusLabel(selected.status) }}
                   </span>
-                </div>
-              </div>
-
-              <!-- 편집 모드 -->
-              <div v-else class="flex flex-col gap-4 border border-gray-200 p-4">
-                <div class="flex flex-col gap-1.5">
-                  <label class="text-[11px] font-bold uppercase tracking-widest text-gray-500">권한</label>
-                  <select
-                    v-model="editForm.role"
-                    class="h-10 border border-gray-300 bg-gray-50 px-3 text-[13px] text-gray-800 outline-none transition focus:border-[#004D3C] focus:bg-white"
-                  >
-                    <option v-for="o in roleOptions.slice(1)" :key="o.value" :value="o.value">{{ o.label }}</option>
-                  </select>
-                </div>
-                <div class="flex flex-col gap-1.5">
-                  <label class="text-[11px] font-bold uppercase tracking-widest text-gray-500">직책</label>
-                  <input
-                    v-model="editForm.position"
-                    type="text"
-                    placeholder="예) 점장, 부점장"
-                    class="h-10 border bg-gray-50 px-3 text-[13px] text-gray-800 outline-none transition focus:bg-white"
-                    :class="editErrors.position ? 'border-red-500 focus:border-red-500' : 'border-gray-300 focus:border-[#004D3C]'"
-                    @input="editErrors.position = ''"
-                  />
-                  <p v-if="editErrors.position" class="text-[12px] font-medium text-red-500">{{ editErrors.position }}</p>
-                </div>
-                <div class="flex flex-col gap-1.5">
-                  <label class="text-[11px] font-bold uppercase tracking-widest text-gray-500">활성 상태</label>
-                  <label class="inline-flex cursor-pointer items-center gap-3">
-                    <input v-model="editForm.active" type="checkbox" class="hidden" />
-                    <span class="toggle-track relative h-5 w-9 border transition-all" :class="editForm.active ? 'bg-[#004D3C] border-[#004D3C]' : 'bg-gray-200 border-gray-300'">
-                      <span class="toggle-thumb absolute top-[3px] h-3 w-3 bg-white transition-transform" :class="editForm.active ? 'translate-x-[19px]' : 'translate-x-[3px]'" />
-                    </span>
-                    <span class="text-[13px] font-medium text-gray-700">{{ editForm.active ? '활성' : '비활성' }}</span>
-                  </label>
                 </div>
               </div>
             </div>
 
-            <!-- 탈퇴 처리 -->
-            <div v-if="selected.active && !isEditing">
+            <!-- 신청 사유 -->
+            <div v-if="selected.applicationReason">
+              <p class="mb-2 text-[11px] font-bold uppercase tracking-widest text-gray-400">가입 신청 사유</p>
+              <p class="border border-gray-200 bg-gray-50 px-3 py-2.5 text-[13px] leading-relaxed text-gray-600">
+                {{ selected.applicationReason }}
+              </p>
+            </div>
+
+            <!-- 탈퇴 처리 (APPROVED 상태에서만) -->
+            <div v-if="selected.status === 'APPROVED'">
               <p class="mb-2 text-[11px] font-bold uppercase tracking-widest text-red-500">계정 탈퇴 처리</p>
-              <p class="mb-3 text-[13px] text-gray-500">탈퇴 처리 시 계정이 즉시 비활성화됩니다. 복구하려면 수정 기능을 이용하세요.</p>
+              <p class="mb-3 text-[13px] text-gray-500">
+                탈퇴 처리 시 해당 사용자의 모든 세션이 즉시 무효화됩니다. 추후 다시 로그인할 수 없습니다.
+              </p>
 
               <div v-if="withdrawConfirm" class="border border-red-200 bg-red-50 p-4">
                 <p class="mb-3 text-[13px] font-medium text-red-700">
                   정말 탈퇴 처리하시겠습니까? <strong>{{ selected.name }}</strong> 계정이 비활성화됩니다.
                 </p>
                 <div class="flex gap-2">
-                  <button type="button" class="h-9 border border-gray-300 bg-white px-4 text-[13px] font-medium text-gray-600 transition hover:bg-gray-50" @click="withdrawConfirm = false">취소</button>
-                  <button type="button" class="h-9 bg-red-600 px-4 text-[13px] font-medium text-white transition hover:bg-red-700" @click="confirmWithdraw">탈퇴 확정</button>
+                  <button
+                    type="button"
+                    class="h-9 border border-gray-300 bg-white px-4 text-[13px] font-medium text-gray-600 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+                    :disabled="withdrawing"
+                    @click="withdrawConfirm = false"
+                  >취소</button>
+                  <button
+                    type="button"
+                    class="h-9 bg-red-600 px-4 text-[13px] font-medium text-white transition hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50"
+                    :disabled="withdrawing"
+                    @click="confirmWithdraw"
+                  >
+                    {{ withdrawing ? '처리 중...' : '탈퇴 확정' }}
+                  </button>
                 </div>
               </div>
               <button
@@ -483,25 +507,7 @@ function confirmWithdraw() {
 
           <!-- 푸터 -->
           <div class="flex shrink-0 items-center justify-end gap-2 border-t border-gray-200 bg-gray-50 px-4 py-3">
-            <template v-if="!isEditing">
-              <button
-                v-if="selected.active"
-                type="button"
-                class="inline-flex h-9 items-center gap-2 bg-[#004D3C] px-5 text-[13px] font-medium text-white transition hover:bg-[#003d30]"
-                @click="startEdit"
-              >
-                <Pencil :size="14" />
-                정보 수정
-              </button>
-              <button type="button" class="h-9 border border-gray-300 bg-white px-5 text-[13px] font-medium text-gray-600 transition hover:bg-gray-50" @click="closeDetail">닫기</button>
-            </template>
-            <template v-else>
-              <button type="button" class="h-9 border border-gray-300 bg-white px-5 text-[13px] font-medium text-gray-600 transition hover:bg-gray-50" @click="cancelEdit">취소</button>
-              <button type="button" class="inline-flex h-9 items-center gap-2 bg-[#004D3C] px-5 text-[13px] font-medium text-white transition hover:bg-[#003d30]" @click="saveEdit">
-                <Save :size="14" />
-                저장
-              </button>
-            </template>
+            <button type="button" class="h-9 border border-gray-300 bg-white px-5 text-[13px] font-medium text-gray-600 transition hover:bg-gray-50" @click="closeDetail">닫기</button>
           </div>
 
         </div>


### PR DESCRIPTION
## 📌 요약
- Refresh Token 기반 인증 시스템 FE 연동
- 본사 관리자 회원 탈퇴 처리 UI 및 BE 연동

<br><br>

## 🎯 작업 내용

-  401 응답 시 `/api/user/refresh` 자동 호출 → 새 Atoken 발급 → 원본 요청 자동 재시도
- 동시 다발 401 요청에서 `refreshPromise` 단일 공유로 refresh 중복 호출 방지
- `/refresh` 자체 401 또는 재시도 후 401 시 `forceLogout` (localStorage 정리 + `/login` 이동)
- 무한 루프 방지: `_retry` 플래그 + `/refresh` URL 매칭 체크

<br><br>

## ✔️ 참고 사항
- 테스트 시나리오
   - 정상 로그인 — Atoken/Rtoken 둘 다 발급 확인
   - Atoken 만료 → 자동 refresh → 원본 요청 재시도 
   - Rtoken 무효 → 강제 로그아웃 + `/login` 이동
- 

<br><br>

## ✔️ 관련 이슈

- Close #369 

<br><br>