### PR TITLE
fix(warehouse): 입고관리 진입 시 본사 API 호출로 인한 401 차단 해결

### DIFF
--- a/src/stores/purchaseOrder.js
+++ b/src/stores/purchaseOrder.js
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import { purchaseOrderApi } from '@/api/hq/purchaseOrder.js'
 import { getInfrastructures } from '@/api/hq/infrastructure.js'
+import { useAuthStore } from '@/stores/auth.js'
 
 // ─── BE ↔ FE 매핑 헬퍼 ─────────────────────────────────────────────────────
 // BE (PurchaseOrder DetailRes/ListRes) ↔ FE store 형식 변환.
@@ -445,13 +446,19 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
     }
   }
 
-  // 스토어 생성 시 자동 fetch (vendor store 패턴)
-  fetchOrders().catch(() => {
-    // fetchOrders 안에서 이미 처리
-  })
-  fetchWarehouses().catch(() => {
-    // fetchWarehouses 안에서 이미 처리
-  })
+  // 스토어 생성 시 자동 fetch (vendor store 패턴) — 본사 도메인 API(/api/hq/**)
+  // 호출이라 role=hq 일 때만 트리거. 다른 권한군(warehouse/store) 화면이 이 store
+  // 를 의존해도(예: warehouseStock) SecurityConfig 가 401/403 차단하지 않도록 안전망.
+  // 본사 화면은 명시적으로 fetchOrders/fetchWarehouses 호출 가능.
+  const auth = useAuthStore()
+  if (auth.user?.role === 'hq') {
+    fetchOrders().catch(() => {
+      // fetchOrders 안에서 이미 처리
+    })
+    fetchWarehouses().catch(() => {
+      // fetchWarehouses 안에서 이미 처리
+    })
+  }
 
   return {
     // state

--- a/src/stores/warehouse/warehouseInbound.js
+++ b/src/stores/warehouse/warehouseInbound.js
@@ -1,14 +1,26 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
-import { usePurchaseOrderStore } from '../purchaseOrder.js'
 import { inboundApi } from '@/api/warehouse/inbound.js'
 
+/**
+ * WHS-005/007/008 창고 관리자 입고 store.
+ *
+ * 단일 진실 원천(ADR-015) — BE InboundController(`/api/warehouse/inbound`) 가 직접 응답.
+ * 권한군 격리 — 본사 도메인 store(`purchaseOrder.js`) 의존 X. 그 store 는
+ * 마운트 시 `/api/hq/**` 자동 fetch 라 창고 관리자(role=WAREHOUSE) 권한으로 호출 시
+ * SecurityConfig 가 차단(401/403). 자체 axios 호출로 분리.
+ *
+ * BE 응답(PurchaseOrderDto.ListRes / DetailRes) 의 code 를 FE 의 id 로 매핑해
+ * 컴포넌트의 `order.id` 호환 유지.
+ */
 export const useWarehouseInboundStore = defineStore('warehouseInbound', () => {
-  const poStore = usePurchaseOrderStore()
+  // --- state ---
+  const items = ref([])           // 입고 후보 발주 목록 (DELIVERED + COMPLETED)
+  const selectedDetail = ref(null) // 선택된 발주의 상세 (items + statusHistory 포함)
+  const loading = ref(false)
+  const error = ref(null)
 
-  // --- view state (입고 화면 전용) ---
   // 'DELIVERED' = 배송완료(도착됨, 입고 확정 대기) / 'COMPLETED' = 입고완료
-  // SHIPPING(배송중) 은 공급처 단계라 창고 화면에 노출 안 함 (BE InboundService 도 차단)
   const activeStatusTab = ref('DELIVERED')
   const selectedOrderId = ref(null)
   const searchKeyword = ref('')
@@ -16,91 +28,184 @@ export const useWarehouseInboundStore = defineStore('warehouseInbound', () => {
   const dateTo = ref('')
   const sortBy = ref('latest') // 'latest' | 'oldest' | 'priceAsc' | 'priceDesc'
 
+  // --- BE 응답 매핑 ---
+  // BE list/detail 응답의 code 를 FE id 로 노출, snake/camel 키 통일.
+  function fromListApi(po) {
+    return {
+      id: po.code,
+      code: po.code,
+      vendorId: po.vendorCode,
+      vendorName: po.vendorName,
+      warehouseId: po.warehouseId,
+      warehouseName: po.warehouseName,
+      warehouseCode: po.warehouseCode,
+      status: po.status,
+      totalPrice: po.totalAmount,
+      itemCount: po.itemCount,
+      productNames: po.productNames ?? [],
+      createdAt: po.createdAt,
+      updatedAt: po.updatedAt,
+      // detail 채워질 때까지 빈 배열로 노출
+      items: [],
+      statusHistory: [],
+    }
+  }
+
+  function fromDetailApi(po) {
+    return {
+      ...fromListApi(po),
+      items: (po.items ?? []).map((it) => ({
+        skuCode: it.skuCode,
+        productName: it.productName,
+        color: it.color,
+        size: it.size,
+        displayOption: it.displayOption,
+        quantity: it.quantity,
+        unitPrice: it.unitPrice,
+        subtotal: it.subtotal,
+      })),
+      statusHistory: (po.statusHistory ?? []).map((h) => ({
+        status: h.status,
+        at: h.changedAt,
+        byName: h.changedByName,
+        note: h.note,
+      })),
+      vendorContactName: po.vendorContactName,
+      cancelReason: po.cancelReason,
+    }
+  }
+
   // --- getters ---
-  const selectedOrder = computed(
-    () => poStore.purchaseOrders.find((o) => o.id === selectedOrderId.value) ?? null,
-  )
+  const selectedOrder = computed(() => {
+    if (!selectedOrderId.value) return null
+    if (selectedDetail.value && selectedDetail.value.id === selectedOrderId.value) {
+      return selectedDetail.value
+    }
+    return items.value.find((o) => o.id === selectedOrderId.value) ?? null
+  })
 
   const inboundList = computed(() => {
-    let list = poStore.purchaseOrders.filter((o) => o.status === activeStatusTab.value)
+    let list = items.value.filter((o) => o.status === activeStatusTab.value)
 
     if (searchKeyword.value.trim()) {
       const k = searchKeyword.value.trim().toLowerCase()
       list = list.filter(
         (o) =>
           o.id.toLowerCase().includes(k)
-          || o.vendorName.toLowerCase().includes(k)
+          || (o.vendorName ?? '').toLowerCase().includes(k)
           || (o.productNames ?? []).some((name) => (name ?? '').toLowerCase().includes(k)),
       )
     }
 
     if (dateFrom.value) {
-      list = list.filter((o) => o.createdAt.slice(0, 10) >= dateFrom.value)
+      list = list.filter((o) => (o.createdAt ?? '').slice(0, 10) >= dateFrom.value)
     }
     if (dateTo.value) {
-      list = list.filter((o) => o.createdAt.slice(0, 10) <= dateTo.value)
+      list = list.filter((o) => (o.createdAt ?? '').slice(0, 10) <= dateTo.value)
     }
 
     const sorted = [...list]
     switch (sortBy.value) {
       case 'oldest':
-        sorted.sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+        sorted.sort((a, b) => (a.createdAt ?? '').localeCompare(b.createdAt ?? ''))
         break
       case 'priceAsc':
-        sorted.sort((a, b) => a.totalPrice - b.totalPrice)
+        sorted.sort((a, b) => (a.totalPrice ?? 0) - (b.totalPrice ?? 0))
         break
       case 'priceDesc':
-        sorted.sort((a, b) => b.totalPrice - a.totalPrice)
+        sorted.sort((a, b) => (b.totalPrice ?? 0) - (a.totalPrice ?? 0))
         break
       default:
-        sorted.sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+        sorted.sort((a, b) => (b.createdAt ?? '').localeCompare(a.createdAt ?? ''))
     }
     return sorted
   })
 
   // 탭 카운트는 항상 전체 기준 (검색·기간 무관)
   const counts = computed(() => ({
-    DELIVERED: poStore.purchaseOrders.filter((o) => o.status === 'DELIVERED').length,
-    COMPLETED: poStore.purchaseOrders.filter((o) => o.status === 'COMPLETED').length,
+    DELIVERED: items.value.filter((o) => o.status === 'DELIVERED').length,
+    COMPLETED: items.value.filter((o) => o.status === 'COMPLETED').length,
   }))
 
   // --- actions ---
-  // 발주 선택 — items/statusHistory 가 비어있으면(list 시점) detail 자동 fetch.
-  // purchaseOrder store 의 selectOrder 와 같은 패턴 — 단일 진실 원천(ADR-015).
-  function selectOrder(id) {
-    selectedOrderId.value = id
-    if (id) {
-      const order = poStore.purchaseOrders.find((o) => o.id === id)
-      if (order && (order.items.length === 0 || order.statusHistory.length === 0)) {
-        poStore.fetchDetail(id).catch(() => {
-          // fetchDetail 안에서 이미 처리
-        })
-      }
+  async function fetchAll() {
+    loading.value = true
+    error.value = null
+    try {
+      const list = await inboundApi.list()
+      items.value = (list ?? []).map(fromListApi)
+    } catch (e) {
+      error.value = e?.message ?? '입고 목록을 불러오지 못했습니다.'
+    } finally {
+      loading.value = false
     }
   }
 
-  // 입고 확정 (WHS-007) — 창고 권한군 entry-point 로 갈아끼움.
-  // BE: POST /api/warehouse/inbound/{code}/confirm → 내부적으로 PurchaseOrderService.complete
-  // (SHIPPING→COMPLETED 검증 + statusHistory append).
-  // 단일 진실 원천(ADR-015) 정합을 위해 confirm 후 poStore.fetchDetail 로 단건 갱신.
+  async function fetchDetail(id) {
+    try {
+      const detail = await inboundApi.detail(id)
+      const mapped = fromDetailApi(detail)
+      selectedDetail.value = mapped
+      // 목록에도 반영 (창고 정보 등 동기화)
+      const idx = items.value.findIndex((o) => o.id === id)
+      if (idx >= 0) {
+        items.value[idx] = { ...items.value[idx], ...mapped }
+      }
+      return mapped
+    } catch (e) {
+      error.value = e?.message ?? '입고 상세를 불러오지 못했습니다.'
+      throw e
+    }
+  }
+
+  function selectOrder(id) {
+    selectedOrderId.value = id
+    if (id) {
+      const order = items.value.find((o) => o.id === id)
+      if (!order || order.items.length === 0 || order.statusHistory.length === 0) {
+        fetchDetail(id).catch(() => {
+          // fetchDetail 안에서 이미 처리
+        })
+      } else {
+        selectedDetail.value = order
+      }
+    } else {
+      selectedDetail.value = null
+    }
+  }
+
+  // 입고 확정 (WHS-007) — DELIVERED → COMPLETED.
+  // BE: POST /api/warehouse/inbound/{code}/confirm (내부적으로 PurchaseOrderService.complete 위임).
   async function confirmInbound(id) {
     await inboundApi.confirm(id)
-    return poStore.fetchDetail(id)
+    await fetchDetail(id)
+    // 상태 전이 후 목록 status 갱신 — 단순화 위해 전체 재조회.
+    await fetchAll()
   }
+
+  // 마운트 자동 fetch — vendor/circularInventoryBuyers store 패턴 일관.
+  fetchAll().catch((err) => {
+    console.error('[warehouseInbound] fetchAll 실패', err)
+  })
 
   return {
     // state
+    items,
     activeStatusTab,
     selectedOrderId,
     searchKeyword,
     dateFrom,
     dateTo,
     sortBy,
+    loading,
+    error,
     // getters
     selectedOrder,
     inboundList,
     counts,
     // actions
+    fetchAll,
+    fetchDetail,
     selectOrder,
     confirmInbound,
   }


### PR DESCRIPTION
## 📌 요약
- 창고 관리자(role=WAREHOUSE) 가 입고관리 페이지 진입 시 화면이 즉시 로그인 페이지로 튕기는 버그 해결. 원인은 warehouseInbound store 가 본사 도메인 purchaseOrder store 를 의존하면서 마운트 시 본사 API(`/api/hq/**`) 를 자동 호출 → SecurityConfig 의 `hasRole("HQ")` 룰에 차단 → axios 401 인터셉터가 forceLogout 발동.

<br><br>

## 🎯 작업 내용
- stores/warehouse/warehouseInbound.js: `usePurchaseOrderStore` 의존을 끊고 자체 `inboundApi.list()` / `inboundApi.detail()` 호출로 전환. items / selectedDetail / loading / error ref + fromListApi / fromDetailApi 매핑 헬퍼 신설. selectedOrder / inboundList / counts / selectOrder / confirmInbound 외부 인터페이스는 그대로라 WarehouseInboundView 변경 0.
- stores/purchaseOrder.js: 마운트 자동 fetch 에 `auth.user?.role === 'hq'` 가드 추가. 다른 권한군 화면이 본사 store 를 의존(예: warehouseStock) 해도 본사 API 호출이 발생하지 않도록 안전망. 본사 화면 진입 시에는 정상 자동 fetch 유지.

<br><br>

## ✔️ 참고 사항
- 본 PR 은 BE 변경 없이 FE 단독 fix. BE 의 `/api/warehouse/inbound` 엔드포인트는 이미 `hasRole("WAREHOUSE")` 보호이며 정상 응답. warehouseInbound store 의 자체 호출이 권한 정합 OK.
- BE InboundController.list 의 `warehouseId` query param 은 별 사이클(`@AuthenticationPrincipal me.locationCode` 마이그레이션) 로 분리. 현재 단계에서는 미전달 시 모든 창고 데이터 노출되는 점 인지하고 있고, 그 마이그레이션 머지 시 자동으로 자기 창고만 필터링됨.

<br><br>

## ✔️ 관련 이슈

- Close #391

<br><br>
