### PR TITLE
refactor(purchase-order, warehouse-inbound): 상태머신 7단계 + 권한별 라벨 분기 적용

### DIFF
--- a/src/api/warehouse/inbound.js
+++ b/src/api/warehouse/inbound.js
@@ -2,15 +2,14 @@
  * inbound.js — BE 연동 (WHS-005/007/008 창고 관리자 입고)
  *
  * BE 엔드포인트:
- *   GET    /api/warehouse/inbound?status=&warehouseId=&from=&to=    (입고 예정/완료 목록)
+ *   GET    /api/warehouse/inbound?status=&warehouseId=&from=&to=    (입고 후보 목록 — READY_TO_SHIP/IN_TRANSIT/ARRIVED/COMPLETED 4상태)
  *   GET    /api/warehouse/inbound/{code}                            (상세 — items + statusHistory)
- *   POST   /api/warehouse/inbound/{code}/confirm                    (입고 확정 SHIPPING → COMPLETED)
+ *   POST   /api/warehouse/inbound/{code}/confirm                    (입고 확정 ARRIVED → COMPLETED)
  *
  * 응답: BaseResponse<T>. unwrap() 으로 result 만 추출, 실패 시 throw.
  *
- * 단일 진실 원천(ADR-015) 정책 — list/detail 은 현재 `purchaseOrder` store 의 SHIPPING/COMPLETED
- * 발주를 그대로 활용하므로 store 에서 직접 호출하지 않을 수도 있음. confirm 만 핵심 사용처.
- * 인증 도입(ADR-011) 전 임시: warehouseId 는 query 파라미터로 받음 (FE 가 auth.user.storeId 전달).
+ * 단일 진실 원천(ADR-015) — BE InboundService 가 PurchaseOrder + statusHistory 를 그대로 활용.
+ * 인증 도입(ADR-011) 전 임시: warehouseId 는 query 파라미터로 받음.
  */
 
 import { apiClient, unwrap } from '../axios.js'
@@ -19,8 +18,8 @@ const BASE = '/api/warehouse/inbound'
 
 export const inboundApi = {
   /**
-   * 입고 목록 조회.
-   * @param {{status?: 'SHIPPING'|'COMPLETED', warehouseId?: string, from?: string, to?: string}} params
+   * 입고 후보 목록 조회.
+   * @param {{status?: 'READY_TO_SHIP'|'IN_TRANSIT'|'ARRIVED'|'COMPLETED', warehouseId?: string, from?: string, to?: string}} params
    */
   list: (params = {}) => {
     const query = {}

--- a/src/stores/purchaseOrder.js
+++ b/src/stores/purchaseOrder.js
@@ -201,12 +201,13 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
     const all = purchaseOrders.value
     return {
       전체: all.length,
-      PENDING: all.filter((o) => o.status === 'PENDING').length,
+      REQUESTED: all.filter((o) => o.status === 'REQUESTED').length,
       APPROVED: all.filter((o) => o.status === 'APPROVED').length,
-      SHIPPING: all.filter((o) => o.status === 'SHIPPING').length,
-      DELIVERED: all.filter((o) => o.status === 'DELIVERED').length,
+      READY_TO_SHIP: all.filter((o) => o.status === 'READY_TO_SHIP').length,
+      IN_TRANSIT: all.filter((o) => o.status === 'IN_TRANSIT').length,
+      ARRIVED: all.filter((o) => o.status === 'ARRIVED').length,
       COMPLETED: all.filter((o) => o.status === 'COMPLETED').length,
-      REJECTED: all.filter((o) => o.status === 'REJECTED').length,
+      CANCELLED: all.filter((o) => o.status === 'CANCELLED').length,
     }
   })
 
@@ -221,8 +222,8 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
   })
 
   const summary = computed(() => {
-    // 취소된(REJECTED) 발주는 총 발주 합계에서 제외 — 실제 처리되지 않은 금액.
-    let base = purchaseOrders.value.filter((o) => o.status !== 'REJECTED')
+    // 취소된(CANCELLED) 발주는 총 발주 합계에서 제외 — 실제 처리되지 않은 금액.
+    let base = purchaseOrders.value.filter((o) => o.status !== 'CANCELLED')
     if (vendorFilter.value) {
       base = base.filter((o) => o.vendorId === vendorFilter.value)
     }

--- a/src/stores/warehouse/warehouseDashboard.js
+++ b/src/stores/warehouse/warehouseDashboard.js
@@ -26,7 +26,16 @@ export const useWarehouseDashboardStore = defineStore('warehouseDashboard', () =
     return Math.round(r * 100)
   })
 
-  const shippingCount = computed(() => statusBreakdown.value.SHIPPING ?? 0)
+  // 입고 예정 = 거래처 책임 단계 합산 (READY_TO_SHIP + IN_TRANSIT + ARRIVED).
+  // BE 가 kpi.scheduledCount 로 이미 합산하지만 statusBreakdown 으로도 fallback 계산.
+  const shippingCount = computed(() => {
+    if (kpi.value.scheduledCount !== undefined && kpi.value.scheduledCount !== null) {
+      return kpi.value.scheduledCount
+    }
+    return (statusBreakdown.value.READY_TO_SHIP ?? 0)
+      + (statusBreakdown.value.IN_TRANSIT ?? 0)
+      + (statusBreakdown.value.ARRIVED ?? 0)
+  })
   const completedCount = computed(() => statusBreakdown.value.COMPLETED ?? 0)
   const stageTotal = computed(() => shippingCount.value + completedCount.value)
 
@@ -49,8 +58,8 @@ export const useWarehouseDashboardStore = defineStore('warehouseDashboard', () =
     try {
       const [progressRes, listRes] = await Promise.all([
         dashboardApi.getInboundProgress(params),
-        // 입고 예정 = DELIVERED(배송완료, 도착됨) — SHIPPING 은 공급처 단계라 창고 화면 미노출
-        inboundApi.list({ ...params, status: 'DELIVERED' }),
+        // 입고 예정 테이블 = ARRIVED(배송 완료, 입고 확정 대기) 발주만 — 도착 임박 강조
+        inboundApi.list({ ...params, status: 'ARRIVED' }),
       ])
       progress.value = progressRes
       // 입고 예정 테이블 — 도착 임박 (오래된 순) 노출 위해 createdAt asc 로 재정렬

--- a/src/stores/warehouse/warehouseInbound.js
+++ b/src/stores/warehouse/warehouseInbound.js
@@ -15,13 +15,15 @@ import { inboundApi } from '@/api/warehouse/inbound.js'
  */
 export const useWarehouseInboundStore = defineStore('warehouseInbound', () => {
   // --- state ---
-  const items = ref([])           // 입고 후보 발주 목록 (DELIVERED + COMPLETED)
+  const items = ref([])           // 입고 후보 발주 목록 (READY_TO_SHIP/IN_TRANSIT/ARRIVED/COMPLETED)
   const selectedDetail = ref(null) // 선택된 발주의 상세 (items + statusHistory 포함)
   const loading = ref(false)
   const error = ref(null)
 
-  // 'DELIVERED' = 배송완료(도착됨, 입고 확정 대기) / 'COMPLETED' = 입고완료
-  const activeStatusTab = ref('DELIVERED')
+  // 창고 화면 4탭 — 거래처 책임 단계도 노출 (사용자 결정: READY_TO_SHIP 부터 보여야 함).
+  // READY_TO_SHIP/IN_TRANSIT/ARRIVED 는 거래처 단계 가시화용, COMPLETED 는 입고 완료.
+  // 입고 확정([입고 완료] 액션) 은 ARRIVED 일 때만 가능.
+  const activeStatusTab = ref('READY_TO_SHIP')
   const selectedOrderId = ref(null)
   const searchKeyword = ref('')
   const dateFrom = ref('')
@@ -123,7 +125,9 @@ export const useWarehouseInboundStore = defineStore('warehouseInbound', () => {
 
   // 탭 카운트는 항상 전체 기준 (검색·기간 무관)
   const counts = computed(() => ({
-    DELIVERED: items.value.filter((o) => o.status === 'DELIVERED').length,
+    READY_TO_SHIP: items.value.filter((o) => o.status === 'READY_TO_SHIP').length,
+    IN_TRANSIT: items.value.filter((o) => o.status === 'IN_TRANSIT').length,
+    ARRIVED: items.value.filter((o) => o.status === 'ARRIVED').length,
     COMPLETED: items.value.filter((o) => o.status === 'COMPLETED').length,
   }))
 
@@ -174,7 +178,7 @@ export const useWarehouseInboundStore = defineStore('warehouseInbound', () => {
     }
   }
 
-  // 입고 확정 (WHS-007) — DELIVERED → COMPLETED.
+  // 입고 확정 (WHS-007) — ARRIVED → COMPLETED.
   // BE: POST /api/warehouse/inbound/{code}/confirm (내부적으로 PurchaseOrderService.complete 위임).
   async function confirmInbound(id) {
     await inboundApi.confirm(id)

--- a/src/stores/warehouse/warehouseInbound.js
+++ b/src/stores/warehouse/warehouseInbound.js
@@ -87,7 +87,10 @@ export const useWarehouseInboundStore = defineStore('warehouseInbound', () => {
   })
 
   const inboundList = computed(() => {
-    let list = items.value.filter((o) => o.status === activeStatusTab.value)
+    // '전체' 탭은 모든 입고 후보(READY_TO_SHIP/IN_TRANSIT/ARRIVED/COMPLETED) 노출.
+    let list = activeStatusTab.value === '전체'
+      ? items.value
+      : items.value.filter((o) => o.status === activeStatusTab.value)
 
     if (searchKeyword.value.trim()) {
       const k = searchKeyword.value.trim().toLowerCase()
@@ -125,6 +128,7 @@ export const useWarehouseInboundStore = defineStore('warehouseInbound', () => {
 
   // 탭 카운트는 항상 전체 기준 (검색·기간 무관)
   const counts = computed(() => ({
+    전체: items.value.length,
     READY_TO_SHIP: items.value.filter((o) => o.status === 'READY_TO_SHIP').length,
     IN_TRANSIT: items.value.filter((o) => o.status === 'IN_TRANSIT').length,
     ARRIVED: items.value.filter((o) => o.status === 'ARRIVED').length,

--- a/src/stores/warehouse/warehouseStock.js
+++ b/src/stores/warehouse/warehouseStock.js
@@ -68,7 +68,7 @@ export const useWarehouseStockStore = defineStore('warehouseStock', () => {
     if (!base) return null
 
     const incoming = poStore.purchaseOrders
-      .filter((o) => o.status === 'SHIPPING' && o.warehouseId === warehouseId)
+      .filter((o) => o.status === 'IN_TRANSIT' && o.warehouseId === warehouseId)
       .flatMap((o) => o.items ?? [])
       .filter((it) => it.productCode === productCode)
       .reduce((sum, it) => sum + (Number(it.quantity) || 0), 0)
@@ -184,7 +184,7 @@ export const useWarehouseStockStore = defineStore('warehouseStock', () => {
     if (!warehouseId || !skuCode) return null
     const base = defaultSkuStock(warehouseId, skuCode)
     const incoming = poStore.purchaseOrders
-      .filter((o) => o.status === 'SHIPPING' && o.warehouseId === warehouseId)
+      .filter((o) => o.status === 'IN_TRANSIT' && o.warehouseId === warehouseId)
       .flatMap((o) => o.items ?? [])
       .filter((it) => it.skuCode && it.skuCode === skuCode)
       .reduce((sum, it) => sum + (Number(it.quantity) || 0), 0)

--- a/src/views/hq/purchase-order/HqPurchaseOrderCreateView.vue
+++ b/src/views/hq/purchase-order/HqPurchaseOrderCreateView.vue
@@ -742,7 +742,7 @@ async function confirmSubmitOrder() {
     if (isEditMode.value) {
       // 가드 재검증 — 다른 곳에서 상태 바뀌었을 수 있음
       const order = poStore.purchaseOrders.find((o) => o.id === editingOrderId.value)
-      if (!order || order.status !== 'PENDING') {
+      if (!order || order.status !== 'REQUESTED') {
         triggerToast('상태가 변경되어 수정할 수 없습니다')
         setTimeout(() => router.replace({ name: 'hq-purchase-orders' }), 900)
         return
@@ -785,7 +785,7 @@ function initEditMode() {
     setTimeout(() => router.replace({ name: 'hq-purchase-orders' }), 900)
     return
   }
-  if (order.status !== 'PENDING') {
+  if (order.status !== 'REQUESTED') {
     triggerToast('승인 대기 상태의 발주만 수정할 수 있습니다')
     setTimeout(() => router.replace({ name: 'hq-purchase-orders' }), 900)
     return

--- a/src/views/hq/purchase-order/HqPurchaseOrderView.vue
+++ b/src/views/hq/purchase-order/HqPurchaseOrderView.vue
@@ -27,14 +27,16 @@ function handleLogout() {
 }
 
 // ─── 상태 탭 ────────────────────────────────────────────────────────────────
+// 본사 화면이라 COMPLETED 라벨은 "종료" (창고 화면은 "입고 완료")
 const STATUS_TABS = [
   { label: '전체', key: '전체' },
-  { label: '승인 대기', key: 'PENDING' },
+  { label: '승인 대기', key: 'REQUESTED' },
   { label: '승인 완료', key: 'APPROVED' },
-  { label: '배송 중', key: 'SHIPPING' },
-  { label: '배송 완료', key: 'DELIVERED' },
-  { label: '입고 완료', key: 'COMPLETED' },
-  { label: '취소', key: 'REJECTED' },
+  { label: '배송 준비 중', key: 'READY_TO_SHIP' },
+  { label: '배송 중', key: 'IN_TRANSIT' },
+  { label: '배송 완료', key: 'ARRIVED' },
+  { label: '종료', key: 'COMPLETED' },
+  { label: '취소', key: 'CANCELLED' },
 ]
 
 // ─── 발주 목록/상세 ──────────────────────────────────────────────────────────
@@ -59,19 +61,23 @@ function triggerToast(message) {
 }
 
 // ─── SYS-001 배치 강제 트리거 (시연·QA용) ─────────────────────────────────
-// 30분 대기 조건을 무시하고 PENDING/APPROVED 모두 즉시 다음 단계로 넘긴다.
+// 30분 대기 조건을 무시하고 거래처 책임 4단계(REQUESTED/APPROVED/READY_TO_SHIP/IN_TRANSIT)
+// 모두 즉시 다음 단계로 넘긴다.
 const isRunningBatch = ref(false)
 async function runBatchTrigger() {
   if (isRunningBatch.value) return
   isRunningBatch.value = true
   try {
     const result = await poStore.runBatch()
-    const total = (result?.approved ?? 0) + (result?.shipping ?? 0) + (result?.delivered ?? 0)
+    const total = (result?.approved ?? 0)
+      + (result?.readyToShip ?? 0)
+      + (result?.inTransit ?? 0)
+      + (result?.arrived ?? 0)
     if (total === 0) {
       triggerToast('자동 전환 대상 발주가 없습니다')
     } else {
       triggerToast(
-        `자동 전환 ${total}건 (승인 ${result.approved} · 출고 ${result.shipping} · 배송완료 ${result.delivered ?? 0})`,
+        `자동 전환 ${total}건 (승인 ${result.approved} · 배송준비 ${result.readyToShip} · 배송중 ${result.inTransit} · 배송완료 ${result.arrived})`,
       )
     }
   } catch (e) {
@@ -82,8 +88,9 @@ async function runBatchTrigger() {
 }
 
 // ─── 발주 취소 (CEN-038) ────────────────────────────────────────────────────
+// REQUESTED (승인 대기) 단계에서만 취소 가능. 그 이후는 거래처가 이미 받았으므로 차단.
 function openCancelConfirm() {
-  if (poStore.selectedOrder?.status !== 'PENDING') return
+  if (poStore.selectedOrder?.status !== 'REQUESTED') return
   cancelReason.value = '' // 모달 열 때마다 초기화
   showCancelConfirm.value = true
 }
@@ -113,25 +120,27 @@ function changeTab(key) {
 // 상태 뱃지 클래스
 function statusClass(status) {
   const map = {
-    PENDING: 'bg-amber-50 text-amber-700',
+    REQUESTED: 'bg-amber-50 text-amber-700',
     APPROVED: 'bg-emerald-50 text-emerald-700',
-    SHIPPING: 'bg-blue-50 text-blue-600',
-    DELIVERED: 'bg-violet-50 text-violet-700',
+    READY_TO_SHIP: 'bg-sky-50 text-sky-700',
+    IN_TRANSIT: 'bg-blue-50 text-blue-600',
+    ARRIVED: 'bg-violet-50 text-violet-700',
     COMPLETED: 'bg-gray-100 text-gray-500',
-    REJECTED: 'bg-red-50 text-red-600',
+    CANCELLED: 'bg-red-50 text-red-600',
   }
   return map[status] ?? 'bg-gray-100 text-gray-500'
 }
 
-// 상태 한국어 라벨
+// 상태 한국어 라벨 — 본사 화면 시점 (COMPLETED = "종료")
 function statusLabel(status) {
   const map = {
-    PENDING: '승인 대기',
+    REQUESTED: '승인 대기',
     APPROVED: '승인 완료',
-    SHIPPING: '배송 중',
-    DELIVERED: '배송 완료',
-    COMPLETED: '입고 완료',
-    REJECTED: '취소',
+    READY_TO_SHIP: '배송 준비 중',
+    IN_TRANSIT: '배송 중',
+    ARRIVED: '배송 완료',
+    COMPLETED: '종료',
+    CANCELLED: '취소',
   }
   return map[status] ?? status
 }
@@ -148,24 +157,26 @@ function formatDate(iso) {
 // 진행 이력 타임라인 — 점/텍스트 색상
 function historyDotClass(status) {
   const map = {
-    PENDING: 'bg-amber-500',
+    REQUESTED: 'bg-amber-500',
     APPROVED: 'bg-emerald-500',
-    SHIPPING: 'bg-blue-500',
-    DELIVERED: 'bg-violet-500',
+    READY_TO_SHIP: 'bg-sky-500',
+    IN_TRANSIT: 'bg-blue-500',
+    ARRIVED: 'bg-violet-500',
     COMPLETED: 'bg-gray-700',
-    REJECTED: 'bg-red-600',
+    CANCELLED: 'bg-red-600',
   }
   return map[status] ?? 'bg-gray-400'
 }
 
 function historyTextClass(status) {
   const map = {
-    PENDING: 'text-amber-700',
+    REQUESTED: 'text-amber-700',
     APPROVED: 'text-emerald-700',
-    SHIPPING: 'text-blue-600',
-    DELIVERED: 'text-violet-700',
+    READY_TO_SHIP: 'text-sky-700',
+    IN_TRANSIT: 'text-blue-600',
+    ARRIVED: 'text-violet-700',
     COMPLETED: 'text-gray-700',
-    REJECTED: 'text-red-700',
+    CANCELLED: 'text-red-700',
   }
   return map[status] ?? 'text-gray-700'
 }
@@ -177,7 +188,7 @@ function goCreatePage() {
 
 function goEditPage() {
   const order = poStore.selectedOrder
-  if (!order || order.status !== 'PENDING') return
+  if (!order || order.status !== 'REQUESTED') return
   router.push({ name: 'hq-purchase-order-edit', params: { id: order.id } })
 }
 
@@ -624,9 +635,9 @@ const TruckIcon = IconBase([
           </div>
 
           <!-- 액션/안내 (상태별 조건부) -->
-          <!-- PENDING 단계에서만 본사 권한(수정/취소) 노출. 승인 이후 단계는 시스템 자동화(RQ-001/002) 및 창고관리자(PO-003/004) 영역이므로 조회만. -->
+          <!-- REQUESTED 단계에서만 본사 권한(수정/취소) 노출. 승인 이후 단계는 SYS-001 자동 전환 및 창고관리자 영역이라 조회만. -->
           <div class="space-y-4 px-4 pb-6 pt-2">
-            <template v-if="poStore.selectedOrder.status === 'PENDING'">
+            <template v-if="poStore.selectedOrder.status === 'REQUESTED'">
               <div class="grid grid-cols-2 gap-2">
                 <button
                   type="button"
@@ -653,19 +664,31 @@ const TruckIcon = IconBase([
 
             <template v-else-if="poStore.selectedOrder.status === 'APPROVED'">
               <p class="text-center text-xs leading-relaxed text-gray-500">
-                승인 완료 · 30분 후 시스템이 자동으로 공급처 출고 처리합니다.
+                승인 완료 · 30분 후 시스템이 자동으로 배송 준비 처리합니다.
               </p>
             </template>
 
-            <template v-else-if="poStore.selectedOrder.status === 'SHIPPING'">
+            <template v-else-if="poStore.selectedOrder.status === 'READY_TO_SHIP'">
+              <p class="text-center text-xs leading-relaxed text-gray-500">
+                배송 준비 중 · 30분 후 시스템이 자동으로 배송 시작 처리합니다.
+              </p>
+            </template>
+
+            <template v-else-if="poStore.selectedOrder.status === 'IN_TRANSIT'">
+              <p class="text-center text-xs leading-relaxed text-gray-500">
+                배송 중 · 30분 후 시스템이 자동으로 배송 완료 처리합니다.
+              </p>
+            </template>
+
+            <template v-else-if="poStore.selectedOrder.status === 'ARRIVED'">
               <p class="text-center text-xs text-gray-500">
-                배송 중 · 창고 입고 검수 대기
+                배송 완료 · 창고 입고 확정 대기
               </p>
             </template>
 
             <template v-else>
               <p
-                v-if="poStore.selectedOrder.status === 'REJECTED' && poStore.selectedOrder.cancelReason"
+                v-if="poStore.selectedOrder.status === 'CANCELLED' && poStore.selectedOrder.cancelReason"
                 class="border border-red-200 bg-red-50 px-3 py-2.5 text-[11px] font-bold leading-relaxed text-red-700"
               >
                 취소 사유: {{ poStore.selectedOrder.cancelReason }}
@@ -673,7 +696,7 @@ const TruckIcon = IconBase([
               <p class="pt-2 text-center text-xs text-gray-400">
                 {{
                   poStore.selectedOrder.status === 'COMPLETED'
-                    ? '입고 완료된 발주입니다.'
+                    ? '종료된 발주입니다.'
                     : '취소된 발주입니다.'
                 }}
               </p>

--- a/src/views/hq/purchase-order/HqPurchaseOrderView.vue
+++ b/src/views/hq/purchase-order/HqPurchaseOrderView.vue
@@ -198,7 +198,12 @@ function handleKeydown(e) {
     poStore.selectedOrderId = null
   }
 }
-onMounted(() => window.addEventListener('keydown', handleKeydown))
+// 화면 진입 시 발주 목록 강제 fetch — 다른 화면(창고 입고 확정 등)에서 status 가
+// 변경됐을 수 있으므로 stale data 방지. store 의 마운트 자동 fetch 는 첫 인스턴스에만 실행됨.
+onMounted(() => {
+  window.addEventListener('keydown', handleKeydown)
+  poStore.fetchOrders().catch(() => {})
+})
 onUnmounted(() => window.removeEventListener('keydown', handleKeydown))
 
 // ─── inline SVG 아이콘 (render 함수 방식) ────────────────────────────────────

--- a/src/views/warehouse/dashboard/WarehouseDashboardView.vue
+++ b/src/views/warehouse/dashboard/WarehouseDashboardView.vue
@@ -136,7 +136,7 @@ const kpiStats = computed(() => [
     label: '입고 예정',
     value: String(shippingCount.value),
     unit: '건',
-    caption: 'SHIPPING',
+    caption: 'IN_PROGRESS',
     tone: 'blue',
   },
   {

--- a/src/views/warehouse/inbound/WarehouseInboundView.vue
+++ b/src/views/warehouse/inbound/WarehouseInboundView.vue
@@ -55,8 +55,12 @@ function handleLogout() {
 }
 
 // ─── 상태 탭 ────────────────────────────────────────────────────────────────
+// 4탭 — 거래처 책임 단계도 가시화 (사용자 결정: READY_TO_SHIP 부터 보여야 함).
+// [입고 확정] 액션은 ARRIVED 일 때만 가능.
 const STATUS_TABS = [
-  { key: 'DELIVERED', label: '입고 예정' },
+  { key: 'READY_TO_SHIP', label: '배송 준비 중' },
+  { key: 'IN_TRANSIT', label: '배송 중' },
+  { key: 'ARRIVED', label: '입고 예정' },
   { key: 'COMPLETED', label: '입고 완료' },
 ]
 
@@ -70,8 +74,8 @@ function changeTab(key) {
 const showConfirmInbound = ref(false)
 
 function openConfirmInbound() {
-  // DELIVERED(배송완료, 도착됨) 상태에서만 입고 확정 가능 — markCompleted 검증
-  if (inbound.selectedOrder?.status !== 'DELIVERED') return
+  // ARRIVED(배송 완료, 도착됨) 상태에서만 입고 확정 가능 — markCompleted 검증
+  if (inbound.selectedOrder?.status !== 'ARRIVED') return
   showConfirmInbound.value = true
 }
 function cancelConfirmInbound() {
@@ -103,24 +107,27 @@ function triggerToast(message) {
 // ─── 헬퍼 ────────────────────────────────────────────────────────────────────
 function statusClass(status) {
   const map = {
-    PENDING: 'bg-amber-50 text-amber-700',
+    REQUESTED: 'bg-amber-50 text-amber-700',
     APPROVED: 'bg-emerald-50 text-emerald-700',
-    SHIPPING: 'bg-blue-50 text-blue-600',
-    DELIVERED: 'bg-violet-50 text-violet-700',
+    READY_TO_SHIP: 'bg-sky-50 text-sky-700',
+    IN_TRANSIT: 'bg-blue-50 text-blue-600',
+    ARRIVED: 'bg-violet-50 text-violet-700',
     COMPLETED: 'bg-gray-100 text-gray-500',
-    REJECTED: 'bg-red-50 text-red-600',
+    CANCELLED: 'bg-red-50 text-red-600',
   }
   return map[status] ?? 'bg-gray-100 text-gray-500'
 }
 
+// 창고 화면 시점 라벨 (COMPLETED = "입고 완료", 본사 화면은 "종료")
 function statusLabel(status) {
   const map = {
-    PENDING: '승인 대기',
+    REQUESTED: '승인 대기',
     APPROVED: '승인 완료',
-    SHIPPING: '배송 중',
-    DELIVERED: '배송 완료',
+    READY_TO_SHIP: '배송 준비 중',
+    IN_TRANSIT: '배송 중',
+    ARRIVED: '배송 완료',
     COMPLETED: '입고 완료',
-    REJECTED: '취소',
+    CANCELLED: '취소',
   }
   return map[status] ?? status
 }
@@ -135,24 +142,26 @@ function formatDate(iso) {
 
 function historyDotClass(status) {
   const map = {
-    PENDING: 'bg-amber-500',
+    REQUESTED: 'bg-amber-500',
     APPROVED: 'bg-emerald-500',
-    SHIPPING: 'bg-blue-500',
-    DELIVERED: 'bg-violet-500',
+    READY_TO_SHIP: 'bg-sky-500',
+    IN_TRANSIT: 'bg-blue-500',
+    ARRIVED: 'bg-violet-500',
     COMPLETED: 'bg-gray-700',
-    REJECTED: 'bg-red-600',
+    CANCELLED: 'bg-red-600',
   }
   return map[status] ?? 'bg-gray-400'
 }
 
 function historyTextClass(status) {
   const map = {
-    PENDING: 'text-amber-700',
+    REQUESTED: 'text-amber-700',
     APPROVED: 'text-emerald-700',
-    SHIPPING: 'text-blue-600',
-    DELIVERED: 'text-violet-700',
+    READY_TO_SHIP: 'text-sky-700',
+    IN_TRANSIT: 'text-blue-600',
+    ARRIVED: 'text-violet-700',
     COMPLETED: 'text-gray-700',
-    REJECTED: 'text-red-700',
+    CANCELLED: 'text-red-700',
   }
   return map[status] ?? 'text-gray-700'
 }
@@ -161,10 +170,16 @@ function selectOrder(id) {
   inbound.selectOrder(id)
 }
 
-// 창고 관점 진행 이력 — DELIVERED/COMPLETED 만 (PENDING/APPROVED/SHIPPING 은 공급처 영역, 노이즈)
+// 창고 관점 진행 이력 — 거래처 단계(READY_TO_SHIP/IN_TRANSIT/ARRIVED) + COMPLETED 노출.
+// REQUESTED/APPROVED 는 본사 승인 영역, CANCELLED 는 창고 화면 미노출이라 필터.
 const visibleHistory = computed(() => {
   const list = inbound.selectedOrder?.statusHistory ?? []
-  return list.filter((h) => h.status === 'DELIVERED' || h.status === 'COMPLETED')
+  return list.filter((h) =>
+    h.status === 'READY_TO_SHIP'
+    || h.status === 'IN_TRANSIT'
+    || h.status === 'ARRIVED'
+    || h.status === 'COMPLETED'
+  )
 })
 
 // ─── ESC 키로 상세 패널 닫기 ────────────────────────────────────────────────
@@ -546,7 +561,19 @@ const CheckIcon = IconBase([{ tag: 'polyline', attrs: { points: '20 6 9 17 4 12'
 
           <!-- 액션/안내 (상태별 분기) -->
           <div class="space-y-3 px-4 pb-6 pt-2">
-            <template v-if="inbound.selectedOrder.status === 'DELIVERED'">
+            <template v-if="inbound.selectedOrder.status === 'READY_TO_SHIP'">
+              <p class="pt-2 text-center text-xs leading-relaxed text-gray-500">
+                공급처에서 배송 준비 중입니다. 배송 시작 시 자동으로 다음 단계로 전환됩니다.
+              </p>
+            </template>
+
+            <template v-else-if="inbound.selectedOrder.status === 'IN_TRANSIT'">
+              <p class="pt-2 text-center text-xs leading-relaxed text-gray-500">
+                배송 중입니다. 도착 시 자동으로 [배송 완료] 단계로 전환됩니다.
+              </p>
+            </template>
+
+            <template v-else-if="inbound.selectedOrder.status === 'ARRIVED'">
               <button
                 type="button"
                 class="inline-flex w-full items-center justify-center gap-1.5 border border-[#004D3C] bg-[#004D3C] px-2 py-3 text-[11px] font-black text-white hover:bg-[#1f4b3a]"

--- a/src/views/warehouse/inbound/WarehouseInboundView.vue
+++ b/src/views/warehouse/inbound/WarehouseInboundView.vue
@@ -55,9 +55,10 @@ function handleLogout() {
 }
 
 // ─── 상태 탭 ────────────────────────────────────────────────────────────────
-// 4탭 — 거래처 책임 단계도 가시화 (사용자 결정: READY_TO_SHIP 부터 보여야 함).
+// 5탭 — [전체] + 거래처 책임 4단계 (사용자 결정: READY_TO_SHIP 부터 보여야 함).
 // [입고 확정] 액션은 ARRIVED 일 때만 가능.
 const STATUS_TABS = [
+  { key: '전체', label: '전체' },
   { key: 'READY_TO_SHIP', label: '배송 준비 중' },
   { key: 'IN_TRANSIT', label: '배송 중' },
   { key: 'ARRIVED', label: '입고 예정' },
@@ -188,7 +189,11 @@ function handleKeydown(e) {
     inbound.selectedOrderId = null
   }
 }
-onMounted(() => window.addEventListener('keydown', handleKeydown))
+// 화면 진입 시 입고 목록 강제 fetch — 다른 화면에서 status 변경됐을 수 있으므로 stale 방지.
+onMounted(() => {
+  window.addEventListener('keydown', handleKeydown)
+  inbound.fetchAll().catch(() => {})
+})
 onUnmounted(() => window.removeEventListener('keydown', handleKeydown))
 
 // ─── inline SVG 아이콘 ────────────────────────────────────────────────────


### PR DESCRIPTION
## 📌 요약
- BE 의 발주 상태머신 7단계 확장(REQUESTED/APPROVED/READY_TO_SHIP/IN_TRANSIT/ARRIVED/COMPLETED/CANCELLED) 에 맞춰 FE 의 상태 키·라벨·액션 가드를 동기화하고, 권한군별 라벨 분기(본사: COMPLETED="종료" / 창고: COMPLETED="입고 완료") 를 view 의 statusLabel 헬퍼에서 처리한다.

<br><br>

## 🎯 작업 내용
- `HqPurchaseOrderView.vue`: STATUS_TABS 7개로 확장 (배송 준비 중·배송 중·배송 완료 분리), 우측 패널 액션 박스 4단계 안내문, 취소·수정 가드 PENDING → REQUESTED, 본사 시점 라벨 적용. 화면 진입 시 `poStore.fetchOrders()` 명시 호출로 stale data 방지.
- `WarehouseInboundView.vue`: STATUS_TABS 5개 ([전체] + READY_TO_SHIP/IN_TRANSIT/ARRIVED/COMPLETED), 입고 확정 가드 DELIVERED → ARRIVED, 진행 이력 4상태 필터, 액션 박스 4단계 분기, 창고 시점 라벨 적용. 화면 진입 시 `inbound.fetchAll()` 명시 호출.
- `stores/purchaseOrder.js`: statusCounts 7키, summary 의 REJECTED → CANCELLED.
- `stores/warehouse/warehouseInbound.js`: activeStatusTab 'READY_TO_SHIP' 시작, counts 5키 ('전체' 포함), inboundList computed 의 '전체' 케이스 처리.
- `stores/warehouse/warehouseDashboard.js`: 입고 예정 list status 'ARRIVED', shippingCount 합산 (kpi.scheduledCount fallback). `stores/warehouse/warehouseStock.js`: incoming 필터 SHIPPING → IN_TRANSIT.
- `views/hq/purchase-order/HqPurchaseOrderCreateView.vue`: 수정 가능 가드 두 곳 PENDING → REQUESTED. `views/warehouse/dashboard/WarehouseDashboardView.vue`: caption 'SHIPPING' → 'IN_PROGRESS'. `api/warehouse/inbound.js`: JSDoc 갱신.

<br><br>

## ✔️ 참고 사항
- 

<br><br>

## ✔️ 관련 이슈

- 

<br><br>
