### PR TITLE
refactor(warehouse): warehouseId 임시 query param 제거 (인증 도입 후속 정리)

### DIFF
--- a/src/api/warehouse/dashboard.js
+++ b/src/api/warehouse/dashboard.js
@@ -2,16 +2,17 @@
  * dashboard.js — BE 연동 (WHS-001 창고 관리자 대시보드)
  *
  * BE 엔드포인트:
- *   GET  /api/warehouse/dashboard/inbound-progress?warehouseId=&from=&to=
+ *   GET  /api/warehouse/dashboard/inbound-progress?from=&to=
  *
  * 응답: BaseResponse<InboundProgressRes>.
  *   result.kpi: { scheduledCount, completedCount, totalCount, progressRate, avgProcessingHours }
  *     - progressRate: 0~1 double
  *     - avgProcessingHours: createdAt → COMPLETED 평균 시간. 0건이면 null
- *     - totalCount: REJECTED 제외 전체 (입고 파이프라인 분모)
- *   result.statusBreakdown: { PENDING, APPROVED, SHIPPING, COMPLETED, REJECTED } 5키 모두 노출
+ *     - totalCount: CANCELLED 제외 전체 (입고 파이프라인 분모)
+ *   result.statusBreakdown: 7상태 모두 노출
  *
- * 인증 도입(ADR-011) 전 임시: warehouseId 는 옵셔널 query 파라미터.
+ * 자기 창고 데이터 격리는 BE 가 @AuthenticationPrincipal 의 locationCode 로 자동 처리 —
+ * FE 는 warehouseId 박지 않음.
  */
 
 import { apiClient, unwrap } from '../axios.js'
@@ -20,11 +21,10 @@ const BASE = '/api/warehouse/dashboard'
 
 export const dashboardApi = {
   /**
-   * @param {{warehouseId?: string, from?: string, to?: string}} params
+   * @param {{from?: string, to?: string}} params
    */
   getInboundProgress: (params = {}) => {
     const query = {}
-    if (params.warehouseId) query.warehouseId = params.warehouseId
     if (params.from) query.from = params.from
     if (params.to) query.to = params.to
     return apiClient.get(`${BASE}/inbound-progress`, { params: query }).then(unwrap)

--- a/src/api/warehouse/inbound.js
+++ b/src/api/warehouse/inbound.js
@@ -2,14 +2,15 @@
  * inbound.js — BE 연동 (WHS-005/007/008 창고 관리자 입고)
  *
  * BE 엔드포인트:
- *   GET    /api/warehouse/inbound?status=&warehouseId=&from=&to=    (입고 후보 목록 — READY_TO_SHIP/IN_TRANSIT/ARRIVED/COMPLETED 4상태)
- *   GET    /api/warehouse/inbound/{code}                            (상세 — items + statusHistory)
- *   POST   /api/warehouse/inbound/{code}/confirm                    (입고 확정 ARRIVED → COMPLETED)
+ *   GET    /api/warehouse/inbound?status=&from=&to=    (입고 후보 목록 — READY_TO_SHIP/IN_TRANSIT/ARRIVED/COMPLETED 4상태)
+ *   GET    /api/warehouse/inbound/{code}               (상세 — items + statusHistory)
+ *   POST   /api/warehouse/inbound/{code}/confirm       (입고 확정 ARRIVED → COMPLETED)
  *
  * 응답: BaseResponse<T>. unwrap() 으로 result 만 추출, 실패 시 throw.
  *
  * 단일 진실 원천(ADR-015) — BE InboundService 가 PurchaseOrder + statusHistory 를 그대로 활용.
- * 인증 도입(ADR-011) 전 임시: warehouseId 는 query 파라미터로 받음.
+ * 자기 창고 데이터 격리는 BE 가 @AuthenticationPrincipal 의 locationCode 로 자동 처리 —
+ * FE 는 warehouseId 박지 않음.
  */
 
 import { apiClient, unwrap } from '../axios.js'
@@ -19,12 +20,11 @@ const BASE = '/api/warehouse/inbound'
 export const inboundApi = {
   /**
    * 입고 후보 목록 조회.
-   * @param {{status?: 'READY_TO_SHIP'|'IN_TRANSIT'|'ARRIVED'|'COMPLETED', warehouseId?: string, from?: string, to?: string}} params
+   * @param {{status?: 'READY_TO_SHIP'|'IN_TRANSIT'|'ARRIVED'|'COMPLETED', from?: string, to?: string}} params
    */
   list: (params = {}) => {
     const query = {}
     if (params.status) query.status = params.status
-    if (params.warehouseId) query.warehouseId = params.warehouseId
     if (params.from) query.from = params.from
     if (params.to) query.to = params.to
     return apiClient.get(BASE, { params: query }).then(unwrap)
@@ -33,6 +33,6 @@ export const inboundApi = {
   /** 상세 조회 (items + statusHistory 포함) */
   detail: (code) => apiClient.get(`${BASE}/${code}`).then(unwrap),
 
-  /** 입고 확정 (SHIPPING → COMPLETED, WHS-007) */
+  /** 입고 확정 (ARRIVED → COMPLETED, WHS-007) */
   confirm: (code) => apiClient.post(`${BASE}/${code}/confirm`).then(unwrap),
 }

--- a/src/views/warehouse/dashboard/WarehouseDashboardView.vue
+++ b/src/views/warehouse/dashboard/WarehouseDashboardView.vue
@@ -97,13 +97,10 @@ watch(range, () => {
   dashStore.fetchInboundProgress(rangeParams.value)
 })
 
-// ─── 단일 창고 컨텍스트 (창고관리자가 본인 창고 1개 담당, 인증 도입 시 auth.user.warehouseId 로 교체) ──
-const warehouseId = 'WH-001'
-
-// 안전재고 미달 카운트 — 이 창고의 vendor_product 중 가용재고 < safetyStock × 1.5 행 개수
+// 안전재고 미달 카운트 — 인증 사용자의 자기 창고 vendor_product 중 가용재고 < safetyStock × 1.5 행 개수
 const shortageCount = computed(() => {
   const codes = (vendorStore.allVendorProducts ?? []).map((vp) => vp.productCode)
-  return stockStore.getShortageCount(warehouseId, codes)
+  return stockStore.getShortageCount(auth.user?.locationCode ?? '', codes)
 })
 
 // ─── KPI / breakdown — store getter 직접 사용 ───────────────────────────────


### PR DESCRIPTION
## 📌 요약
- BE 가 인증 사용자 기반 마이그레이션 끝내면서 `warehouseId` query param 더이상 받지 않게 됨. 인증 도입 전 임시로 박아뒀던 FE 측 하드코드와 옵셔널 query 파라미터 분기 정리

<br><br>

## 🎯 작업 내용
- `views/warehouse/dashboard/WarehouseDashboardView.vue` — `const warehouseId = 'WH-001'` 하드코드 제거 + 안전재고 미달 카운트 산출은 `auth.user?.locationCode` 직접 사용
- `api/warehouse/dashboard.js` / `inbound.js` — `getInboundProgress`/`list` 의 `warehouseId` 옵셔널 query 분기 제거 + JSDoc 업데이트
- BE 측 동일 사이클 (이슈 #189) 의 `@AuthenticationPrincipal` 마이그레이션과 paired

<br><br>

## ✔️ 참고 사항
- BE PR 머지 전에 본 PR 머지하면 BE 가 query param 무시하지만 FE 도 안 박으니 영향 없음 — 머지 순서 자유
- `auth.user.locationCode` 는 팀원 로그인 응답(`UserDto.LoginRes`) 에 이미 박혀 있어 추가 작업 불필요

<br><br>

## ✔️ 관련 이슈

- Close #397

<br><br>
