### PR TITLE
refactor: 매장 관리자 로그인 권한에 따라 판매/발주 화면을 본사 재고 api 대신 매장 재고 api로 변경

### DIFF
--- a/docs/codex/store/api/01-plan/프론트_매장범위강제_연동전환_계획.md
+++ b/docs/codex/store/api/01-plan/프론트_매장범위강제_연동전환_계획.md
@@ -1,0 +1,43 @@
+# 프론트 매장 범위 강제 연동 전환 계획 (판매+발주 전체, 완전 치환)
+
+## 1. 목표
+- 백엔드 계약 변경(`storeCode`, `storeLocationId` 제거)에 맞춰 매장 판매/발주 화면을 정렬한다.
+- 로그인 사용자 매장 식별은 `auth.user.locationCode/locationName` 기준으로 통일한다.
+- 재고 조회는 본사 공통 API가 아닌 매장 전용 API(`/api/store/inventories`)로 전환한다.
+
+## 2. 적용 범위
+- 판매: 등록, 내역
+- 발주: 등록, 내역, 분석
+- 대상 화면
+  - `StorePosView`
+  - `StoreSalesHistoryView`
+  - `StoreOrderRequestView`
+  - `StoreOrderHistoryView`
+  - `StoreOrderAnalysisView`
+
+## 3. 구현 계획
+
+### 3.1 API 계약 정리
+- 판매 생성 요청 payload에서 `storeCode` 제거
+- 발주 생성 요청 payload에서 `storeCode`, `storeLocationId` 제거
+- 판매 목록/발주 목록/발주 분석 요청에서 `storeCode` query 제거
+
+### 3.2 재고 조회 경로 전환
+- 판매 등록/발주 요청 화면의 `@/api/hq/inventory.js` 의존 제거
+- `@/api/store/inventory.js`의 `getStoreInventories`, `getStoreInventorySkus` 사용
+- 화면 모델에 맞게 재고/안전재고/가용재고/권장수량 매핑
+
+### 3.3 auth 필드 완전 치환
+- `auth.user.storeCode/storeName/storeLocationId` 참조 제거
+- `auth.user.locationCode/locationName`로 교체
+- 매장 정보 누락 가드 메시지와 조건도 `locationCode` 기준으로 변경
+
+## 4. 검증 기준
+- 판매/발주 생성이 매장 식별값 없이 정상 동작
+- 판매/발주 내역·분석 조회가 `storeCode` 없이 정상 동작
+- 판매/발주 등록 화면 SKU 로딩이 `/api/store/inventories` 기준으로 정상 동작
+- 기존 UX(검색/정렬/탭/상세 이동) 유지
+
+## 5. 가정
+- 백엔드 신계약이 선반영되어 있다.
+- `auth.user.locationCode/locationName`은 로그인 시 항상 유효하다.

--- a/src/views/store/orders/StoreOrderAnalysisView.vue
+++ b/src/views/store/orders/StoreOrderAnalysisView.vue
@@ -54,9 +54,9 @@ const activeTopMenu = computed(() => '발주 관리')
 // [함수] 발주 분석 API를 호출해 요약/랭킹 데이터를 갱신한다.
 async function fetchAnalytics() {
   try {
-    if (!auth.user?.storeCode || !auth.user?.storeLocationId) return
+    if (!auth.user?.locationCode) return
 
-    const res = await getStoreOrderAnalytics({ storeCode: auth.user.storeCode })
+    const res = await getStoreOrderAnalytics()
     analyticsSummary.value = {
       totalOrders: Number(res?.totalOrders ?? 0),
       totalRequestedQuantity: Number(res?.totalRequestedQuantity ?? 0),

--- a/src/views/store/orders/StoreOrderHistoryView.vue
+++ b/src/views/store/orders/StoreOrderHistoryView.vue
@@ -113,12 +113,11 @@ async function fetchOrders() {
   errorMessage.value = ''
 
   try {
-    if (!auth.user?.storeCode || !auth.user?.storeLocationId) {
+    if (!auth.user?.locationCode) {
       throw new Error('로그인 매장 정보가 없어 발주 내역을 조회할 수 없습니다.')
     }
 
     const result = await getStoreOrders({
-      storeCode: auth.user.storeCode,
       from: dateFrom.value || undefined,
       to: dateTo.value || undefined,
       keyword: searchKeyword.value?.trim() || undefined,

--- a/src/views/store/orders/StoreOrderRequestView.vue
+++ b/src/views/store/orders/StoreOrderRequestView.vue
@@ -11,7 +11,6 @@ import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
 import { createStoreOrder, getStoreOrderDetail, updateStoreOrder } from '@/api/store/orders.js'
 import { getStoreInventories, getStoreInventorySkus } from '@/api/store/inventory.js'
-import { getProductSkus } from '@/api/hq/productMaster.js'
 
 /**
  * ==============================================================================
@@ -341,20 +340,13 @@ async function loadSkuRows() {
     const items = await getStoreInventories()
 
     const skuGroups = await Promise.all(items.map((item) => getStoreInventorySkus(item.itemCode)))
-    const productSkuGroups = await Promise.all(items.map((item) => getProductSkus(item.itemCode)))
-
     const rows = []
     items.forEach((item, index) => {
       const skus = skuGroups[index] ?? []
-      const productSkus = productSkuGroups[index] ?? []
-      const unitPriceBySkuCode = new Map(
-        productSkus.map((productSku) => [productSku.skuCode, Number(productSku.unitPrice ?? 0)]),
-      )
 
       skus.forEach((sku) => {
         const stock = Number(sku.actualStock ?? 0)
         const safetyStock = Number(sku.safetyStock ?? 0)
-        const inboundExpectedQuantity = Number(sku.inboundExpectedQuantity ?? 0)
 
         rows.push({
           skuId: sku.skuCode,
@@ -365,7 +357,7 @@ async function loadSkuRows() {
           subCategory: item.childCategory,
           color: sku.color,
           size: sku.size,
-          unitPrice: Number(sku.unitPrice ?? unitPriceBySkuCode.get(sku.skuCode) ?? 0),
+          unitPrice: Number(sku.unitPrice ?? 0),
           stock,
           safetyStock,
           inboundExpectedQuantity: Number(sku.inboundExpectedQuantity ?? 0),

--- a/src/views/store/orders/StoreOrderRequestView.vue
+++ b/src/views/store/orders/StoreOrderRequestView.vue
@@ -10,7 +10,7 @@ import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
 import { createStoreOrder, getStoreOrderDetail, updateStoreOrder } from '@/api/store/orders.js'
-import { getCompanyWideInventories, getCompanyWideInventorySkus } from '@/api/hq/inventory.js'
+import { getStoreInventories, getStoreInventorySkus } from '@/api/store/inventory.js'
 import { getProductSkus } from '@/api/hq/productMaster.js'
 
 /**
@@ -234,7 +234,7 @@ function decreaseLine(line) {
 async function submitRequest() {
   feedbackMessage.value = ''
 
-  if (!auth.user?.storeCode || !auth.user?.storeLocationId) {
+  if (!auth.user?.locationCode) {
     showFeedback('로그인 매장 정보가 없어 발주를 진행할 수 없습니다.', 'error')
     return
   }
@@ -274,8 +274,6 @@ async function submitRequest() {
 
   try {
     const result = await createStoreOrder({
-      storeCode: auth.user.storeCode,
-      storeLocationId: String(auth.user.storeLocationId),
       requestedByMemberId: auth.user.employeeCode ?? '',
       requestedByName: auth.user.name ?? '매장 관리자',
       memo: memo.value,
@@ -332,8 +330,7 @@ async function loadEditingOrder() {
 
 // [함수] 로그인 매장 기준으로 발주 가능 SKU 목록을 조회해 화면 상태를 갱신한다.
 async function loadSkuRows() {
-  const locationId = auth.user?.storeLocationId
-  if (!locationId) {
+  if (!auth.user?.locationCode) {
     showFeedback('매장 위치 정보가 없어 SKU 목록을 불러올 수 없습니다.', 'error')
     skuRows.value = []
     return
@@ -341,11 +338,9 @@ async function loadSkuRows() {
 
   loading.value = true
   try {
-    const params = { locationType: 'STORE', locationIds: [locationId] }
-    const page = await getCompanyWideInventories(params)
-    const items = page?.items ?? []
+    const items = await getStoreInventories()
 
-    const skuGroups = await Promise.all(items.map((item) => getCompanyWideInventorySkus(item.itemCode, params)))
+    const skuGroups = await Promise.all(items.map((item) => getStoreInventorySkus(item.itemCode)))
     const productSkuGroups = await Promise.all(items.map((item) => getProductSkus(item.itemCode)))
 
     const rows = []
@@ -373,8 +368,8 @@ async function loadSkuRows() {
           unitPrice: Number(sku.unitPrice ?? unitPriceBySkuCode.get(sku.skuCode) ?? 0),
           stock,
           safetyStock,
-          inboundExpectedQuantity,
-          availableStoreStock: stock + inboundExpectedQuantity,
+          inboundExpectedQuantity: Number(sku.inboundExpectedQuantity ?? 0),
+          availableStoreStock: Number(sku.availableStock ?? 0),
           recommendedQuantity: Math.max(0, safetyStock - stock),
           stockStatus: stock === 0 ? 'out' : stock <= safetyStock ? 'low' : 'normal',
         })
@@ -443,7 +438,7 @@ onMounted(async () => {
             </p>
           </div>
           <div class="text-right text-[11px] font-bold text-gray-500">
-            <p>{{ auth.user?.storeName ?? '매장' }} · 요청서 {{ requestLines.length }}건</p>
+            <p>{{ auth.user?.locationName ?? '매장' }} · 요청서 {{ requestLines.length }}건</p>
             <p class="mt-1 text-gray-400">
               총 요청 수량 {{ totalRequestedQuantity }}개 · 권장 수량
               {{ totalRecommendedQuantity }}개

--- a/src/views/store/sales/StorePosView.vue
+++ b/src/views/store/sales/StorePosView.vue
@@ -11,7 +11,6 @@ import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
 import { useSalesStore } from '@/stores/store/storeSales.js'
 import { getStoreInventories, getStoreInventorySkus } from '@/api/store/inventory.js'
-import { getProductSkus } from '@/api/hq/productMaster.js'
 import { createSale } from '@/api/store/sales.js'
 
 import { Plus, Ban } from 'lucide-vue-next'
@@ -293,17 +292,10 @@ async function loadStoreSkus() {
     const skuLists = await Promise.all(
       items.map((item) => getStoreInventorySkus(item.itemCode)),
     )
-    const productSkuLists = await Promise.all(
-      items.map((item) => getProductSkus(item.itemCode)),
-    )
 
     const rows = []
     items.forEach((item, idx) => {
       const skus = skuLists[idx] ?? []
-      const productSkus = productSkuLists[idx] ?? []
-      const unitPriceBySkuCode = new Map(
-        productSkus.map((productSku) => [productSku.skuCode, Number(productSku.unitPrice ?? 0)]),
-      )
       skus.forEach((sku) => {
         rows.push({
           skuId: sku.skuCode,
@@ -313,7 +305,7 @@ async function loadStoreSkus() {
           subCategory: item.childCategory,
           color: sku.color,
           size: sku.size,
-          unitPrice: Number(sku.unitPrice ?? unitPriceBySkuCode.get(sku.skuCode) ?? 0),
+          unitPrice: Number(sku.unitPrice ?? 0),
           stock: Number(sku.actualStock ?? 0),
           safetyStock: sku.safetyStock ?? 0,
           status: sku.status,

--- a/src/views/store/sales/StorePosView.vue
+++ b/src/views/store/sales/StorePosView.vue
@@ -10,7 +10,7 @@ import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
 import { useSalesStore } from '@/stores/store/storeSales.js'
-import { getCompanyWideInventories, getCompanyWideInventorySkus } from '@/api/hq/inventory.js'
+import { getStoreInventories, getStoreInventorySkus } from '@/api/store/inventory.js'
 import { getProductSkus } from '@/api/hq/productMaster.js'
 import { createSale } from '@/api/store/sales.js'
 
@@ -36,10 +36,7 @@ const selectedSubCategory = ref('전체')
 const selectedColor = ref('전체')
 const searchTerm = ref('')
 const salesLines = ref([])
-const saleRequest = reactive({
-  storeCode: '',
-  items: [],
-})
+const saleRequest = reactive({ items: [] })
 const feedbackMessage = ref('')
 const isSuccessModalOpen = ref(false)
 const completedSale = ref(null)
@@ -205,12 +202,7 @@ function clearSalesList() {
 // [함수] 판매 등록 API를 호출하고 성공/실패 상태를 처리한다.
 async function confirmSale() {
   feedbackMessage.value = ''
-  saleRequest.storeCode = auth.user?.storeCode ?? ''
   saleRequest.items = salesLines.value.map((line) => ({ skuCode: line.skuId, quantity: line.quantity }))
-  if (!saleRequest.storeCode) {
-    feedbackMessage.value = '매장 코드가 없어 판매를 진행할 수 없습니다.'
-    return
-  }
   if (saleRequest.items.length === 0) {
     feedbackMessage.value = '판매 목록이 비어 있습니다.'
     return
@@ -288,8 +280,7 @@ function stockStatus(sku) {
 
 // [함수] 로그인 매장의 상품/SKU 재고 데이터를 조회해 POS 테이블 모델로 매핑한다.
 async function loadStoreSkus() {
-  const locationId = auth.user?.storeLocationId
-  if (!locationId) {
+  if (!auth.user?.locationCode) {
     feedbackMessage.value = '매장 위치 정보가 없어 상품/재고를 불러올 수 없습니다.'
     return
   }
@@ -297,12 +288,10 @@ async function loadStoreSkus() {
   loadingSkus.value = true
   feedbackMessage.value = ''
   try {
-    const params = { locationType: 'STORE', locationIds: [locationId] }
-    const page = await getCompanyWideInventories(params)
-    const items = page?.items ?? []
+    const items = await getStoreInventories()
 
     const skuLists = await Promise.all(
-      items.map((item) => getCompanyWideInventorySkus(item.itemCode, params)),
+      items.map((item) => getStoreInventorySkus(item.itemCode)),
     )
     const productSkuLists = await Promise.all(
       items.map((item) => getProductSkus(item.itemCode)),
@@ -325,7 +314,7 @@ async function loadStoreSkus() {
           color: sku.color,
           size: sku.size,
           unitPrice: Number(sku.unitPrice ?? unitPriceBySkuCode.get(sku.skuCode) ?? 0),
-          stock: sku.actualStock ?? 0,
+          stock: Number(sku.actualStock ?? 0),
           safetyStock: sku.safetyStock ?? 0,
           status: sku.status,
         })

--- a/src/views/store/sales/StoreSalesHistoryView.vue
+++ b/src/views/store/sales/StoreSalesHistoryView.vue
@@ -31,7 +31,6 @@ const activeSubMenu = ref('판매 내역')
 const searchTerm = ref('')
 const selectedSaleId = ref('')
 const listQuery = reactive({
-  storeCode: '',
   from: '',
   to: '',
   keyword: '',
@@ -77,13 +76,16 @@ function headlineLabel(sale) {
  */
 // [함수] 판매 목록 API를 호출하고 화면 상태를 갱신한다.
 async function loadSales() {
-  listQuery.storeCode = auth.user?.storeCode ?? ''
+  if (!auth.user?.locationCode) {
+    sales.setError('로그인 매장 정보가 없어 판매 내역을 조회할 수 없습니다.')
+    sales.setSales([])
+    return
+  }
   listQuery.keyword = searchTerm.value.trim()
   try {
     sales.setLoading(true)
     sales.setError('')
     const params = {}
-    if (listQuery.storeCode) params.storeCode = listQuery.storeCode
     if (listQuery.from) params.from = listQuery.from
     if (listQuery.to) params.to = listQuery.to
     if (listQuery.keyword) params.keyword = listQuery.keyword


### PR DESCRIPTION
## 📌 요약
- 백엔드 신계약(회원가입/로그인 기능 개발 완료)에 맞춰 판매/발주 화면 전반을 `locationCode/locationName` 기준으로 전환
- 매장 화면의 HQ API 의존을 제거했습니다.

<br><br>

## 🎯 작업 내용
- 판매/발주 등록/내역/분석 화면에서 `auth.user.storeCode/storeName/storeLocationId` 참조 제거
- `auth.user.locationCode/locationName` 기준으로 매장 가드/표시/요청 흐름 통일
- API 계약 정리:
  - 판매 생성 payload에서 `storeCode` 제거
  - 발주 생성 payload에서 `storeCode`, `storeLocationId` 제거
  - 판매/발주 목록/분석 호출에서 `storeCode` query 제거
- 재고 조회 경로 전환:
  - `StorePosView`, `StoreOrderRequestView`에서 HQ SKU API(`@/api/hq/productMaster`) 제거
  - 매장 재고 API(`@/api/store/inventory`) 기반으로 SKU 목록/재고 매핑
- 런타임 이슈 수정:
  - 매장 권한에서 `/api/hq/*` 호출로 발생하던 GET 연쇄 실패/로그인 이탈 문제 해소

<br><br>

## ✔️ 참고 사항
- 매장 화면은 서버가 로그인 매장 범위를 강제하므로 클라이언트 파라미터 조작으로 타 매장 조회가 불가해야 합니다.
- 로컬 빌드 검증은 실행 환경(Windows 실행 정책/oxide 모듈 로딩) 이슈가 있어 별도 환경 점검이 필요합니다.

<br><br>

## ✔️ 관련 이슈

- Close #236 

<br><br>