### PR TITLE
refactor(purchase-order): 본사 발주 상태 탭 8→5 그루핑 + 승인 대기 강조

### DIFF
--- a/src/stores/purchaseOrder.js
+++ b/src/stores/purchaseOrder.js
@@ -4,7 +4,7 @@ import { purchaseOrderApi } from '@/api/hq/purchaseOrder.js'
 import { getInfrastructures } from '@/api/hq/infrastructure.js'
 import { useAuthStore } from '@/stores/auth.js'
 
-// SYS-001 배치가 자동 처리하는 거래처 책임 단계 묶음.
+// SYS-001 배치가 자동 처리하는 공급처 책임 단계 묶음.
 // 본사 관리자는 액션 불가 — UI 탭에서 하나로 그루핑한다.
 export const VENDOR_PROCESSING_STATUSES = ['APPROVED', 'READY_TO_SHIP', 'IN_TRANSIT', 'ARRIVED']
 

--- a/src/stores/purchaseOrder.js
+++ b/src/stores/purchaseOrder.js
@@ -4,6 +4,10 @@ import { purchaseOrderApi } from '@/api/hq/purchaseOrder.js'
 import { getInfrastructures } from '@/api/hq/infrastructure.js'
 import { useAuthStore } from '@/stores/auth.js'
 
+// SYS-001 배치가 자동 처리하는 거래처 책임 단계 묶음.
+// 본사 관리자는 액션 불가 — UI 탭에서 하나로 그루핑한다.
+export const VENDOR_PROCESSING_STATUSES = ['APPROVED', 'READY_TO_SHIP', 'IN_TRANSIT', 'ARRIVED']
+
 // ─── BE ↔ FE 매핑 헬퍼 ─────────────────────────────────────────────────────
 // BE (PurchaseOrder DetailRes/ListRes) ↔ FE store 형식 변환.
 // 매핑:
@@ -18,8 +22,7 @@ import { useAuthStore } from '@/stores/auth.js'
 function toFeOrder(beOrder) {
   if (!beOrder) return null
   // BE ListRes 는 itemCount + productNames, DetailRes 는 items 배열만 보내므로 fallback 처리.
-  const itemCount =
-    beOrder.itemCount ?? (Array.isArray(beOrder.items) ? beOrder.items.length : 0)
+  const itemCount = beOrder.itemCount ?? (Array.isArray(beOrder.items) ? beOrder.items.length : 0)
   // ListRes 의 productNames 우선, DetailRes 면 items.productName 으로 fallback (목록 검색·표시 일관성).
   const productNames = Array.isArray(beOrder.productNames)
     ? beOrder.productNames
@@ -57,7 +60,7 @@ function toFeItem(beItem) {
     skuCode: beItem.skuCode ?? '',
     color: beItem.color ?? '',
     size: beItem.size ?? '',
-    displayOption: beItem.displayOption ?? [beItem.color, beItem.size].filter(Boolean).join('/') ,
+    displayOption: beItem.displayOption ?? [beItem.color, beItem.size].filter(Boolean).join('/'),
     quantity: beItem.quantity,
     unitPrice: beItem.unitPrice,
     subtotal: beItem.subtotal,
@@ -88,13 +91,15 @@ function toFeCatalogMaster(beMaster) {
     contractUnitPrice: beMaster.contractUnitPrice,
     minSkuUnitPrice: beMaster.minSkuUnitPrice,
     maxSkuUnitPrice: beMaster.maxSkuUnitPrice,
-    skus: Array.isArray(beMaster.skus) ? beMaster.skus.map((s) => ({
-      skuCode: s.skuCode,
-      color: s.color ?? '',
-      size: s.size ?? '',
-      displayOption: s.displayOption ?? [s.color, s.size].filter(Boolean).join('/') ,
-      unitPrice: s.unitPrice,
-    })) : [],
+    skus: Array.isArray(beMaster.skus)
+      ? beMaster.skus.map((s) => ({
+          skuCode: s.skuCode,
+          color: s.color ?? '',
+          size: s.size ?? '',
+          displayOption: s.displayOption ?? [s.color, s.size].filter(Boolean).join('/'),
+          unitPrice: s.unitPrice,
+        }))
+      : [],
   }
 }
 
@@ -155,7 +160,9 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
   const filteredOrders = computed(() => {
     let list = purchaseOrders.value
 
-    if (activeStatusTab.value !== '전체') {
+    if (activeStatusTab.value === 'VENDOR_PROCESSING') {
+      list = list.filter((o) => VENDOR_PROCESSING_STATUSES.includes(o.status))
+    } else if (activeStatusTab.value !== '전체') {
       list = list.filter((o) => o.status === activeStatusTab.value)
     }
 
@@ -208,6 +215,7 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
       ARRIVED: all.filter((o) => o.status === 'ARRIVED').length,
       COMPLETED: all.filter((o) => o.status === 'COMPLETED').length,
       CANCELLED: all.filter((o) => o.status === 'CANCELLED').length,
+      VENDOR_PROCESSING: all.filter((o) => VENDOR_PROCESSING_STATUSES.includes(o.status)).length,
     }
   })
 
@@ -306,9 +314,7 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
     catalogError.value = null
     try {
       const res = await purchaseOrderApi.getCatalog({ vendorCode, warehouseCode })
-      catalogMasters.value = Array.isArray(res?.masters)
-        ? res.masters.map(toFeCatalogMaster)
-        : []
+      catalogMasters.value = Array.isArray(res?.masters) ? res.masters.map(toFeCatalogMaster) : []
       catalogFacets.value = Array.isArray(res?.optionFacets)
         ? res.optionFacets.map(toFeCatalogFacet)
         : []

--- a/src/views/hq/purchase-order/HqPurchaseOrderView.vue
+++ b/src/views/hq/purchase-order/HqPurchaseOrderView.vue
@@ -28,13 +28,13 @@ function handleLogout() {
 
 // ─── 상태 탭 ────────────────────────────────────────────────────────────────
 // 본사 화면이라 COMPLETED 라벨은 "종료" (창고 화면은 "입고 완료").
-// 거래처 책임 4단계(APPROVED/READY_TO_SHIP/IN_TRANSIT/ARRIVED)는 SYS-001 배치가
-// 자동 처리하므로 본사는 액션 불가 — '거래처 처리 중' 한 탭으로 그루핑해 인지 부담 감소.
+// 공급처 책임 4단계(APPROVED/READY_TO_SHIP/IN_TRANSIT/ARRIVED)는 SYS-001 배치가
+// 자동 처리하므로 본사는 액션 불가 — '공급처 처리 중' 한 탭으로 그루핑해 인지 부담 감소.
 // 세부 단계는 우측 상세의 진행 이력 타임라인이 시각화한다.
 const STATUS_TABS = [
   { label: '전체', key: '전체' },
   { label: '승인 대기', key: 'REQUESTED' },
-  { label: '거래처 처리 중', key: 'VENDOR_PROCESSING' },
+  { label: '공급처 처리 중', key: 'VENDOR_PROCESSING' },
   { label: '종료', key: 'COMPLETED' },
   { label: '취소', key: 'CANCELLED' },
 ]
@@ -61,7 +61,7 @@ function triggerToast(message) {
 }
 
 // ─── SYS-001 배치 강제 트리거 (시연·QA용) ─────────────────────────────────
-// 30분 대기 조건을 무시하고 거래처 책임 4단계(REQUESTED/APPROVED/READY_TO_SHIP/IN_TRANSIT)
+// 30분 대기 조건을 무시하고 공급처 책임 4단계(REQUESTED/APPROVED/READY_TO_SHIP/IN_TRANSIT)
 // 모두 즉시 다음 단계로 넘긴다.
 const isRunningBatch = ref(false)
 async function runBatchTrigger() {
@@ -89,7 +89,7 @@ async function runBatchTrigger() {
 }
 
 // ─── 발주 취소 (CEN-038) ────────────────────────────────────────────────────
-// REQUESTED (승인 대기) 단계에서만 취소 가능. 그 이후는 거래처가 이미 받았으므로 차단.
+// REQUESTED (승인 대기) 단계에서만 취소 가능. 그 이후는 공급처가 이미 받았으므로 차단.
 function openCancelConfirm() {
   if (poStore.selectedOrder?.status !== 'REQUESTED') return
   cancelReason.value = '' // 모달 열 때마다 초기화

--- a/src/views/hq/purchase-order/HqPurchaseOrderView.vue
+++ b/src/views/hq/purchase-order/HqPurchaseOrderView.vue
@@ -27,14 +27,14 @@ function handleLogout() {
 }
 
 // ─── 상태 탭 ────────────────────────────────────────────────────────────────
-// 본사 화면이라 COMPLETED 라벨은 "종료" (창고 화면은 "입고 완료")
+// 본사 화면이라 COMPLETED 라벨은 "종료" (창고 화면은 "입고 완료").
+// 거래처 책임 4단계(APPROVED/READY_TO_SHIP/IN_TRANSIT/ARRIVED)는 SYS-001 배치가
+// 자동 처리하므로 본사는 액션 불가 — '거래처 처리 중' 한 탭으로 그루핑해 인지 부담 감소.
+// 세부 단계는 우측 상세의 진행 이력 타임라인이 시각화한다.
 const STATUS_TABS = [
   { label: '전체', key: '전체' },
   { label: '승인 대기', key: 'REQUESTED' },
-  { label: '승인 완료', key: 'APPROVED' },
-  { label: '배송 준비 중', key: 'READY_TO_SHIP' },
-  { label: '배송 중', key: 'IN_TRANSIT' },
-  { label: '배송 완료', key: 'ARRIVED' },
+  { label: '거래처 처리 중', key: 'VENDOR_PROCESSING' },
   { label: '종료', key: 'COMPLETED' },
   { label: '취소', key: 'CANCELLED' },
 ]
@@ -69,10 +69,11 @@ async function runBatchTrigger() {
   isRunningBatch.value = true
   try {
     const result = await poStore.runBatch()
-    const total = (result?.approved ?? 0)
-      + (result?.readyToShip ?? 0)
-      + (result?.inTransit ?? 0)
-      + (result?.arrived ?? 0)
+    const total =
+      (result?.approved ?? 0) +
+      (result?.readyToShip ?? 0) +
+      (result?.inTransit ?? 0) +
+      (result?.arrived ?? 0)
     if (total === 0) {
       triggerToast('자동 전환 대상 발주가 없습니다')
     } else {
@@ -290,9 +291,7 @@ const TruckIcon = IconBase([
   >
     <div class="flex flex-col gap-4">
       <!-- 총 발주 요약 (공급처/기간 컨텍스트 반영) -->
-      <section
-        class="flex items-center gap-4 border border-gray-200 bg-white px-5 py-4 shadow-sm"
-      >
+      <section class="flex items-center gap-4 border border-gray-200 bg-white px-5 py-4 shadow-sm">
         <div
           class="flex h-12 w-12 shrink-0 items-center justify-center bg-[#E6F2F0] text-[#004D3C]"
         >
@@ -339,6 +338,16 @@ const TruckIcon = IconBase([
             >
               {{ poStore.statusCounts[tab.key] }}
             </span>
+            <!-- 본사 액션 가능 단계 강조 — REQUESTED 카운트 > 0 + 비활성 탭일 때만 -->
+            <span
+              v-if="
+                tab.key === 'REQUESTED' &&
+                poStore.statusCounts.REQUESTED > 0 &&
+                poStore.activeStatusTab !== 'REQUESTED'
+              "
+              class="ml-0.5 inline-block h-1.5 w-1.5 rounded-full bg-amber-500"
+              aria-hidden="true"
+            />
           </button>
         </div>
       </section>
@@ -577,10 +586,16 @@ const TruckIcon = IconBase([
                   </tr>
                 </thead>
                 <tbody class="divide-y divide-gray-100">
-                  <tr v-for="item in poStore.selectedOrder.items" :key="item.skuCode || item.productId">
+                  <tr
+                    v-for="item in poStore.selectedOrder.items"
+                    :key="item.skuCode || item.productId"
+                  >
                     <td class="px-2 py-2 align-top">
                       <div class="font-bold text-gray-800">{{ item.productName }}</div>
-                      <div v-if="item.displayOption" class="mt-0.5 text-[11px] font-bold text-[#004D3C]">
+                      <div
+                        v-if="item.displayOption"
+                        class="mt-0.5 text-[11px] font-bold text-[#004D3C]"
+                      >
                         {{ item.displayOption }}
                       </div>
                       <div v-if="item.skuCode" class="text-[10px] text-gray-400">
@@ -631,9 +646,7 @@ const TruckIcon = IconBase([
                   <p class="text-[11px] font-black" :class="historyTextClass(h.status)">
                     {{ statusLabel(h.status) }}
                   </p>
-                  <p class="text-[10px] text-gray-500">
-                    {{ formatDate(h.at) }} · {{ h.byName }}
-                  </p>
+                  <p class="text-[10px] text-gray-500">{{ formatDate(h.at) }} · {{ h.byName }}</p>
                 </li>
               </ol>
             </section>
@@ -686,14 +699,14 @@ const TruckIcon = IconBase([
             </template>
 
             <template v-else-if="poStore.selectedOrder.status === 'ARRIVED'">
-              <p class="text-center text-xs text-gray-500">
-                배송 완료 · 창고 입고 확정 대기
-              </p>
+              <p class="text-center text-xs text-gray-500">배송 완료 · 창고 입고 확정 대기</p>
             </template>
 
             <template v-else>
               <p
-                v-if="poStore.selectedOrder.status === 'CANCELLED' && poStore.selectedOrder.cancelReason"
+                v-if="
+                  poStore.selectedOrder.status === 'CANCELLED' && poStore.selectedOrder.cancelReason
+                "
                 class="border border-red-200 bg-red-50 px-3 py-2.5 text-[11px] font-bold leading-relaxed text-red-700"
               >
                 취소 사유: {{ poStore.selectedOrder.cancelReason }}
@@ -757,7 +770,9 @@ const TruckIcon = IconBase([
             취소 후에는 되돌릴 수 없습니다. 같은 발주가 필요하면 새 발주로 다시 만들어야 합니다.
           </p>
         </div>
-        <div class="flex items-center justify-end gap-2 border-t border-gray-200 bg-gray-50 px-5 py-3">
+        <div
+          class="flex items-center justify-end gap-2 border-t border-gray-200 bg-gray-50 px-5 py-3"
+        >
           <button
             type="button"
             class="border border-gray-300 bg-white px-4 py-2 text-xs font-black text-gray-700 hover:bg-gray-100"
@@ -790,6 +805,5 @@ const TruckIcon = IconBase([
         {{ toast.message }}
       </div>
     </Transition>
-
   </AppLayout>
 </template>


### PR DESCRIPTION
## 📌 요약
- 본사 발주 화면 (`/hq/purchase-orders`) 의 상단 상태 탭을 8개에서 5개로 그루핑하여 본사 관리자의 의사결정 부담을 줄였다.

<br><br>

## 🎯 작업 내용
- `purchaseOrder` store 에 `VENDOR_PROCESSING_STATUSES` 상수와 `statusCounts.VENDOR_PROCESSING` 키 추가, `filteredOrders` 의 status 필터에 그룹 매칭 분기 도입 (기존 7개 개별 카운트 키는 그대로 유지)
- `HqPurchaseOrderView.vue` 의 `STATUS_TABS` 를 `[전체 / 승인 대기 / 공급처 처리 중 / 종료 / 취소]` 5탭으로 재구성. 공급처 책임 4단계 (`APPROVED / READY_TO_SHIP / IN_TRANSIT / ARRIVED`) 는 SYS-001 배치 자동 처리 구간이라 한 탭으로 묶음
- 비활성 "승인 대기" 탭에 `REQUESTED` 카운트 > 0 일 때만 amber 점 배지 노출 — 본사 액션 가능 단계만 시각적 강조
- 새로 추가한 코드/주석의 용어를 기존 일관된 호칭인 `공급처` 로 통일 (`거래처` → `공급처`)
- 우측 상세 패널의 상태별 안내 박스와 진행 이력 타임라인의 7-상태 매핑은 유지 — 묶인 4단계 세부 진행은 타임라인이 시각화

<br><br>

## ✔️ 참고 사항
- 

<br><br>

## ✔️ 관련 이슈

- Close #403

<br><br>
