### PR TITLE
fix(purchase-order): 새 발주 페이지 입고창고 셀렉트 폭 흔들림/창고 목록 미로딩 회귀 정리

### DIFF
--- a/src/views/hq/purchase-order/HqPurchaseOrderCreateView.vue
+++ b/src/views/hq/purchase-order/HqPurchaseOrderCreateView.vue
@@ -828,6 +828,10 @@ onMounted(() => {
     loadDraft()
   }
   reloadCatalog()
+  // 인증 hydrate race 로 store 마운트 시점 fetch 가 스킵될 수 있어 보장 fetch.
+  if (poStore.warehouses.length === 0) {
+    poStore.fetchWarehouses()
+  }
 })
 
 // 공급처 필터 변경 시 server-side 재 fetch (한 공급처 결과만 받기)
@@ -919,7 +923,7 @@ const AlertTriangleIcon = IconBase([
           <select
             ref="warehouseSelectRef"
             :value="selectedWarehouseCode"
-            class="border border-gray-300 bg-white px-3 py-1.5 text-xs outline-none focus:border-[#004D3C]"
+            class="min-w-[160px] border border-gray-300 bg-white px-3 py-1.5 text-xs outline-none focus:border-[#004D3C]"
             @change="handleWarehouseChange($event.target.value)"
           >
             <option value="">창고 선택</option>


### PR DESCRIPTION
## 📌 요약
- 본사 [새 발주] 화면 입고창고 셀렉트 폭이 fetch 전후 흔들리고, 새로고침 직후 직접 진입 시 옵션 목록이 비는 회귀 2건 정리.

<br><br>

## 🎯 작업 내용
- `HqPurchaseOrderCreateView.vue:919` 셀렉트에 `min-w-[160px]` 추가해 옵션 텍스트 길이와 무관하게 폭 고정 (fetch 전후 시각 변동 차단).
- 페이지 `onMounted` 에 `if (poStore.warehouses.length === 0) poStore.fetchWarehouses()` 보장 fetch 한 줄 추가 — store 마운트 시 인증 hydrate race 로 자동 fetch 가 스킵되더라도 페이지 진입 시점에 라우터 가드를 통과한 상태이므로 안전하게 채움.
- store / BE 미변경 (FE-only, view 한 파일).

<br><br>

## ✔️ 참고 사항
- 

<br><br>

## ✔️ 관련 이슈

- Close #408

<br><br>
