### PR TITLE
refactor(warehouse-inbound): 창고 입고 페이지 inbound 도메인 응답 기준 재구성

### DIFF
--- a/src/stores/warehouse/warehouseInbound.js
+++ b/src/stores/warehouse/warehouseInbound.js
@@ -5,75 +5,76 @@ import { inboundApi } from '@/api/warehouse/inbound.js'
 /**
  * WHS-005/007/008 창고 관리자 입고 store.
  *
- * 단일 진실 원천(ADR-015) — BE InboundController(`/api/warehouse/inbound`) 가 직접 응답.
- * 권한군 격리 — 본사 도메인 store(`purchaseOrder.js`) 의존 X. 그 store 는
- * 마운트 시 `/api/hq/**` 자동 fetch 라 창고 관리자(role=WAREHOUSE) 권한으로 호출 시
- * SecurityConfig 가 차단(401/403). 자체 axios 호출로 분리.
+ * BE 의 신설 inbound 도메인(`/api/warehouse/inbound`) 응답 기반.
+ * 본사 발주 입고 + 창고간 이동 입고 두 source 통합 (이번 사이클은 PURCHASE_ORDER 만 active).
  *
- * BE 응답(PurchaseOrderDto.ListRes / DetailRes) 의 code 를 FE 의 id 로 매핑해
- * 컴포넌트의 `order.id` 호환 유지.
+ * id 호환 — `entity.id` 컴포넌트 패턴 보존을 위해 inboundCode 를 id 로 노출.
+ * totalPrice 는 totalAmount 의 alias (기존 컴포넌트 호환).
  */
 export const useWarehouseInboundStore = defineStore('warehouseInbound', () => {
   // --- state ---
-  const items = ref([]) // 입고 후보 발주 목록 (READY_TO_SHIP/IN_TRANSIT/ARRIVED/COMPLETED)
-  const selectedDetail = ref(null) // 선택된 발주의 상세 (items + statusHistory 포함)
+  const items = ref([])
+  const selectedDetail = ref(null)
   const loading = ref(false)
   const error = ref(null)
 
-  // 창고 화면 5탭 — [전체] + 거래처 책임 4단계 (READY_TO_SHIP/IN_TRANSIT/ARRIVED/COMPLETED).
-  // 첫 진입 시 [전체] 활성 — STATUS_TABS 첫 항목과 일치시켜 사용자 멘탈 모델 보존.
-  // 입고 확정([입고 완료] 액션) 은 ARRIVED 일 때만 가능.
+  // 5탭 — [전체 / READY_TO_SHIP / IN_TRANSIT / ARRIVED / COMPLETED]
   const activeStatusTab = ref('전체')
   const selectedOrderId = ref(null)
   const searchKeyword = ref('')
   const dateFrom = ref('')
   const dateTo = ref('')
-  const sortBy = ref('latest') // 'latest' | 'oldest' | 'priceAsc' | 'priceDesc'
+  const sortBy = ref('latest')
 
-  // --- BE 응답 매핑 ---
-  // BE list/detail 응답의 code 를 FE id 로 노출, snake/camel 키 통일.
-  function fromListApi(po) {
+  // --- BE WhInboundDto 응답 매핑 ---
+  function fromListApi(v) {
     return {
-      id: po.code,
-      code: po.code,
-      vendorId: po.vendorCode,
-      vendorName: po.vendorName,
-      warehouseId: po.warehouseId,
-      warehouseName: po.warehouseName,
-      warehouseCode: po.warehouseCode,
-      status: po.status,
-      totalPrice: po.totalAmount,
-      itemCount: po.itemCount,
-      productNames: po.productNames ?? [],
-      createdAt: po.createdAt,
-      updatedAt: po.updatedAt,
+      id: v.inboundCode,
+      inboundCode: v.inboundCode,
+      inboundType: v.inboundType,        // 'PURCHASE_ORDER' | 'WAREHOUSE_TRANSFER'
+      sourceRefNo: v.sourceRefNo,        // PO-... | STF-...
+      sourceName: v.sourceName,          // 공급처명 | 출발창고명
+      warehouseName: v.warehouseName,
+      status: v.status,
+      totalQuantity: v.totalQuantity ?? 0,
+      totalAmount: v.totalAmount ?? null,
+      totalPrice: v.totalAmount ?? null, // 기존 컴포넌트 호환 alias
+      productNames: v.productNames ?? [],
+      createdAt: v.createdAt,
+      arrivedAt: v.arrivedAt ?? null,
+      completedAt: v.completedAt ?? null,
+      // 호환 — 기존 컴포넌트가 vendorName 직접 접근 시 sourceName 그대로
+      vendorName: v.sourceName,
       // detail 채워질 때까지 빈 배열로 노출
       items: [],
       statusHistory: [],
     }
   }
 
-  // BE PurchaseOrderDto.DetailRes 응답엔 productNames/itemCount 가 없음 (ListRes 만 보유) —
-  // fromListApi 를 spread 하면 두 필드를 빈 값으로 박아 selectOrder→fetchDetail 머지 시
-  // list 의 productNames 를 덮는 회귀가 발생. 의도적으로 detail 응답에 실제 있는 필드만 매핑.
-  function fromDetailApi(po) {
+  function fromDetailApi(v) {
     return {
-      id: po.code,
-      code: po.code,
-      vendorId: po.vendorCode,
-      vendorName: po.vendorName,
-      warehouseId: po.warehouseId,
-      warehouseName: po.warehouseName,
-      warehouseCode: po.warehouseCode,
-      status: po.status,
-      totalPrice: po.totalAmount,
-      createdAt: po.createdAt,
-      updatedAt: po.updatedAt,
-      items: (po.items ?? []).map((it) => ({
+      id: v.inboundCode,
+      inboundCode: v.inboundCode,
+      inboundType: v.inboundType,
+      sourceRefNo: v.sourceRefNo,
+      sourceName: v.sourceName,
+      warehouseId: v.warehouseId,           // stockStore lookup 용
+      warehouseName: v.warehouseName,
+      status: v.status,
+      totalQuantity: v.totalQuantity ?? 0,
+      totalAmount: v.totalAmount ?? null,
+      totalPrice: v.totalAmount ?? null,
+      createdAt: v.createdAt,
+      arrivedAt: v.arrivedAt ?? null,
+      completedAt: v.completedAt ?? null,
+      confirmedByName: v.confirmedByName ?? null,
+      memo: v.memo ?? null,
+      vendorName: v.sourceName,
+      items: (v.items ?? []).map((it) => ({
         id: it.skuCode,
-        skuCode: it.skuCode,
         productCode: it.productCode,
         productName: it.productName,
+        skuCode: it.skuCode,
         color: it.color,
         size: it.size,
         displayOption: it.displayOption,
@@ -81,14 +82,12 @@ export const useWarehouseInboundStore = defineStore('warehouseInbound', () => {
         unitPrice: it.unitPrice,
         subtotal: it.subtotal,
       })),
-      statusHistory: (po.statusHistory ?? []).map((h) => ({
+      statusHistory: (v.statusHistory ?? []).map((h) => ({
         status: h.status,
-        at: h.changedAt,
-        byName: h.changedByName,
+        at: h.at,                        // BE 가 changedAt → at 노출 (StatusHistoryRes.from)
+        byName: h.byName,                // BE 가 changedByName → byName
         note: h.note,
       })),
-      vendorContactName: po.vendorContactName,
-      cancelReason: po.cancelReason,
     }
   }
 
@@ -102,7 +101,6 @@ export const useWarehouseInboundStore = defineStore('warehouseInbound', () => {
   })
 
   const inboundList = computed(() => {
-    // '전체' 탭은 모든 입고 후보(READY_TO_SHIP/IN_TRANSIT/ARRIVED/COMPLETED) 노출.
     let list =
       activeStatusTab.value === '전체'
         ? items.value
@@ -112,8 +110,9 @@ export const useWarehouseInboundStore = defineStore('warehouseInbound', () => {
       const k = searchKeyword.value.trim().toLowerCase()
       list = list.filter(
         (o) =>
-          o.id.toLowerCase().includes(k) ||
-          (o.vendorName ?? '').toLowerCase().includes(k) ||
+          (o.inboundCode ?? '').toLowerCase().includes(k) ||
+          (o.sourceRefNo ?? '').toLowerCase().includes(k) ||
+          (o.sourceName ?? '').toLowerCase().includes(k) ||
           (o.productNames ?? []).some((name) => (name ?? '').toLowerCase().includes(k)),
       )
     }
@@ -131,10 +130,10 @@ export const useWarehouseInboundStore = defineStore('warehouseInbound', () => {
         sorted.sort((a, b) => (a.createdAt ?? '').localeCompare(b.createdAt ?? ''))
         break
       case 'priceAsc':
-        sorted.sort((a, b) => (a.totalPrice ?? 0) - (b.totalPrice ?? 0))
+        sorted.sort((a, b) => (a.totalAmount ?? 0) - (b.totalAmount ?? 0))
         break
       case 'priceDesc':
-        sorted.sort((a, b) => (b.totalPrice ?? 0) - (a.totalPrice ?? 0))
+        sorted.sort((a, b) => (b.totalAmount ?? 0) - (a.totalAmount ?? 0))
         break
       default:
         sorted.sort((a, b) => (b.createdAt ?? '').localeCompare(a.createdAt ?? ''))
@@ -142,7 +141,6 @@ export const useWarehouseInboundStore = defineStore('warehouseInbound', () => {
     return sorted
   })
 
-  // 탭 카운트는 항상 전체 기준 (검색·기간 무관)
   const counts = computed(() => ({
     전체: items.value.length,
     READY_TO_SHIP: items.value.filter((o) => o.status === 'READY_TO_SHIP').length,
@@ -170,7 +168,6 @@ export const useWarehouseInboundStore = defineStore('warehouseInbound', () => {
       const detail = await inboundApi.detail(id)
       const mapped = fromDetailApi(detail)
       selectedDetail.value = mapped
-      // 목록에도 반영 (창고 정보 등 동기화)
       const idx = items.value.findIndex((o) => o.id === id)
       if (idx >= 0) {
         items.value[idx] = { ...items.value[idx], ...mapped }
@@ -198,22 +195,19 @@ export const useWarehouseInboundStore = defineStore('warehouseInbound', () => {
     }
   }
 
-  // 입고 확정 (WHS-007) — ARRIVED → COMPLETED.
-  // BE: POST /api/warehouse/inbound/{code}/confirm (내부적으로 PurchaseOrderService.complete 위임).
+  // 입고 확정 (WHS-007) — ARRIVED → COMPLETED. BE: POST /api/warehouse/inbound/{inboundCode}/confirm
   async function confirmInbound(id) {
     await inboundApi.confirm(id)
     await fetchDetail(id)
-    // 상태 전이 후 목록 status 갱신 — 단순화 위해 전체 재조회.
     await fetchAll()
   }
 
-  // 마운트 자동 fetch — vendor/circularInventoryBuyers store 패턴 일관.
+  // 마운트 자동 fetch
   fetchAll().catch((err) => {
     console.error('[warehouseInbound] fetchAll 실패', err)
   })
 
   return {
-    // state
     items,
     activeStatusTab,
     selectedOrderId,
@@ -223,11 +217,9 @@ export const useWarehouseInboundStore = defineStore('warehouseInbound', () => {
     sortBy,
     loading,
     error,
-    // getters
     selectedOrder,
     inboundList,
     counts,
-    // actions
     fetchAll,
     fetchDetail,
     selectOrder,

--- a/src/views/warehouse/inbound/WarehouseInboundView.vue
+++ b/src/views/warehouse/inbound/WarehouseInboundView.vue
@@ -119,6 +119,23 @@ function statusClass(status) {
   return map[status] ?? 'bg-gray-100 text-gray-500'
 }
 
+// inboundType 분기 — 발주(emerald) / 이동(indigo)
+function inboundTypeClass(type) {
+  const map = {
+    PURCHASE_ORDER: 'bg-emerald-50 text-emerald-700',
+    WAREHOUSE_TRANSFER: 'bg-indigo-50 text-indigo-700',
+  }
+  return map[type] ?? 'bg-gray-100 text-gray-500'
+}
+
+function inboundTypeLabel(type) {
+  const map = {
+    PURCHASE_ORDER: '발주',
+    WAREHOUSE_TRANSFER: '이동',
+  }
+  return map[type] ?? type ?? '-'
+}
+
 // 창고 화면 시점 라벨 (COMPLETED = "입고 완료", 본사 화면은 "종료")
 function statusLabel(status) {
   const map = {
@@ -340,16 +357,18 @@ const CheckIcon = IconBase([{ tag: 'polyline', attrs: { points: '20 6 9 17 4 12'
           </div>
 
           <div class="overflow-auto">
-            <table class="w-full min-w-[760px] table-fixed border-collapse text-xs">
+            <table class="w-full min-w-[920px] table-fixed border-collapse text-xs">
               <thead class="bg-gray-100 text-[10px] uppercase tracking-wider text-gray-500">
                 <tr>
-                  <th class="w-32 px-3 py-2 text-left font-black">발주번호</th>
-                  <th class="w-32 px-3 py-2 text-left font-black">공급처</th>
-                  <th class="w-28 px-3 py-2 text-left font-black">입고 창고</th>
+                  <th class="w-16 px-2 py-2 text-center font-black">종류</th>
+                  <th class="w-36 px-3 py-2 text-left font-black">입고번호</th>
+                  <th class="w-36 px-3 py-2 text-left font-black">출처번호</th>
+                  <th class="w-32 px-3 py-2 text-left font-black">출처</th>
                   <th class="w-44 px-3 py-2 text-left font-black">품목</th>
-                  <th class="w-28 px-3 py-2 text-right font-black">총금액</th>
+                  <th class="w-20 px-3 py-2 text-right font-black">수량</th>
+                  <th class="w-28 px-3 py-2 text-right font-black">금액</th>
                   <th class="w-20 px-3 py-2 text-center font-black">상태</th>
-                  <th class="w-28 px-3 py-2 text-center font-black">입고 예정일</th>
+                  <th class="w-28 px-3 py-2 text-center font-black">도착(예정)일</th>
                 </tr>
               </thead>
               <tbody class="divide-y divide-gray-100">
@@ -360,9 +379,17 @@ const CheckIcon = IconBase([{ tag: 'polyline', attrs: { points: '20 6 9 17 4 12'
                   :class="{ 'bg-[#E6F2F0]': inbound.selectedOrderId === order.id }"
                   @click="selectOrder(order.id)"
                 >
-                  <td class="px-3 py-3 font-bold text-gray-400">{{ order.id }}</td>
-                  <td class="px-3 py-3 font-black text-gray-800">{{ order.vendorName }}</td>
-                  <td class="px-3 py-3 font-bold text-gray-600">{{ order.warehouseName }}</td>
+                  <td class="px-2 py-3 text-center">
+                    <span
+                      class="inline-flex px-2 py-1 text-[10px] font-black"
+                      :class="inboundTypeClass(order.inboundType)"
+                    >
+                      {{ inboundTypeLabel(order.inboundType) }}
+                    </span>
+                  </td>
+                  <td class="px-3 py-3 font-bold text-gray-700">{{ order.inboundCode }}</td>
+                  <td class="px-3 py-3 font-bold text-gray-500">{{ order.sourceRefNo }}</td>
+                  <td class="px-3 py-3 font-black text-gray-800">{{ order.sourceName }}</td>
                   <td class="px-3 py-3 font-bold text-gray-700">
                     <span class="block truncate" :title="(order.productNames ?? []).join(', ')">
                       <template v-if="order.productNames && order.productNames.length > 0">
@@ -374,8 +401,14 @@ const CheckIcon = IconBase([{ tag: 'polyline', attrs: { points: '20 6 9 17 4 12'
                       <template v-else>—</template>
                     </span>
                   </td>
+                  <td class="px-3 py-3 text-right font-bold text-gray-700">
+                    {{ (order.totalQuantity ?? 0).toLocaleString() }}
+                  </td>
                   <td class="px-3 py-3 text-right font-black text-gray-800">
-                    ₩{{ order.totalPrice.toLocaleString() }}
+                    <template v-if="order.totalAmount != null">
+                      ₩{{ order.totalAmount.toLocaleString() }}
+                    </template>
+                    <span v-else class="text-gray-300">—</span>
                   </td>
                   <td class="px-3 py-3 text-center">
                     <span
@@ -386,11 +419,11 @@ const CheckIcon = IconBase([{ tag: 'polyline', attrs: { points: '20 6 9 17 4 12'
                     </span>
                   </td>
                   <td class="px-3 py-3 text-center text-[11px] text-gray-500">
-                    {{ formatDate(order.createdAt) }}
+                    {{ formatDate(order.arrivedAt ?? order.createdAt) }}
                   </td>
                 </tr>
                 <tr v-if="inbound.inboundList.length === 0">
-                  <td colspan="7" class="px-3 py-8 text-center text-xs text-gray-400">
+                  <td colspan="9" class="px-3 py-8 text-center text-xs text-gray-400">
                     조회된 입고 내역이 없습니다.
                   </td>
                 </tr>
@@ -432,20 +465,30 @@ const CheckIcon = IconBase([{ tag: 'polyline', attrs: { points: '20 6 9 17 4 12'
 
           <!-- 상세 내용 -->
           <div class="flex flex-1 flex-col gap-4 overflow-y-auto p-4">
-            <!-- 기본 정보 -->
+            <!-- 기본 정보 (공통) -->
             <section class="space-y-3">
-              <div>
-                <p class="text-[10px] font-bold uppercase text-gray-400">발주번호</p>
-                <p class="mt-0.5 text-sm font-black text-gray-900">
-                  {{ inbound.selectedOrder.id }}
-                </p>
+              <div class="grid grid-cols-2 gap-3">
+                <div>
+                  <p class="text-[10px] font-bold uppercase text-gray-400">입고번호</p>
+                  <p class="mt-0.5 text-sm font-black text-gray-900">
+                    {{ inbound.selectedOrder.inboundCode }}
+                  </p>
+                </div>
+                <div>
+                  <p class="text-[10px] font-bold uppercase text-gray-400">출처번호</p>
+                  <p class="mt-0.5 text-xs font-black text-gray-700">
+                    {{ inbound.selectedOrder.sourceRefNo }}
+                  </p>
+                </div>
               </div>
 
               <div class="grid grid-cols-2 gap-3">
                 <div>
-                  <p class="text-[10px] font-bold uppercase text-gray-400">공급처</p>
+                  <p class="text-[10px] font-bold uppercase text-gray-400">
+                    {{ inbound.selectedOrder.inboundType === 'WAREHOUSE_TRANSFER' ? '출발 창고' : '공급처' }}
+                  </p>
                   <p class="mt-0.5 text-xs font-black text-gray-800">
-                    {{ inbound.selectedOrder.vendorName }}
+                    {{ inbound.selectedOrder.sourceName }}
                   </p>
                 </div>
                 <div>
@@ -459,10 +502,15 @@ const CheckIcon = IconBase([{ tag: 'polyline', attrs: { points: '20 6 9 17 4 12'
                     class="inline-flex items-center gap-1 text-[10px] font-bold uppercase text-gray-400"
                   >
                     <UserIcon :size="10" />
-                    담당자
+                    종류
                   </p>
-                  <p class="mt-0.5 text-xs font-black text-gray-800">
-                    {{ inbound.selectedOrder.memberName }}
+                  <p class="mt-0.5">
+                    <span
+                      class="inline-flex px-2 py-1 text-[10px] font-black"
+                      :class="inboundTypeClass(inbound.selectedOrder.inboundType)"
+                    >
+                      {{ inboundTypeLabel(inbound.selectedOrder.inboundType) }}
+                    </span>
                   </p>
                 </div>
                 <div>
@@ -474,7 +522,8 @@ const CheckIcon = IconBase([{ tag: 'polyline', attrs: { points: '20 6 9 17 4 12'
               </div>
             </section>
 
-            <!-- 품목 테이블 -->
+            <!-- 발주 입고 분기 (PURCHASE_ORDER) — 품목 테이블 + 단가/소계 -->
+            <template v-if="inbound.selectedOrder.inboundType === 'PURCHASE_ORDER'">
             <section>
               <p class="mb-2 text-[10px] font-black uppercase text-gray-400">발주 품목</p>
               <table class="w-full text-xs">
@@ -529,14 +578,26 @@ const CheckIcon = IconBase([{ tag: 'polyline', attrs: { points: '20 6 9 17 4 12'
                   <tr>
                     <td colspan="5" class="px-2 py-2">총계</td>
                     <td class="px-2 py-2 text-right text-[#004D3C]">
-                      ₩{{ inbound.selectedOrder.totalPrice.toLocaleString() }}
+                      <template v-if="inbound.selectedOrder.totalAmount != null">
+                        ₩{{ inbound.selectedOrder.totalAmount.toLocaleString() }}
+                      </template>
+                      <span v-else class="text-gray-300">—</span>
                     </td>
                   </tr>
                 </tfoot>
               </table>
             </section>
+            </template>
 
-            <!-- 진행 이력 타임라인 — 창고 단계(SHIPPING/COMPLETED)만 -->
+            <!-- 이동 입고 분기 (WAREHOUSE_TRANSFER) — 후속 사이클 -->
+            <div
+              v-else-if="inbound.selectedOrder.inboundType === 'WAREHOUSE_TRANSFER'"
+              class="border border-dashed border-gray-300 bg-gray-50 px-3 py-6 text-center text-xs text-gray-400"
+            >
+              창고간 이동 입고 상세는 outbound 도메인 합류 후 사이클에서 추가됩니다.
+            </div>
+
+            <!-- 진행 이력 타임라인 — 모든 inboundType 공통 -->
             <section v-if="visibleHistory.length">
               <p class="mb-2 text-[10px] font-black uppercase text-gray-400">진행 이력</p>
               <ol class="ml-2">


### PR DESCRIPTION
## 📌 요약
- BE 의 신설 inbound 도메인 (`/api/warehouse/inbound`) 응답 모양에 맞춰 창고 입고 페이지 재구성. 컬럼 9개로 확장하고 inboundType 별 분기 도입.

<br><br>

## 🎯 작업 내용
- `stores/warehouse/warehouseInbound.js` `fromApi` 헬퍼를 PurchaseOrderDto 기반에서 `WhInboundDto` 기반으로 갈아끼움 — `inboundCode / inboundType / sourceRefNo / sourceName / warehouseId` 신규 매핑. `totalPrice` 는 `totalAmount` 의 호환 alias.
- `WarehouseInboundView.vue` 테이블 컬럼 9개 재구성 — 종류 뱃지 (발주/이동) + 입고번호 (IB-...) + 출처번호 (PO-.../STF-...) + 출처 + 품목 + 수량 + 금액 + 상태 + 도착일. 자기 창고 격리(PR #190) 후 동일 값이던 입고 창고 컬럼 제거.
- 우측 상세 패널을 `inboundType` 별 `v-if` 분기 — `PURCHASE_ORDER` 만 active, `WAREHOUSE_TRANSFER` 자리는 placeholder (BE outbound 도메인 합류 후 후속 사이클에서 추가). 입고번호/출처번호 라벨 분리, 출처 라벨은 inboundType 별 동적("공급처"/"출발 창고"). 검색 키워드도 `inboundCode / sourceRefNo / sourceName / productNames` 로 확장.

<br><br>

## ✔️ 참고 사항
- 

<br><br>

## ✔️ 관련 이슈

- Close #407

<br><br>
