### PR TITLE
feat 창고관리자 창고 재고 조회 기능 구현

### DIFF
--- a/CICD/k8s/ingress.yml
+++ b/CICD/k8s/ingress.yml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: stockit-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - www.stockit.kro.kr
+      secretName: stockit-tls
+  rules:
+    - host: www.stockit.kro.kr
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: stockit-be
+                port:
+                  number: 80
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: front-service
+                port:
+                  number: 80

--- a/src/api/warehouse/inventory.js
+++ b/src/api/warehouse/inventory.js
@@ -1,0 +1,11 @@
+import api, { unwrap } from '@/api/axios.js'
+
+export async function getWarehouseInventories() {
+  const res = await api.get('/api/warehouse/inventories')
+  return unwrap(res)
+}
+
+export async function getWarehouseInventorySkus(itemCode) {
+  const res = await api.get(`/api/warehouse/inventories/${itemCode}/skus`)
+  return unwrap(res)
+}

--- a/src/views/hq/infrastructure/HqInfrastructureManagementView.vue
+++ b/src/views/hq/infrastructure/HqInfrastructureManagementView.vue
@@ -173,9 +173,7 @@ async function loadWarehouses() {
     address: w.address,
     manager: w.managerName,
     contact: w.contact,
-    capacity: w.capacity,
     stockQty: w.mappedStoreCount * 1000,
-    occupancy: Math.min(95, 20 + w.mappedStoreCount * 15),
     status: statusToKor[w.status] ?? w.status,
   }))
 }
@@ -230,7 +228,6 @@ async function quickCreateWarehouse() {
       managerName: '담당자',
       contact: '02-0000-0000',
       address: '서울시 강서구',
-      capacity: '10,000 PLT / 5,000㎡',
       status: 'ACTIVE',
     })
     await loadWarehouses()
@@ -479,21 +476,6 @@ const iconMap = {
                     <span>현재 재고 수량</span>
                     <strong class="text-[#0f766e]">{{ warehouse.stockQty.toLocaleString() }} EA</strong>
                   </p>
-                </div>
-
-                <div class="store-stock-graph">
-                  <div class="store-stock-head">
-                    <span>공간 점유율</span>
-                    <strong :class="{ low: warehouse.occupancy >= 90 }">{{ warehouse.occupancy }}%</strong>
-                  </div>
-                  <div class="store-stock-track">
-                    <div
-                      class="store-stock-fill"
-                      :class="{ caution: warehouse.occupancy >= 80 && warehouse.occupancy < 90, low: warehouse.occupancy >= 90 }"
-                      :style="{ width: `${warehouse.occupancy}%` }"
-                    />
-                  </div>
-                  <p class="store-stock-meta">{{ warehouse.capacity }}</p>
                 </div>
               </article>
 
@@ -1109,7 +1091,6 @@ const iconMap = {
 .w-address { width: 240px; }
 .w-end { width: 112px; }
 .w-stock { width: 136px; }
-.w-occupancy { width: 132px; }
 .w-store-name { width: 148px; }
 .w-priority { width: 92px; }
 .w-lead { width: 92px; }
@@ -1229,53 +1210,6 @@ const iconMap = {
   border-color: #d1d5db;
   background: #f9fafb;
   color: #6b7280;
-}
-
-.occupancy-wrap {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.occupancy-wrap span {
-  min-width: 38px;
-  color: #4b5563;
-  font-size: 11px;
-  font-weight: 700;
-}
-
-.occupancy-wrap span.danger {
-  color: #dc2626;
-}
-
-.occupancy-bar,
-.detail-occupancy-bar {
-  overflow: hidden;
-  border: 1px solid #e5e7eb;
-  background: #f3f4f6;
-}
-
-.occupancy-bar {
-  width: 56px;
-  height: 8px;
-}
-
-.detail-occupancy-bar {
-  margin-top: 10px;
-  height: 10px;
-}
-
-.occupancy-fill {
-  height: 100%;
-  background: #004d3c;
-}
-
-.occupancy-fill.warning {
-  background: #d97706;
-}
-
-.occupancy-fill.danger {
-  background: #dc2626;
 }
 
 .table-footer {

--- a/src/views/hq/infrastructure/HqInfrastructureMappingView.vue
+++ b/src/views/hq/infrastructure/HqInfrastructureMappingView.vue
@@ -28,13 +28,21 @@ const loading = ref(false)
 const errorMessage = ref('')
 const saveMessage = ref('')
 const rows = ref([])
+const allRegionOptions = ref([])
 const warehouseOptions = ref([])
 const savingStoreCode = ref('')
 
 const statusToKor = { ACTIVE: '활성', INACTIVE: '비활성', SUSPENDED: '점검중' }
 const korToStatus = { 활성: 'ACTIVE', 비활성: 'INACTIVE', 점검중: 'SUSPENDED' }
 
-const regionOptions = computed(() => ['전체 지역', ...new Set(rows.value.map((row) => row.region))])
+const regionOptions = computed(() => ['전체 지역', ...allRegionOptions.value])
+
+function warehouseOptionLabel(code) {
+  if (!code) return ''
+  const found = warehouseOptions.value.find((item) => item.code === code)
+  if (!found) return code
+  return `${found.code} · ${found.name}`
+}
 
 function handleLogout() {
   auth.logout()
@@ -44,6 +52,15 @@ function handleLogout() {
 async function loadOptions() {
   const options = await getInfrastructureMappingOptions()
   warehouseOptions.value = options.warehouses || []
+}
+
+async function loadAllRegionOptions() {
+  const list = await getStoreInfrastructureMappings({})
+  const regions = [...new Set((list || []).map((row) => row.region).filter(Boolean))]
+  allRegionOptions.value = regions.sort((a, b) => a.localeCompare(b, 'ko'))
+  if (region.value !== '전체 지역' && !allRegionOptions.value.includes(region.value)) {
+    region.value = '전체 지역'
+  }
 }
 
 function normalizeRows(list) {
@@ -122,6 +139,7 @@ watch([search, region, status], () => {
 
 onMounted(async () => {
   await loadOptions()
+  await loadAllRegionOptions()
   await loadRows()
 })
 </script>
@@ -164,11 +182,11 @@ onMounted(async () => {
           <table class="min-w-full border-collapse text-xs">
             <thead>
               <tr class="border-b border-gray-200 bg-gray-50 text-left text-[11px] font-black uppercase tracking-[0.06em] text-gray-500">
-                <th class="px-3 py-2">매장</th>
+                <th class="min-w-[12rem] px-3 py-2">매장</th>
                 <th class="px-3 py-2">지역</th>
                 <th class="px-3 py-2">상태</th>
-                <th class="px-3 py-2">주 창고</th>
-                <th class="px-3 py-2">예비 창고</th>
+                <th class="min-w-[19rem] px-3 py-2">주 창고</th>
+                <th class="min-w-[19rem] px-3 py-2">예비 창고</th>
                 <th class="px-3 py-2">저장</th>
               </tr>
             </thead>
@@ -186,7 +204,11 @@ onMounted(async () => {
                 <td class="px-3 py-2 font-bold text-gray-700">{{ row.region }}</td>
                 <td class="px-3 py-2 font-bold text-gray-700">{{ statusToKor[row.status] || row.status }}</td>
                 <td class="px-3 py-2">
-                  <select v-model="row.draftPrimaryWarehouseCode" class="h-8 w-44 border border-gray-300 px-2 text-xs font-bold outline-none focus:border-[#004D3C]">
+                  <select
+                    v-model="row.draftPrimaryWarehouseCode"
+                    :title="row.draftPrimaryWarehouseCode ? warehouseOptionLabel(row.draftPrimaryWarehouseCode) : '선택'"
+                    class="h-8 w-full min-w-[18rem] border border-gray-300 px-2 text-xs font-bold outline-none focus:border-[#004D3C] xl:min-w-[24rem]"
+                  >
                     <option value="">선택</option>
                     <option v-for="warehouse in warehouseOptions" :key="warehouse.code" :value="warehouse.code">
                       {{ warehouse.code }} · {{ warehouse.name }}
@@ -194,7 +216,11 @@ onMounted(async () => {
                   </select>
                 </td>
                 <td class="px-3 py-2">
-                  <select v-model="row.draftBackupWarehouseCode" class="h-8 w-44 border border-gray-300 px-2 text-xs font-bold outline-none focus:border-[#004D3C]">
+                  <select
+                    v-model="row.draftBackupWarehouseCode"
+                    :title="row.draftBackupWarehouseCode ? warehouseOptionLabel(row.draftBackupWarehouseCode) : '미지정'"
+                    class="h-8 w-full min-w-[18rem] border border-gray-300 px-2 text-xs font-bold outline-none focus:border-[#004D3C] xl:min-w-[24rem]"
+                  >
                     <option value="">미지정</option>
                     <option v-for="warehouse in warehouseOptions" :key="`backup-${warehouse.code}`" :value="warehouse.code">
                       {{ warehouse.code }} · {{ warehouse.name }}

--- a/src/views/hq/infrastructure/HqWarehouseDetailView.vue
+++ b/src/views/hq/infrastructure/HqWarehouseDetailView.vue
@@ -33,16 +33,6 @@ const backQuery = computed(() => ({
   search: typeof route.query.search === 'string' ? route.query.search : undefined,
 }))
 
-const occupancy = computed(() => {
-  if (!warehouse.value) return 0
-  return Math.min(95, 20 + Number(warehouse.value.mappedStoreCount || 0) * 15)
-})
-
-const stockQty = computed(() => {
-  if (!warehouse.value) return 0
-  return Number(warehouse.value.mappedStoreCount || 0) * 1000
-})
-
 const connectedStoresPlaceholder = computed(() => {
   if (!warehouse.value) return []
   return Array.from({ length: Number(warehouse.value.mappedStoreCount || 0) }).map((_, index) => `연결 매장 ${index + 1}`)
@@ -127,29 +117,7 @@ onMounted(() => {
             <p class="flex items-center justify-between"><span class="font-bold text-gray-500">주소</span><strong class="font-black text-gray-900">{{ warehouse.address }}</strong></p>
             <p class="flex items-center justify-between"><span class="font-bold text-gray-500">담당 책임자</span><strong class="font-black text-gray-900">{{ warehouse.managerName }}</strong></p>
             <p class="flex items-center justify-between"><span class="font-bold text-gray-500">연락처</span><strong class="font-black text-gray-900">{{ warehouse.contact }}</strong></p>
-            <p class="flex items-center justify-between"><span class="font-bold text-gray-500">창고 용량</span><strong class="font-black text-gray-900">{{ warehouse.capacity }}</strong></p>
             <p class="flex items-center justify-between"><span class="font-bold text-gray-500">상태</span><strong class="font-black text-gray-900">{{ statusToKor[warehouse.status] || warehouse.status }}</strong></p>
-          </div>
-        </article>
-
-        <article class="border border-gray-300 bg-white p-4 shadow-sm">
-          <h2 class="text-xs font-black uppercase tracking-[0.1em] text-gray-500">공간 점유율 / 현재 재고</h2>
-          <div class="mt-4">
-            <div class="mb-2 flex items-center justify-between text-xs font-bold text-gray-600">
-              <span>공간 점유율(추정)</span>
-              <strong class="text-base font-black" :class="occupancy >= 90 ? 'text-red-600' : 'text-gray-900'">{{ occupancy }}%</strong>
-            </div>
-            <div class="h-3 w-full bg-gray-200">
-              <div
-                class="h-full"
-                :class="occupancy >= 90 ? 'bg-red-500' : occupancy >= 80 ? 'bg-amber-500' : 'bg-[#0f766e]'"
-                :style="{ width: `${occupancy}%` }"
-              />
-            </div>
-            <p class="mt-2 text-right text-[11px] font-bold text-gray-500">
-              현재 재고(추정) {{ stockQty.toLocaleString() }} EA
-            </p>
-            <p class="mt-2 text-[10px] font-bold text-gray-400">* 점유율/재고는 mappedStoreCount 기반 임시 추정치입니다.</p>
           </div>
         </article>
 

--- a/src/views/hq/products/HqProductManagementView.vue
+++ b/src/views/hq/products/HqProductManagementView.vue
@@ -52,9 +52,7 @@ const selectedParentFilter = ref('all')
 const selectedChildFilter = ref('all')
 const parentCategoryOptions = computed(() => categories.value.map((cat) => cat.name))
 const childCategoryOptions = computed(() => {
-  if (selectedParentFilter.value === 'all') {
-    return categories.value.flatMap((cat) => cat.children.map((child) => child.name))
-  }
+  if (selectedParentFilter.value === 'all') return []
   const target = categories.value.find((cat) => cat.name === selectedParentFilter.value)
   return target ? target.children.map((child) => child.name) : []
 })
@@ -286,7 +284,6 @@ async function loadProducts() {
     const vendorNameByCode = new Map(vendors.value.map(v => [v.code, v.name]))
     const list = await getProducts({
       keyword: productKeyword.value || undefined,
-      categoryCode: selectedParentFilter.value === 'all' ? undefined : selectedParentFilter.value,
     })
     productMasterData.value = list.map((p) => ({
       ...resolveCategoryNames(p.categoryCode),
@@ -309,9 +306,6 @@ async function loadVendors() {
 }
 
 watch(productKeyword, () => {
-  if (activeSideMenu.value !== '카테고리 관리') loadProducts()
-})
-watch([selectedParentFilter, selectedChildFilter], () => {
   if (activeSideMenu.value !== '카테고리 관리') loadProducts()
 })
 
@@ -343,7 +337,7 @@ onMounted(() => {
           </label>
 
           <label v-if="activeSideMenu !== '카테고리 관리'" class="flex items-center gap-2 text-[11px] font-bold text-gray-500">
-            대분류
+            카테고리 1단계
             <select
               :value="selectedParentFilter"
               class="border border-gray-300 bg-gray-50 px-3 py-1.5 text-xs font-bold text-gray-700 outline-none focus:border-[#004D3C] focus:bg-white"
@@ -355,12 +349,13 @@ onMounted(() => {
           </label>
 
           <label v-if="activeSideMenu !== '카테고리 관리'" class="flex items-center gap-2 text-[11px] font-bold text-gray-500">
-            소분류
+            카테고리 2단계
             <select
               v-model="selectedChildFilter"
+              :disabled="selectedParentFilter === 'all'"
               class="border border-gray-300 bg-gray-50 px-3 py-1.5 text-xs font-bold text-gray-700 outline-none focus:border-[#004D3C] focus:bg-white"
             >
-              <option value="all">전체</option>
+              <option value="all">{{ selectedParentFilter === 'all' ? '1단계 먼저 선택' : '전체' }}</option>
               <option v-for="child in childCategoryOptions" :key="child" :value="child">{{ child }}</option>
             </select>
           </label>

--- a/src/views/store/inventory/StoreInventorySkuDetailView.vue
+++ b/src/views/store/inventory/StoreInventorySkuDetailView.vue
@@ -14,6 +14,12 @@ const skuData = ref([])
 const isLoading = ref(false)
 const loadError = ref('')
 const requestSeq = ref(0)
+const COLOR_LABEL_BY_CODE = {
+  BLK: '검정',
+  WHT: '흰색',
+  NVY: '네이비',
+  GRY: '그레이',
+}
 
 const storeTopMenus = roleMenus.store
 const storeSideMenus = roleMenus.store.find((menu) => menu.label === '재고 관리')?.children ?? []
@@ -33,6 +39,7 @@ const skuRows = computed(() =>
       actualStock: Number(sku.actualStock ?? 0),
       availableStock: Number(sku.availableStock ?? 0),
       safetyStock: Number(sku.safetyStock ?? 0),
+      colorLabel: COLOR_LABEL_BY_CODE[String(sku.color ?? '').toUpperCase()] ?? sku.color,
     }))
     .sort((a, b) => String(a.color ?? '').localeCompare(String(b.color ?? ''), 'ko') || String(a.size ?? '').localeCompare(String(b.size ?? ''), 'ko')),
 )
@@ -139,6 +146,7 @@ watch(
             <thead class="bg-gray-50 text-[10px] uppercase tracking-[0.12em] text-gray-500">
               <tr>
                 <th class="px-3 py-3 font-black">SKU 코드</th>
+                <th class="px-3 py-3 font-black">품목명</th>
                 <th class="px-3 py-3 font-black">색상</th>
                 <th class="px-3 py-3 font-black">사이즈</th>
                 <th class="px-3 py-3 text-right font-black">실재고</th>
@@ -151,7 +159,8 @@ watch(
             <tbody class="divide-y divide-gray-100">
               <tr v-for="sku in skuRows" :key="sku.skuCode">
                 <td class="px-3 py-3 font-mono font-bold text-gray-600">{{ sku.skuCode }}</td>
-                <td class="px-3 py-3 font-bold text-gray-800">{{ sku.color }}</td>
+                <td class="px-3 py-3 font-bold text-gray-900">{{ itemName }}</td>
+                <td class="px-3 py-3 font-bold text-gray-800">{{ sku.colorLabel }}</td>
                 <td class="px-3 py-3 font-black text-gray-900">{{ sku.size }}</td>
                 <td class="px-3 py-3 text-right font-black text-gray-900">{{ sku.actualStock.toLocaleString() }}</td>
                 <td class="px-3 py-3 text-right font-black text-gray-900">{{ sku.availableStock.toLocaleString() }}</td>
@@ -164,7 +173,7 @@ watch(
                 <td class="px-3 py-3 font-bold text-gray-500">{{ formatDateTime(sku.updatedAt) }}</td>
               </tr>
               <tr v-if="skuRows.length === 0">
-                <td colspan="8" class="px-3 py-14 text-center text-sm font-bold text-gray-400">
+                <td colspan="9" class="px-3 py-14 text-center text-sm font-bold text-gray-400">
                   {{ isLoading ? 'SKU 재고를 불러오는 중입니다.' : '조회 가능한 SKU 재고가 없습니다.' }}
                 </td>
               </tr>

--- a/src/views/warehouse/WarehouseInventorySkuDetailView.vue
+++ b/src/views/warehouse/WarehouseInventorySkuDetailView.vue
@@ -26,6 +26,12 @@ const skuData = ref([])
 const isLoading = ref(false)
 const loadError = ref('')
 const requestSeq = ref(0)
+const COLOR_LABEL_BY_CODE = {
+  BLK: '검정',
+  WHT: '흰색',
+  NVY: '네이비',
+  GRY: '그레이',
+}
 
 const skuRows = computed(() =>
   skuData.value
@@ -34,6 +40,7 @@ const skuRows = computed(() =>
       actualStock: Number(sku.actualStock ?? 0),
       availableStock: Number(sku.availableStock ?? 0),
       safetyStock: Number(sku.safetyStock ?? 0),
+      colorLabel: COLOR_LABEL_BY_CODE[String(sku.color ?? '').toUpperCase()] ?? sku.color,
     }))
     .sort((a, b) => String(a.color ?? '').localeCompare(String(b.color ?? ''), 'ko') || String(a.size ?? '').localeCompare(String(b.size ?? ''), 'ko')),
 )
@@ -133,6 +140,7 @@ watch(
             <thead class="bg-gray-50 text-[10px] uppercase tracking-[0.12em] text-gray-500">
               <tr>
                 <th class="px-3 py-3 font-black">SKU 코드</th>
+                <th class="px-3 py-3 font-black">품목명</th>
                 <th class="px-3 py-3 font-black">색상</th>
                 <th class="px-3 py-3 font-black">사이즈</th>
                 <th class="px-3 py-3 text-right font-black">실재고</th>
@@ -145,7 +153,8 @@ watch(
             <tbody class="divide-y divide-gray-100">
               <tr v-for="sku in skuRows" :key="sku.skuCode">
                 <td class="px-3 py-3 font-mono font-bold text-gray-600">{{ sku.skuCode }}</td>
-                <td class="px-3 py-3 font-bold text-gray-800">{{ sku.color }}</td>
+                <td class="px-3 py-3 font-bold text-gray-900">{{ itemName }}</td>
+                <td class="px-3 py-3 font-bold text-gray-800">{{ sku.colorLabel }}</td>
                 <td class="px-3 py-3 font-black text-gray-900">{{ sku.size }}</td>
                 <td class="px-3 py-3 text-right font-black text-gray-900">{{ sku.actualStock.toLocaleString() }}</td>
                 <td class="px-3 py-3 text-right font-black text-gray-900">{{ sku.availableStock.toLocaleString() }}</td>
@@ -158,7 +167,7 @@ watch(
                 <td class="px-3 py-3 font-bold text-gray-500">{{ sku.updatedAt ? new Date(sku.updatedAt).toLocaleString('ko-KR', { hour12: false }) : '-' }}</td>
               </tr>
               <tr v-if="skuRows.length === 0">
-                <td colspan="8" class="px-3 py-14 text-center text-sm font-bold text-gray-400">
+                <td colspan="9" class="px-3 py-14 text-center text-sm font-bold text-gray-400">
                   {{ isLoading ? 'SKU 재고를 불러오는 중입니다.' : '조회 가능한 SKU 재고가 없습니다.' }}
                 </td>
               </tr>

--- a/src/views/warehouse/WarehouseInventorySkuDetailView.vue
+++ b/src/views/warehouse/WarehouseInventorySkuDetailView.vue
@@ -1,9 +1,11 @@
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
+import { getWarehouseInventorySkus } from '@/api/warehouse/inventory.js'
+import { extractErrorMessage } from '@/api/axios.js'
 
 const route = useRoute()
 const router = useRouter()
@@ -15,41 +17,25 @@ const warehouseSideMenus = roleMenus.warehouse.find((menu) => menu.label === '�
 const activeSideMenu = ref('창고 재고 조회')
 const activeTopMenu = computed(() => '재고 관리')
 
-const colorOptions = ['검정', '흰색', '그레이', '아이보리']
-const colorCodeMap = { 검정: 'BLK', 흰색: 'WHT', 그레이: 'GRY', 아이보리: 'IVR' }
-const sizeOptions = ['XS', 'S', 'M', 'L', 'XL']
-
 const itemCode = computed(() => String(route.params.itemCode ?? route.query.itemCode ?? ''))
 const itemName = computed(() => String(route.query.itemName ?? '선택 품목'))
 const parentCategory = computed(() => String(route.query.parentCategory ?? '-'))
 const childCategory = computed(() => String(route.query.childCategory ?? '-'))
 
-const seed = computed(() =>
-  itemCode.value.split('').reduce((sum, char) => sum + char.charCodeAt(0), 0),
-)
+const skuData = ref([])
+const isLoading = ref(false)
+const loadError = ref('')
+const requestSeq = ref(0)
 
 const skuRows = computed(() =>
-  colorOptions.flatMap((color, colorIndex) =>
-    sizeOptions.map((size, sizeIndex) => {
-      const actualStock = 20 + ((seed.value + colorIndex * 17 + sizeIndex * 11) % 90)
-      const reservedStock = (seed.value + colorIndex * 7 + sizeIndex * 13) % 12
-      const availableStock = Math.max(actualStock - reservedStock, 0)
-      const safetyStock = 22 + (sizeIndex % 3) * 6
-      const status = availableStock === 0 ? '품절' : availableStock < safetyStock ? '부족' : '정상'
-      const updatedAt = `2026.04.${String(27 - (colorIndex % 3)).padStart(2, '0')} ${String(9 + sizeIndex).padStart(2, '0')}:15`
-
-      return {
-        skuCode: `${itemCode.value}-${colorCodeMap[color]}-${size}`,
-        color,
-        size,
-        actualStock,
-        availableStock,
-        safetyStock,
-        status,
-        updatedAt,
-      }
-    }),
-  ),
+  skuData.value
+    .map((sku) => ({
+      ...sku,
+      actualStock: Number(sku.actualStock ?? 0),
+      availableStock: Number(sku.availableStock ?? 0),
+      safetyStock: Number(sku.safetyStock ?? 0),
+    }))
+    .sort((a, b) => String(a.color ?? '').localeCompare(String(b.color ?? ''), 'ko') || String(a.size ?? '').localeCompare(String(b.size ?? ''), 'ko')),
 )
 
 const statusClass = (status) => ({
@@ -76,6 +62,39 @@ function handleLogout() {
   auth.logout()
   router.push('/dev-login')
 }
+
+async function loadSkuRows() {
+  const seq = ++requestSeq.value
+  if (!itemCode.value) {
+    skuData.value = []
+    return
+  }
+  isLoading.value = true
+  loadError.value = ''
+  try {
+    const rows = await getWarehouseInventorySkus(itemCode.value)
+    if (seq !== requestSeq.value) return
+    skuData.value = Array.isArray(rows) ? rows : []
+  } catch (e) {
+    if (seq !== requestSeq.value) return
+    skuData.value = []
+    loadError.value = extractErrorMessage(e, 'SKU 재고를 불러오지 못했습니다.')
+  } finally {
+    if (seq !== requestSeq.value) return
+    isLoading.value = false
+  }
+}
+
+onMounted(() => {
+  loadSkuRows()
+})
+
+watch(
+  () => route.fullPath,
+  () => {
+    loadSkuRows()
+  },
+)
 </script>
 
 <template>
@@ -96,6 +115,7 @@ function handleLogout() {
             <p class="mt-1 text-xs font-bold text-gray-500">
               {{ itemCode }} · {{ parentCategory }} &gt; {{ childCategory }}
             </p>
+            <p v-if="loadError" class="mt-2 text-xs font-bold text-red-600">{{ loadError }}</p>
           </div>
           <button
             type="button"
@@ -135,7 +155,12 @@ function handleLogout() {
                     {{ sku.status }}
                   </span>
                 </td>
-                <td class="px-3 py-3 font-bold text-gray-500">{{ sku.updatedAt }}</td>
+                <td class="px-3 py-3 font-bold text-gray-500">{{ sku.updatedAt ? new Date(sku.updatedAt).toLocaleString('ko-KR', { hour12: false }) : '-' }}</td>
+              </tr>
+              <tr v-if="skuRows.length === 0">
+                <td colspan="8" class="px-3 py-14 text-center text-sm font-bold text-gray-400">
+                  {{ isLoading ? 'SKU 재고를 불러오는 중입니다.' : '조회 가능한 SKU 재고가 없습니다.' }}
+                </td>
               </tr>
             </tbody>
           </table>

--- a/src/views/warehouse/WarehouseInventoryView.vue
+++ b/src/views/warehouse/WarehouseInventoryView.vue
@@ -1,9 +1,11 @@
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
+import { getWarehouseInventories } from '@/api/warehouse/inventory.js'
+import { extractErrorMessage } from '@/api/axios.js'
 
 const router = useRouter()
 const route = useRoute()
@@ -14,11 +16,6 @@ const warehouseSideMenus = roleMenus.warehouse.find((menu) => menu.label === '�
 const activeSideMenu = ref('창고 재고 조회')
 const activeTopMenu = computed(() => '재고 관리')
 
-const warehouseInfo = {
-  code: 'WH-ICN-01',
-  name: '인천 제1창고',
-}
-
 const categoryMap = {
   상의: ['반팔', '긴팔', '셔츠', '니트', '후드티'],
   바지: ['청바지', '반바지', '긴바지', '츄리닝'],
@@ -26,20 +23,9 @@ const categoryMap = {
   아우터: ['패딩', '후드집업', '자켓', '가디건'],
 }
 
-const inventoryData = [
-  { itemCode: 'SPA-TOP-001', parentCategory: '상의', childCategory: '반팔', itemName: '코튼 베이직 반팔 티셔츠', actualStock: 184, availableStock: 172, safetyStock: 60, status: '정상', updatedAt: '2026.04.27 09:20' },
-  { itemCode: 'SPA-TOP-002', parentCategory: '상의', childCategory: '긴팔', itemName: '슬림핏 긴팔 티셔츠', actualStock: 38, availableStock: 32, safetyStock: 45, status: '부족', updatedAt: '2026.04.27 09:10' },
-  { itemCode: 'SPA-TOP-003', parentCategory: '상의', childCategory: '셔츠', itemName: '오버핏 옥스포드 셔츠', actualStock: 420, availableStock: 402, safetyStock: 120, status: '정상', updatedAt: '2026.04.27 08:50' },
-  { itemCode: 'SPA-TOP-004', parentCategory: '상의', childCategory: '니트', itemName: '라운드넥 소프트 니트', actualStock: 0, availableStock: 0, safetyStock: 80, status: '품절', updatedAt: '2026.04.27 08:30' },
-  { itemCode: 'SPA-PNT-001', parentCategory: '바지', childCategory: '청바지', itemName: '스트레이트 워싱 데님', actualStock: 128, availableStock: 121, safetyStock: 60, status: '정상', updatedAt: '2026.04.27 08:15' },
-  { itemCode: 'SPA-PNT-002', parentCategory: '바지', childCategory: '반바지', itemName: '라이트 코튼 쇼츠', actualStock: 22, availableStock: 18, safetyStock: 40, status: '부족', updatedAt: '2026.04.27 07:55' },
-  { itemCode: 'SPA-PNT-003', parentCategory: '바지', childCategory: '긴바지', itemName: '와이드 밴딩 팬츠', actualStock: 76, availableStock: 69, safetyStock: 55, status: '정상', updatedAt: '2026.04.27 07:35' },
-  { itemCode: 'SPA-SKT-001', parentCategory: '치마', childCategory: '미니스커트', itemName: 'A라인 데님 미니스커트', actualStock: 14, availableStock: 10, safetyStock: 35, status: '부족', updatedAt: '2026.04.26 19:45' },
-  { itemCode: 'SPA-SKT-002', parentCategory: '치마', childCategory: '롱스커트', itemName: '플리츠 롱스커트', actualStock: 0, availableStock: 0, safetyStock: 25, status: '품절', updatedAt: '2026.04.26 19:20' },
-  { itemCode: 'SPA-OUT-001', parentCategory: '아우터', childCategory: '패딩', itemName: '라이트 숏 패딩', actualStock: 98, availableStock: 92, safetyStock: 45, status: '정상', updatedAt: '2026.04.26 18:40' },
-  { itemCode: 'SPA-OUT-002', parentCategory: '아우터', childCategory: '후드집업', itemName: '스웨트 후드 집업', actualStock: 17, availableStock: 12, safetyStock: 30, status: '부족', updatedAt: '2026.04.26 18:10' },
-  { itemCode: 'SPA-OUT-003', parentCategory: '아우터', childCategory: '자켓', itemName: '싱글 브레스트 자켓', actualStock: 64, availableStock: 58, safetyStock: 25, status: '정상', updatedAt: '2026.04.26 17:55' },
-]
+const inventoryData = ref([])
+const isLoading = ref(false)
+const loadError = ref('')
 
 const selectedParentCategory = ref(typeof route.query.parent === 'string' ? route.query.parent : '')
 const selectedChildCategory = ref(typeof route.query.child === 'string' ? route.query.child : '')
@@ -52,7 +38,7 @@ const childCategoryOptions = computed(() =>
 
 const filteredInventory = computed(() => {
   const keyword = searchTerm.value.trim().toLowerCase()
-  return inventoryData.filter((item) => {
+  return inventoryData.value.filter((item) => {
     const matchesParent = !selectedParentCategory.value || item.parentCategory === selectedParentCategory.value
     const matchesChild = !selectedChildCategory.value || item.childCategory === selectedChildCategory.value
     const matchesStatus = !selectedStatus.value || item.status === selectedStatus.value
@@ -105,6 +91,31 @@ function handleLogout() {
   auth.logout()
   router.push('/dev-login')
 }
+
+async function loadInventories() {
+  isLoading.value = true
+  loadError.value = ''
+  try {
+    const rows = await getWarehouseInventories()
+    inventoryData.value = Array.isArray(rows)
+      ? rows.map(row => ({
+        ...row,
+        actualStock: Number(row.actualStock ?? 0),
+        availableStock: Number(row.availableStock ?? 0),
+        safetyStock: Number(row.safetyStock ?? 0),
+      }))
+      : []
+  } catch (e) {
+    inventoryData.value = []
+    loadError.value = extractErrorMessage(e, '창고 재고를 불러오지 못했습니다.')
+  } finally {
+    isLoading.value = false
+  }
+}
+
+onMounted(() => {
+  loadInventories()
+})
 </script>
 
 <template>
@@ -123,10 +134,11 @@ function handleLogout() {
             <h1 class="mt-1 text-lg font-black text-gray-900">창고 재고 조회</h1>
           </div>
           <div class="text-right text-[11px] font-bold text-gray-500">
-            <p>{{ warehouseInfo.code }} · {{ warehouseInfo.name }}</p>
+            <p>{{ auth.user?.locationCode ?? 'WAREHOUSE' }} · {{ auth.user?.locationName ?? '창고' }}</p>
             <p class="mt-1 text-gray-400">기준일 {{ today }} · 조회 {{ filteredInventory.length }}건</p>
           </div>
         </div>
+        <p v-if="loadError" class="mb-3 text-xs font-bold text-red-600">{{ loadError }}</p>
 
         <div class="grid gap-3 xl:grid-cols-[1.2fr_1fr_1fr_1fr_1.2fr]">
           <label class="flex flex-col gap-1.5">
@@ -226,11 +238,11 @@ function handleLogout() {
                       {{ item.status }}
                     </span>
                   </td>
-                  <td class="px-3 py-3 font-bold text-gray-500">{{ item.updatedAt }}</td>
+                  <td class="px-3 py-3 font-bold text-gray-500">{{ item.updatedAt ? new Date(item.updatedAt).toLocaleString('ko-KR', { hour12: false }) : '-' }}</td>
                 </tr>
                 <tr v-if="filteredInventory.length === 0">
                   <td colspan="8" class="px-3 py-14 text-center text-sm font-bold text-gray-400">
-                    조건에 맞는 창고 재고가 없습니다.
+                    {{ isLoading ? '창고 재고를 불러오는 중입니다.' : '조건에 맞는 창고 재고가 없습니다.' }}
                   </td>
                 </tr>
               </tbody>


### PR DESCRIPTION
## 📌 요약
- 창고 관리자 화면의 재고 조회/상세를 더미 데이터에서 실데이터(API) 기반으로 전환했습니다.
- 로그인한 창고 관리자(`locationCode`) 기준으로 본인 창고 재고만 조회되도록 UI 연동을 완료했습니다.

<br><br>

## 🎯 작업 내용
- `WarehouseInventoryView`를 API 연동 구조로 전환하고, 목록 필터/검색/상태 표시를 실데이터 기준으로 유지
- `WarehouseInventorySkuDetailView`를 상세 API 연동으로 전환하고, 라우트 변경 시 재조회/요청 경합 방지 처리 적용
- SKU 상세 테이블에 `품목명` 컬럼 추가 및 색상 코드(`BLK/WHT/NVY/GRY`) 한글 라벨 노출 적용

<br><br>

## ✔️ 참고 사항
- 품목 코드는 DB의 `product_master.code`(`PRD-...`)를 그대로 표시하도록 통일
- 기존 더미 store 의존을 제거했으며, 백엔드 응답 스키마 변경 없이 화면 로직만 교체

<br><br>

## ✔️ 관련 이슈

- Close #401

<br><br>
