### PR TITLE
refactor(purchase-order): HqPurchaseOrderCreateView 책임 단위 분리 2차 — 5개 자식 컴포넌트 추출

### DIFF
--- a/src/components/hq/purchase-order/PurchaseOrderBulkQtyModal.vue
+++ b/src/components/hq/purchase-order/PurchaseOrderBulkQtyModal.vue
@@ -1,0 +1,67 @@
+<script setup>
+import { ref, watch } from 'vue'
+
+const props = defineProps({
+  open: { type: Boolean, required: true },
+  selectedCount: { type: Number, required: true },
+})
+const emit = defineEmits(['close', 'apply'])
+
+const qtyInput = ref(0)
+
+// open 변경 시 입력값 초기화. 모달이 다시 열릴 때 이전 값 안 남게.
+watch(
+  () => props.open,
+  (next) => {
+    if (next) qtyInput.value = 0
+  },
+)
+
+function onApply() {
+  const qty = Number(qtyInput.value) || 0
+  emit('apply', qty)
+}
+</script>
+
+<template>
+  <div
+    v-if="open"
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+    @click.self="emit('close')"
+  >
+    <div class="w-full max-w-sm overflow-hidden bg-white shadow-xl">
+      <div class="bg-[#004D3C] px-5 py-3 text-white">
+        <h2 class="text-sm font-black">수량 일괄 입력</h2>
+      </div>
+      <div class="p-5 text-xs text-gray-700">
+        <p class="mb-3">
+          선택한 <strong>{{ selectedCount }}개 SKU</strong> 모두에 동일한 수량을 적용합니다.
+        </p>
+        <input
+          v-model.number="qtyInput"
+          type="number"
+          min="1"
+          placeholder="수량"
+          class="w-full border border-gray-300 px-3 py-2 text-center text-sm outline-none focus:border-[#004D3C]"
+          @keydown.enter="onApply"
+        />
+      </div>
+      <div class="flex items-center justify-end gap-2 border-t border-gray-200 bg-gray-50 px-5 py-3">
+        <button
+          type="button"
+          class="border border-gray-300 bg-white px-4 py-2 text-xs font-black text-gray-700 hover:bg-gray-100"
+          @click="emit('close')"
+        >
+          취소
+        </button>
+        <button
+          type="button"
+          class="border border-[#004D3C] bg-[#004D3C] px-4 py-2 text-xs font-black text-white hover:bg-[#1f4b3a]"
+          @click="onApply"
+        >
+          적용
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/hq/purchase-order/PurchaseOrderCart.vue
+++ b/src/components/hq/purchase-order/PurchaseOrderCart.vue
@@ -1,0 +1,150 @@
+<script setup>
+// 우측 발주서(장바구니). cart 상태 자체는 부모가 보유 — 자식은 표시 + 액션 emit 만.
+// 한 발주서 = 한 공급처 정책의 시점 헤더, 수량 +/- input, 라인별 소계, 총액, 비우기/요청 푸터까지.
+import { ShoppingCartIcon, TrashIcon } from '@/components/hq/purchase-order/icons.js'
+
+defineProps({
+  cart: { type: Array, required: true },
+  currentCartVendorName: { type: String, default: '' },
+  cartTotal: { type: Number, required: true },
+  canSubmit: { type: Boolean, required: true },
+  isEditMode: { type: Boolean, default: false },
+  highlightedSkuCode: { type: String, default: '' },
+})
+
+defineEmits([
+  'increase-qty',
+  'decrease-qty',
+  'update-qty',
+  'remove-item',
+  'scroll-to-catalog-sku',
+  'open-clear-cart-confirm',
+  'open-submit-confirm',
+])
+</script>
+
+<template>
+  <aside
+    class="flex w-full shrink-0 flex-col overflow-hidden border border-gray-300 bg-white shadow-sm xl:w-96"
+  >
+    <!-- 헤더 -->
+    <div class="flex items-center justify-between bg-[#004D3C] px-4 py-3 text-white">
+      <h3 class="inline-flex items-center gap-2 text-[11px] font-black uppercase tracking-wider">
+        <ShoppingCartIcon :size="14" />
+        발주 요청서
+      </h3>
+      <span class="text-[10px] font-bold opacity-80">{{ cart.length }}건</span>
+    </div>
+
+    <!-- 공급처 표시 -->
+    <div
+      v-if="currentCartVendorName"
+      class="border-b border-gray-200 bg-[#E6F2F0] px-4 py-2 text-[10px] font-black uppercase tracking-wider text-[#004D3C]"
+    >
+      {{ currentCartVendorName }}
+    </div>
+
+    <!-- 본문 -->
+    <div class="flex-1 overflow-y-auto p-3">
+      <div v-if="cart.length === 0" class="py-10 text-center text-xs text-gray-400">
+        왼쪽 카탈로그에서 품목을 담아주세요
+      </div>
+      <ul v-else class="space-y-2">
+        <li
+          v-for="(item, idx) in cart"
+          :key="(item.skuCode || item.productCode) + '-' + idx"
+          class="border bg-white p-2 transition-colors"
+          :class="highlightedSkuCode === item.skuCode
+            ? 'border-[#004D3C] ring-2 ring-[#004D3C]/30'
+            : 'border-gray-200'"
+          :data-cart-sku-code="item.skuCode"
+        >
+          <div class="flex items-start justify-between gap-2">
+            <div class="min-w-0 flex-1">
+              <p class="text-xs font-black text-gray-800">{{ item.productName }}</p>
+              <p v-if="item.displayOption" class="text-[10px] font-bold text-[#004D3C]">
+                {{ item.displayOption }}
+              </p>
+              <p class="text-[10px] text-gray-400">
+                {{ item.skuCode || item.productCode }} · ₩{{ item.unitPrice.toLocaleString() }}
+              </p>
+            </div>
+            <button
+              v-if="item.skuCode"
+              type="button"
+              class="text-[10px] font-bold text-gray-500 hover:text-[#004D3C] underline"
+              title="좌측 카탈로그에서 보기"
+              @click="$emit('scroll-to-catalog-sku', item.skuCode)"
+            >
+              ← 카탈로그
+            </button>
+            <button
+              type="button"
+              class="text-red-400 hover:text-red-600"
+              aria-label="삭제"
+              @click="$emit('remove-item', idx)"
+            >
+              <TrashIcon :size="12" />
+            </button>
+          </div>
+          <div class="mt-2 flex items-center justify-between">
+            <div class="flex items-center gap-1">
+              <button
+                type="button"
+                class="flex h-6 w-6 items-center justify-center border border-gray-300 bg-white text-xs hover:bg-gray-50"
+                @click="$emit('decrease-qty', idx)"
+              >
+                −
+              </button>
+              <input
+                :value="item.quantity"
+                type="number"
+                min="1"
+                class="w-12 border border-gray-300 py-0.5 text-center text-xs outline-none focus:border-[#004D3C]"
+                @change="$emit('update-qty', idx, $event.target.value)"
+              />
+              <button
+                type="button"
+                class="flex h-6 w-6 items-center justify-center border border-gray-300 bg-white text-xs hover:bg-gray-50"
+                @click="$emit('increase-qty', idx)"
+              >
+                +
+              </button>
+            </div>
+            <span class="text-xs font-bold text-gray-700">
+              ₩{{ (item.unitPrice * item.quantity).toLocaleString() }}
+            </span>
+          </div>
+        </li>
+      </ul>
+    </div>
+
+    <!-- 푸터 -->
+    <div class="space-y-2 border-t border-gray-200 bg-gray-50 p-3">
+      <div class="flex items-center justify-between">
+        <span class="text-[11px] font-bold uppercase text-gray-500">총액</span>
+        <span class="text-sm font-black text-[#004D3C]">
+          ₩{{ cartTotal.toLocaleString() }}
+        </span>
+      </div>
+      <div class="grid grid-cols-2 gap-2">
+        <button
+          type="button"
+          class="border border-gray-400 bg-white px-2 py-2 text-[11px] font-black text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+          :disabled="cart.length === 0"
+          @click="$emit('open-clear-cart-confirm')"
+        >
+          장바구니 비우기
+        </button>
+        <button
+          type="button"
+          class="border border-[#004D3C] bg-[#004D3C] px-2 py-2 text-[11px] font-black text-white hover:bg-[#1f4b3a] disabled:cursor-not-allowed disabled:opacity-50"
+          :disabled="!canSubmit"
+          @click="$emit('open-submit-confirm')"
+        >
+          {{ isEditMode ? '수정 저장' : '발주 요청' }}
+        </button>
+      </div>
+    </div>
+  </aside>
+</template>

--- a/src/components/hq/purchase-order/PurchaseOrderCatalog.vue
+++ b/src/components/hq/purchase-order/PurchaseOrderCatalog.vue
@@ -1,0 +1,486 @@
+<script setup>
+import { computed, nextTick, ref, toRef } from 'vue'
+import { usePurchaseOrderStore } from '@/stores/purchaseOrder.js'
+import { useFacets } from '@/composables/hq/purchaseOrder/useFacets.js'
+import { usePurchaseOrderStockSim } from '@/composables/hq/purchaseOrder/useStockSim.js'
+import { PlusIcon, SearchIcon } from '@/components/hq/purchase-order/icons.js'
+
+// 새 발주 카탈로그 — 좌측 표시 + 검색·정렬·필터·그룹 접힘·부족만 보기·SKU 다중 선택까지 자체 책임.
+// 부모와의 통신은 v-model 7개(키워드/필터/정렬/부족/선택/접힘/수량) + cart 액션 emit 2개로 좁혀짐.
+// store/composable 은 자식이 직접 import — 부모의 카탈로그 관련 의존이 사라짐.
+
+const props = defineProps({
+  selectedWarehouseCode: { type: String, required: true },
+  isEditMode: { type: Boolean, default: false },
+  cart: { type: Array, required: true },
+})
+
+const keyword = defineModel('keyword', { type: String, required: true })
+const vendorFilter = defineModel('vendorFilter', { type: String, required: true })
+const sortBy = defineModel('sortBy', { type: String, required: true })
+const shortageOnly = defineModel('shortageOnly', { type: Boolean, required: true })
+const selectedSkus = defineModel('selectedSkus', { type: Set, required: true })
+const collapsed = defineModel('collapsed', { type: Object, required: true })
+const rowQuantities = defineModel('rowQuantities', { type: Object, required: true })
+
+const emit = defineEmits(['add-sku-to-cart', 'add-group-to-cart', 'scroll-to-cart-sku'])
+
+const poStore = usePurchaseOrderStore()
+const { activeFacetFilters, toggleFacet, isFacetActive, clearFacets, skuMatchesFacets } = useFacets()
+const {
+  stockStore,
+  rowStock,
+  rowStockLevel,
+  rowSuggested,
+  stockLevelClass,
+  statusChipForSku,
+  shortageRank,
+} = usePurchaseOrderStockSim(toRef(props, 'selectedWarehouseCode'))
+
+const searchInputRef = ref(null)
+
+const catalogSkuRows = computed(() => poStore.catalogSkuRows)
+const catalogFacets = computed(() => poStore.catalogFacets)
+const catalogLoading = computed(() => poStore.catalogLoading)
+
+const vendorOptions = computed(() => {
+  const seen = new Map()
+  for (const r of catalogSkuRows.value) {
+    if (r.type === 'header' && !seen.has(r.vendorCode)) {
+      seen.set(r.vendorCode, { id: r.vendorCode, code: r.vendorCode, name: r.vendorName })
+    }
+  }
+  return [...seen.values()].sort((a, b) => a.name.localeCompare(b.name, 'ko'))
+})
+
+const filteredRows = computed(() => {
+  const kw = keyword.value.trim().toLowerCase()
+  const all = catalogSkuRows.value
+  if (all.length === 0) return []
+
+  let skus = all.filter((r) => r.type === 'sku')
+  if (kw) {
+    skus = skus.filter((r) =>
+      [r.vendorName, r.productName, r.productCode, r.skuCode, r.color, r.size, r.displayOption]
+        .some((s) => (s ?? '').toLowerCase().includes(kw)),
+    )
+  }
+  skus = skus.filter(skuMatchesFacets)
+
+  if (shortageOnly.value && props.selectedWarehouseCode) {
+    skus = skus.filter((r) => {
+      const level = rowStockLevel(r.skuCode)
+      return level === 'critical' || level === 'warning'
+    })
+  }
+
+  switch (sortBy.value) {
+    case 'shortage':
+      skus = [...skus].sort((a, b) => {
+        const rankDiff = shortageRank(a.skuCode) - shortageRank(b.skuCode)
+        if (rankDiff !== 0) return rankDiff
+        return a.productName.localeCompare(b.productName, 'ko')
+          || (a.optionValue ?? '').localeCompare(b.optionValue ?? '', 'ko')
+      })
+      break
+    case 'priceAsc':
+      skus = [...skus].sort((a, b) => a.unitPrice - b.unitPrice)
+      break
+    case 'priceDesc':
+      skus = [...skus].sort((a, b) => b.unitPrice - a.unitPrice)
+      break
+    case 'nameAsc':
+      skus = [...skus].sort((a, b) =>
+        a.productName.localeCompare(b.productName, 'ko')
+          || (a.displayOption || '').localeCompare(b.displayOption || '', 'ko'),
+      )
+      break
+    default:
+      break
+  }
+
+  const skusByMaster = new Map()
+  for (const s of skus) {
+    if (!skusByMaster.has(s.masterKey)) skusByMaster.set(s.masterKey, [])
+    skusByMaster.get(s.masterKey).push(s)
+  }
+  const headerByMaster = new Map()
+  for (const r of all) {
+    if (r.type === 'header') headerByMaster.set(r.masterKey, r)
+  }
+
+  const result = []
+  for (const [masterKey, skuList] of skusByMaster) {
+    const header = headerByMaster.get(masterKey)
+    if (!header) continue
+    result.push(header)
+    if (!collapsed.value[masterKey]) result.push(...skuList)
+  }
+  return result
+})
+
+const matchedSkuCount = computed(() => filteredRows.value.filter((r) => r.type === 'sku').length)
+
+const shortageCount = computed(() => {
+  if (!props.selectedWarehouseCode) return 0
+  const skuCodes = catalogSkuRows.value
+    .filter((r) => r.type === 'sku')
+    .map((r) => r.skuCode)
+  return stockStore.getSkuShortageCount(props.selectedWarehouseCode, skuCodes)
+})
+
+function rowKey(row) {
+  if (row.type === 'vendor') return `v-${row.vendorCode}`
+  if (row.type === 'header') return `h-${row.masterKey}`
+  return `s-${row.skuCode}`
+}
+
+function isInCart(skuCode) {
+  return props.cart.some((it) => it.skuCode === skuCode)
+}
+
+function isGroupAllSelected(masterKey) {
+  const skus = filteredRows.value.filter((r) => r.type === 'sku' && r.masterKey === masterKey)
+  if (skus.length === 0) return false
+  return skus.every((s) => selectedSkus.value.has(s.skuCode))
+}
+
+function isGroupSomeSelected(masterKey) {
+  const skus = filteredRows.value.filter((r) => r.type === 'sku' && r.masterKey === masterKey)
+  return skus.some((s) => selectedSkus.value.has(s.skuCode)) && !isGroupAllSelected(masterKey)
+}
+
+function toggleSkuSelected(skuCode) {
+  const set = new Set(selectedSkus.value)
+  if (set.has(skuCode)) set.delete(skuCode)
+  else set.add(skuCode)
+  selectedSkus.value = set
+}
+
+function toggleGroupSelected(masterKey, evt) {
+  evt?.stopPropagation?.()
+  const skus = filteredRows.value.filter((r) => r.type === 'sku' && r.masterKey === masterKey)
+  const set = new Set(selectedSkus.value)
+  const allSelected = skus.every((s) => set.has(s.skuCode))
+  for (const s of skus) {
+    if (allSelected) set.delete(s.skuCode)
+    else set.add(s.skuCode)
+  }
+  selectedSkus.value = set
+}
+
+function toggleGroup(masterKey) {
+  collapsed.value = { ...collapsed.value, [masterKey]: !collapsed.value[masterKey] }
+}
+
+function expandAll() {
+  collapsed.value = {}
+}
+
+function collapseAll() {
+  const next = {}
+  for (const r of catalogSkuRows.value) {
+    if (r.type === 'header') next[r.masterKey] = true
+  }
+  collapsed.value = next
+}
+
+function applySuggestedToSku(row) {
+  const suggested = rowSuggested(row.skuCode)
+  if (suggested <= 0) return
+  rowQuantities.value = { ...rowQuantities.value, [row.skuCode]: suggested }
+  nextTick(() => {
+    const el = document.querySelector(`[data-sku-code="${row.skuCode}"] input[type="number"]`)
+    if (el) {
+      el.focus()
+      el.select?.()
+    }
+  })
+}
+
+function focusSearch() {
+  searchInputRef.value?.focus?.()
+}
+
+function scrollToSku(skuCode) {
+  const skuRow = catalogSkuRows.value.find((r) => r.type === 'sku' && r.skuCode === skuCode)
+  if (skuRow && collapsed.value[skuRow.masterKey]) {
+    collapsed.value = { ...collapsed.value, [skuRow.masterKey]: false }
+  }
+  nextTick(() => {
+    const el = document.querySelector(`[data-sku-code="${skuCode}"]`)
+    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  })
+}
+
+defineExpose({ focusSearch, scrollToSku })
+</script>
+
+<template>
+  <div class="flex min-w-0 flex-1 flex-col overflow-hidden border border-gray-300 bg-white shadow-sm">
+    <!-- 필터 헤더 -->
+    <div class="flex flex-wrap items-center gap-2 border-b border-gray-200 bg-gray-50 p-2 pr-[15px]">
+      <label class="relative block">
+        <SearchIcon :size="14" class="absolute left-2.5 top-1/2 -translate-y-1/2 text-gray-400" />
+        <input
+          ref="searchInputRef"
+          v-model="keyword"
+          type="text"
+          placeholder='제품명/SKU코드/옵션값 검색  ("/" 로 포커스)'
+          class="w-72 border border-gray-300 bg-white py-1.5 pl-8 pr-3 text-xs outline-none focus:border-[#004D3C]"
+        />
+      </label>
+      <select
+        v-model="vendorFilter"
+        :disabled="isEditMode"
+        class="border border-gray-300 bg-white px-3 py-1.5 text-xs outline-none focus:border-[#004D3C] disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500"
+      >
+        <option value="all">전체 공급처</option>
+        <option v-for="v in vendorOptions" :key="v.code" :value="v.code">{{ v.name }}</option>
+      </select>
+      <select
+        v-model="sortBy"
+        class="border border-gray-300 bg-white px-3 py-1.5 text-xs outline-none focus:border-[#004D3C]"
+      >
+        <option value="default">정렬: 기본</option>
+        <option value="shortage">부족 SKU 우선</option>
+        <option value="priceAsc">단가 ↑</option>
+        <option value="priceDesc">단가 ↓</option>
+        <option value="nameAsc">제품명 ㄱ-ㄴ</option>
+      </select>
+      <button
+        type="button"
+        class="border border-gray-300 bg-white px-2 py-1.5 text-[11px] font-bold text-gray-600 hover:bg-gray-50"
+        @click="expandAll"
+      >
+        전체 펼치기
+      </button>
+      <button
+        type="button"
+        class="border border-gray-300 bg-white px-2 py-1.5 text-[11px] font-bold text-gray-600 hover:bg-gray-50"
+        @click="collapseAll"
+      >
+        전체 접기
+      </button>
+      <button
+        type="button"
+        class="border px-3 py-1.5 text-[11px] font-black transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+        :class="
+          shortageOnly
+            ? 'border-red-400 bg-red-50 text-red-700'
+            : shortageCount > 0
+              ? 'border-red-300 bg-white text-red-600 hover:bg-red-50'
+              : 'border-gray-300 bg-white text-gray-600 hover:bg-gray-50'
+        "
+        :disabled="!selectedWarehouseCode || shortageCount === 0"
+        :title="!selectedWarehouseCode ? '먼저 창고를 선택하세요' : (shortageCount === 0 ? '재고 부족 품목 없음' : '가용재고가 안전재고 1.5배 미만인 마스터만 표시')"
+        @click="shortageOnly = !shortageOnly"
+      >
+        {{ shortageOnly ? `✓ 부족만 (${shortageCount})` : (selectedWarehouseCode && shortageCount > 0 ? `부족만 보기 (${shortageCount})` : '부족만 보기') }}
+      </button>
+      <span class="ml-auto text-[11px] font-bold text-gray-500">SKU {{ matchedSkuCount }}건</span>
+    </div>
+
+    <!-- Facet 필터 칩 (옵션 axis 별) -->
+    <div
+      v-if="catalogFacets.length > 0"
+      class="flex flex-wrap items-center gap-2 border-b border-gray-200 bg-white px-2 py-2 pr-[15px]"
+    >
+      <div v-for="facet in catalogFacets" :key="facet.name" class="flex items-center gap-1">
+        <span class="text-[10px] font-black uppercase tracking-wider text-gray-400">{{ facet.name }}</span>
+        <button
+          v-for="value in facet.values"
+          :key="`${facet.name}-${value}`"
+          type="button"
+          class="border px-2 py-0.5 text-[10px] font-bold transition-colors"
+          :class="isFacetActive(facet.name, value)
+            ? 'border-[#004D3C] bg-[#004D3C] text-white'
+            : 'border-gray-300 bg-white text-gray-600 hover:bg-gray-50'"
+          @click="toggleFacet(facet.name, value)"
+        >
+          {{ value }}
+        </button>
+      </div>
+      <button
+        v-if="Object.keys(activeFacetFilters).length > 0"
+        type="button"
+        class="ml-auto text-[10px] font-bold text-gray-500 hover:text-gray-700 underline"
+        @click="clearFacets"
+      >
+        필터 초기화
+      </button>
+    </div>
+
+    <!-- 창고 미선택 안내 -->
+    <div
+      v-if="!selectedWarehouseCode"
+      class="border-b border-amber-200 bg-amber-50 px-3 py-2 pr-[15px] text-[11px] font-bold text-amber-700"
+    >
+      입고 창고를 먼저 선택해주세요. 창고가 정해져야 발주서를 만들 수 있습니다.
+    </div>
+
+    <!-- 카탈로그 테이블 — 카드 내부 자체 스크롤. 그룹 헤더 sticky. -->
+    <div class="min-h-0 flex-1 overflow-auto">
+      <table class="w-full table-fixed border-collapse text-xs">
+        <thead class="bg-gray-100 text-xs text-gray-500">
+          <tr>
+            <th class="w-8 px-1 py-2 text-center font-black"></th>
+            <th class="w-44 px-2 py-2 text-left font-black">옵션</th>
+            <th class="w-28 px-2 py-2 text-left font-black">SKU 코드</th>
+            <th class="w-20 px-2 py-2 text-right font-black">단가</th>
+            <th class="w-12 px-2 py-2 text-right font-black" title="실재고 + 입고예정 - 출고예정">가용</th>
+            <th class="w-12 px-2 py-2 text-right font-black" title="실재고 (현재 보유)">실</th>
+            <th class="w-12 px-2 py-2 text-right font-black" title="안전재고 (이 밑으로 떨어지면 안 됨)">안전</th>
+            <th class="w-14 px-2 py-2 text-right font-black" title="안전재고 × 1.5 까지 채우는 권장 발주 수량">권장</th>
+            <th class="w-14 px-1 py-2 text-center font-black">상태</th>
+            <th class="w-14 px-1 py-2 text-center font-black">수량</th>
+            <th class="w-12 px-2 py-2 text-center font-black"></th>
+          </tr>
+        </thead>
+        <tbody :class="!selectedWarehouseCode ? 'pointer-events-none opacity-50' : ''">
+          <template v-for="row in filteredRows" :key="rowKey(row)">
+            <tr
+              v-if="row.type === 'header'"
+              class="bg-gray-50 hover:bg-gray-100 border-t border-gray-200 cursor-pointer select-none"
+              @click="toggleGroup(row.masterKey)"
+            >
+              <td class="px-1 py-2.5 text-center">
+                <input
+                  v-if="!collapsed[row.masterKey]"
+                  type="checkbox"
+                  :checked="isGroupAllSelected(row.masterKey)"
+                  :indeterminate.prop="isGroupSomeSelected(row.masterKey)"
+                  class="cursor-pointer"
+                  @click.stop
+                  @change="toggleGroupSelected(row.masterKey, $event)"
+                />
+              </td>
+              <td colspan="10" class="px-3 py-2.5">
+                <div class="flex items-center gap-3 flex-wrap">
+                  <span class="text-[11px] font-black text-gray-500 shrink-0">
+                    {{ collapsed[row.masterKey] ? '▸' : '▾' }}
+                  </span>
+                  <span class="text-xs font-black text-gray-900 truncate">{{ row.productName }}</span>
+                  <span class="font-mono text-[10px] font-bold text-gray-400 shrink-0">{{ row.productCode }}</span>
+                  <span class="ml-auto text-[10px] font-bold text-gray-400 shrink-0">
+                    공급처
+                    <span class="ml-1 font-black text-gray-700">{{ row.vendorName }}</span>
+                  </span>
+                </div>
+              </td>
+            </tr>
+            <tr
+              v-else
+              class="border-b border-gray-100 hover:bg-[#F4FAF8]"
+              :class="selectedSkus.has(row.skuCode) ? 'bg-emerald-50' : ''"
+              :data-sku-code="row.skuCode"
+            >
+              <td class="px-1 py-2 text-center align-middle">
+                <input
+                  type="checkbox"
+                  :checked="selectedSkus.has(row.skuCode)"
+                  class="cursor-pointer"
+                  @change="toggleSkuSelected(row.skuCode)"
+                />
+              </td>
+              <td class="px-2 py-2 align-middle">
+                <div class="text-xs font-bold text-gray-800">{{ row.displayOption }}</div>
+              </td>
+              <td class="px-2 py-2 text-[11px] text-gray-500 align-middle">{{ row.skuCode }}</td>
+              <td class="px-2 py-2 text-right font-bold text-[#004D3C] align-middle">
+                ₩{{ row.unitPrice.toLocaleString() }}
+              </td>
+              <td class="px-2 py-2 text-right font-bold align-middle" :class="stockLevelClass(rowStockLevel(row.skuCode))">
+                <template v-if="rowStock(row.skuCode)">{{ rowStock(row.skuCode).available }}</template>
+                <span v-else class="text-gray-300">—</span>
+              </td>
+              <td class="px-2 py-2 text-right font-bold text-gray-500 align-middle">
+                <template v-if="rowStock(row.skuCode)">{{ rowStock(row.skuCode).onHand }}</template>
+                <span v-else class="text-gray-300">—</span>
+              </td>
+              <td class="px-2 py-2 text-right font-bold text-gray-500 align-middle">
+                <template v-if="rowStock(row.skuCode)">{{ rowStock(row.skuCode).safetyStock }}</template>
+                <span v-else class="text-gray-300">—</span>
+              </td>
+              <td class="px-2 py-2 text-right align-middle">
+                <template v-if="rowStock(row.skuCode)">
+                  <button
+                    v-if="rowSuggested(row.skuCode) > 0"
+                    type="button"
+                    class="border border-red-300 bg-red-50 px-2 py-0.5 text-[10px] font-black text-red-700 hover:bg-red-100"
+                    :title="`권장 발주 ${rowSuggested(row.skuCode)}개를 수량 입력란에 채웁니다`"
+                    @click="applySuggestedToSku(row)"
+                  >
+                    {{ rowSuggested(row.skuCode) }}
+                  </button>
+                  <span v-else class="text-gray-300">—</span>
+                </template>
+                <span v-else class="text-gray-300">—</span>
+              </td>
+              <td class="px-1 py-2 text-center align-middle">
+                <template v-if="statusChipForSku(row.skuCode)">
+                  <span
+                    class="inline-flex min-w-9 justify-center px-1.5 py-0.5 text-[10px] font-black"
+                    :class="statusChipForSku(row.skuCode).class"
+                  >
+                    {{ statusChipForSku(row.skuCode).label }}
+                  </span>
+                </template>
+                <span v-else class="text-gray-300">—</span>
+              </td>
+              <td class="px-1 py-2 align-middle">
+                <input
+                  type="number"
+                  min="0"
+                  placeholder="0"
+                  class="w-full border border-gray-300 px-1 py-1 text-center text-xs outline-none focus:border-[#004D3C]"
+                  :value="rowQuantities[row.skuCode] ?? ''"
+                  @input="rowQuantities = { ...rowQuantities, [row.skuCode]: Number($event.target.value) || 0 }"
+                  @keydown.enter.exact="emit('add-sku-to-cart', row)"
+                  @keydown.enter.shift.prevent="emit('add-group-to-cart', row.masterKey)"
+                />
+              </td>
+              <td class="px-2 py-2 text-center align-middle">
+                <div class="inline-flex items-center gap-1">
+                  <button
+                    type="button"
+                    class="inline-flex items-center justify-center border border-[#004D3C] bg-white p-1 text-[#004D3C] hover:bg-[#E6F2F0] disabled:cursor-not-allowed disabled:opacity-40"
+                    :disabled="!(Number(rowQuantities[row.skuCode]) > 0)"
+                    title="장바구니 담기 (Enter)"
+                    @click="emit('add-sku-to-cart', row)"
+                  >
+                    <PlusIcon :size="12" />
+                  </button>
+                  <button
+                    v-if="isInCart(row.skuCode)"
+                    type="button"
+                    class="text-[10px] font-bold text-[#004D3C] hover:underline"
+                    title="장바구니에서 보기"
+                    @click="emit('scroll-to-cart-sku', row.skuCode)"
+                  >
+                    ●
+                  </button>
+                </div>
+              </td>
+            </tr>
+          </template>
+          <tr v-if="!catalogLoading && catalogSkuRows.length === 0">
+            <td colspan="11" class="px-3 py-8 text-center text-xs text-gray-400">
+              노출 가능한 계약 제품이 없습니다.
+            </td>
+          </tr>
+          <tr v-else-if="!catalogLoading && filteredRows.length === 0">
+            <td colspan="11" class="px-3 py-8 text-center text-xs text-gray-400">
+              검색 결과가 없습니다.
+            </td>
+          </tr>
+          <tr v-if="catalogLoading">
+            <td colspan="11" class="px-3 py-8 text-center text-xs text-gray-400">
+              카탈로그를 불러오는 중...
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>

--- a/src/components/hq/purchase-order/PurchaseOrderConfirmModal.vue
+++ b/src/components/hq/purchase-order/PurchaseOrderConfirmModal.vue
@@ -1,0 +1,65 @@
+<script setup>
+import { computed } from 'vue'
+import { AlertTriangleIcon } from '@/components/hq/purchase-order/icons.js'
+
+// 단순 confirm 모달 (창고 변경 / 공급처 변경 / 장바구니 비우기 통합).
+// 본문은 slot — 호출처가 메시지 자유롭게 작성.
+// variant 가 header 색상 + confirm 버튼 색상 + 경고 아이콘 노출 결정.
+const props = defineProps({
+  open: { type: Boolean, required: true },
+  variant: {
+    type: String,
+    default: 'signature',
+    validator: (v) => ['signature', 'amber', 'red'].includes(v),
+  },
+  title: { type: String, required: true },
+  confirmLabel: { type: String, required: true },
+})
+defineEmits(['cancel', 'confirm'])
+
+const headerClass = computed(() => {
+  if (props.variant === 'amber') return 'flex items-center gap-2 bg-amber-600 px-5 py-3 text-white'
+  if (props.variant === 'red') return 'bg-red-700 px-5 py-3 text-white'
+  return 'bg-[#004D3C] px-5 py-3 text-white'
+})
+
+const confirmBtnClass = computed(() => {
+  if (props.variant === 'amber') {
+    return 'border border-amber-600 bg-amber-600 px-4 py-2 text-xs font-black text-white hover:bg-amber-500'
+  }
+  if (props.variant === 'red') {
+    return 'border border-red-700 bg-red-700 px-4 py-2 text-xs font-black text-white hover:bg-red-600'
+  }
+  return 'border border-[#004D3C] bg-[#004D3C] px-4 py-2 text-xs font-black text-white hover:bg-[#1f4b3a]'
+})
+</script>
+
+<template>
+  <div
+    v-if="open"
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+    @click.self="$emit('cancel')"
+  >
+    <div class="w-full max-w-sm overflow-hidden bg-white shadow-xl">
+      <div :class="headerClass">
+        <AlertTriangleIcon v-if="variant === 'amber'" :size="14" />
+        <h2 class="text-sm font-black">{{ title }}</h2>
+      </div>
+      <div class="p-5 text-xs text-gray-700">
+        <slot />
+      </div>
+      <div class="flex items-center justify-end gap-2 border-t border-gray-200 bg-gray-50 px-5 py-3">
+        <button
+          type="button"
+          class="border border-gray-300 bg-white px-4 py-2 text-xs font-black text-gray-700 hover:bg-gray-100"
+          @click="$emit('cancel')"
+        >
+          취소
+        </button>
+        <button type="button" :class="confirmBtnClass" @click="$emit('confirm')">
+          {{ confirmLabel }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/hq/purchase-order/PurchaseOrderFloatingBar.vue
+++ b/src/components/hq/purchase-order/PurchaseOrderFloatingBar.vue
@@ -1,0 +1,38 @@
+<script setup>
+defineProps({
+  selectedCount: { type: Number, required: true },
+})
+defineEmits(['openBulkQty', 'clearSelection'])
+</script>
+
+<template>
+  <Transition
+    enter-active-class="transition-all duration-200"
+    leave-active-class="transition-all duration-200"
+    enter-from-class="opacity-0 translate-y-2"
+    leave-to-class="opacity-0 translate-y-2"
+  >
+    <div
+      v-if="selectedCount > 0"
+      class="fixed bottom-6 left-1/2 z-40 -translate-x-1/2 transform"
+    >
+      <div class="flex items-center gap-3 border border-[#004D3C] bg-[#004D3C] px-4 py-2.5 text-white shadow-xl">
+        <span class="text-xs font-black">{{ selectedCount }}개 SKU 선택됨</span>
+        <button
+          type="button"
+          class="border border-white bg-white px-3 py-1 text-[11px] font-black text-[#004D3C] hover:bg-gray-100"
+          @click="$emit('openBulkQty')"
+        >
+          수량 일괄 입력
+        </button>
+        <button
+          type="button"
+          class="text-[11px] font-bold text-white/80 hover:text-white underline"
+          @click="$emit('clearSelection')"
+        >
+          선택 해제
+        </button>
+      </div>
+    </div>
+  </Transition>
+</template>

--- a/src/components/hq/purchase-order/PurchaseOrderSubmitConfirmModal.vue
+++ b/src/components/hq/purchase-order/PurchaseOrderSubmitConfirmModal.vue
@@ -1,0 +1,72 @@
+<script setup>
+// 발주 요청/수정 최종 확인 모달. 발주서 요약(창고/공급처/품목 수/총액) + mode 별 안내문.
+defineProps({
+  open: { type: Boolean, required: true },
+  isEditMode: { type: Boolean, default: false },
+  warehouseName: { type: String, default: '' },
+  vendorName: { type: String, default: '' },
+  itemCount: { type: Number, required: true },
+  totalAmount: { type: Number, required: true },
+})
+defineEmits(['cancel', 'confirm'])
+</script>
+
+<template>
+  <div
+    v-if="open"
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+    @click.self="$emit('cancel')"
+  >
+    <div class="w-full max-w-sm overflow-hidden bg-white shadow-xl">
+      <div class="bg-[#004D3C] px-5 py-3 text-white">
+        <h2 class="text-sm font-black">{{ isEditMode ? '발주 수정 확인' : '발주 요청 확인' }}</h2>
+      </div>
+      <div class="space-y-2 p-5 text-xs text-gray-700">
+        <p class="text-[10px] font-bold uppercase tracking-wider text-gray-400">발주서 요약</p>
+        <dl class="space-y-1.5">
+          <div class="flex justify-between gap-2">
+            <dt class="text-gray-500">입고 창고</dt>
+            <dd class="font-bold text-gray-800">{{ warehouseName }}</dd>
+          </div>
+          <div class="flex justify-between gap-2">
+            <dt class="text-gray-500">공급처</dt>
+            <dd class="font-bold text-gray-800">{{ vendorName }}</dd>
+          </div>
+          <div class="flex justify-between gap-2">
+            <dt class="text-gray-500">품목</dt>
+            <dd class="font-bold text-gray-800">{{ itemCount }}건</dd>
+          </div>
+          <div class="flex justify-between gap-2">
+            <dt class="text-gray-500">총액</dt>
+            <dd class="font-black text-[#004D3C]">₩{{ totalAmount.toLocaleString() }}</dd>
+          </div>
+        </dl>
+        <p class="pt-2 text-[11px] leading-relaxed text-gray-500">
+          <template v-if="isEditMode">
+            이 내용으로 발주를 수정합니다. 공급처 승인 전까지만 가능합니다.
+          </template>
+          <template v-else>
+            이 내용으로 공급처에 발주 요청합니다.
+            요청 후 공급처 응답 받기 전까지 [취소] 가능합니다.
+          </template>
+        </p>
+      </div>
+      <div class="flex items-center justify-end gap-2 border-t border-gray-200 bg-gray-50 px-5 py-3">
+        <button
+          type="button"
+          class="border border-gray-300 bg-white px-4 py-2 text-xs font-black text-gray-700 hover:bg-gray-100"
+          @click="$emit('cancel')"
+        >
+          취소
+        </button>
+        <button
+          type="button"
+          class="border border-[#004D3C] bg-[#004D3C] px-4 py-2 text-xs font-black text-white hover:bg-[#1f4b3a]"
+          @click="$emit('confirm')"
+        >
+          {{ isEditMode ? '수정 저장' : '발주 요청' }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/views/hq/purchase-order/HqPurchaseOrderCreateView.vue
+++ b/src/views/hq/purchase-order/HqPurchaseOrderCreateView.vue
@@ -7,18 +7,15 @@ import { useAuthStore } from '@/stores/auth.js'
 import { usePurchaseOrderStore } from '@/stores/purchaseOrder.js'
 import {
   ArrowLeftIcon,
-  PlusIcon,
-  SearchIcon,
   ShoppingCartIcon,
   TrashIcon,
 } from '@/components/hq/purchase-order/icons.js'
 import PurchaseOrderBulkQtyModal from '@/components/hq/purchase-order/PurchaseOrderBulkQtyModal.vue'
+import PurchaseOrderCatalog from '@/components/hq/purchase-order/PurchaseOrderCatalog.vue'
 import PurchaseOrderConfirmModal from '@/components/hq/purchase-order/PurchaseOrderConfirmModal.vue'
 import PurchaseOrderFloatingBar from '@/components/hq/purchase-order/PurchaseOrderFloatingBar.vue'
 import PurchaseOrderSubmitConfirmModal from '@/components/hq/purchase-order/PurchaseOrderSubmitConfirmModal.vue'
 import { useToast } from '@/composables/useToast.js'
-import { useFacets } from '@/composables/hq/purchaseOrder/useFacets.js'
-import { usePurchaseOrderStockSim } from '@/composables/hq/purchaseOrder/useStockSim.js'
 import { usePurchaseOrderDraft } from '@/composables/hq/purchaseOrder/useDraft.js'
 
 const router = useRouter()
@@ -27,7 +24,8 @@ const auth = useAuthStore()
 const poStore = usePurchaseOrderStore()
 
 const { toast, triggerToast } = useToast()
-const { activeFacetFilters, toggleFacet, isFacetActive, clearFacets, skuMatchesFacets } = useFacets()
+// 카탈로그 child 의 expose 메소드(focusSearch/scrollToSku) 호출용 ref.
+const catalogRef = ref(null)
 
 const isEditMode = computed(() => route.name === 'hq-purchase-order-edit')
 const editingOrderId = computed(() => route.params.id ?? null)
@@ -54,16 +52,8 @@ const vendorFilter = ref('all')
 const sortBy = ref('default')
 const cart = ref([])
 
-// 재고 시뮬레이션 — selectedWarehouseCode 의존이라 정의 이후 호출.
-const {
-  stockStore,
-  rowStock,
-  rowStockLevel,
-  rowSuggested,
-  stockLevelClass,
-  statusChipForSku,
-  shortageRank,
-} = usePurchaseOrderStockSim(selectedWarehouseCode)
+// 재고 시뮬레이션 / facet 필터 / 카탈로그 헬퍼는 PurchaseOrderCatalog child 가 자체 보유.
+// 부모는 cart/모달/제출 같은 도메인 액션만.
 
 // localStorage 드래프트 영속화 — edit 모드는 자동 no-op.
 const { loadDraft, saveDraft, clearDraftStorage } = usePurchaseOrderDraft({
@@ -91,13 +81,10 @@ const collapsed = ref({})
 const shortageOnly = ref(false)
 
 // ─── Power 모드 ─────────────────────────────────────────────────────────────
-// 다중 선택: skuCode set
+// 다중 선택: skuCode set — Floating bar 와 카탈로그가 v-model 로 공유.
 const selectedSkus = ref(new Set())
-// activeFacetFilters / toggleFacet / ... 는 useFacets() composable 에서 제공.
 // Bulk 수량 모달 — 입력값은 모달 컴포넌트 로컬 state (open/close 만 부모 관리)
 const showBulkQtyModal = ref(false)
-// 검색창 ref (단축키용)
-const searchInputRef = ref(null)
 // cart 강조용 — [좌측에서 보기] / [장바구니에서 보기] 점프 시 잠시 highlight
 const highlightedSkuCode = ref('')
 let highlightTimer = null
@@ -119,52 +106,13 @@ function scrollToCartSku(skuCode) {
   }
 }
 
+// cart → 카탈로그 점프 — child(catalogRef) 의 expose 메소드 위임 (그룹 펼침 + scrollIntoView).
 function scrollToCatalogSku(skuCode) {
-  // 그룹이 접혀 있으면 펼침
-  const skuRow = catalogSkuRows.value.find((r) => r.type === 'sku' && r.skuCode === skuCode)
-  if (skuRow && collapsed.value[skuRow.masterKey]) {
-    collapsed.value[skuRow.masterKey] = false
-  }
-  nextTick(() => {
-    const el = document.querySelector(`[data-sku-code="${skuCode}"]`)
-    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' })
-  })
+  catalogRef.value?.scrollToSku?.(skuCode)
 }
 
-function isInCart(skuCode) {
-  return cart.value.some((item) => item.skuCode === skuCode)
-}
-
-function toggleSkuSelected(skuCode) {
-  const set = new Set(selectedSkus.value)
-  if (set.has(skuCode)) set.delete(skuCode)
-  else set.add(skuCode)
-  selectedSkus.value = set
-}
-
-function isGroupAllSelected(masterKey) {
-  const skus = filteredRows.value.filter((r) => r.type === 'sku' && r.masterKey === masterKey)
-  if (skus.length === 0) return false
-  return skus.every((s) => selectedSkus.value.has(s.skuCode))
-}
-
-function isGroupSomeSelected(masterKey) {
-  const skus = filteredRows.value.filter((r) => r.type === 'sku' && r.masterKey === masterKey)
-  return skus.some((s) => selectedSkus.value.has(s.skuCode)) && !isGroupAllSelected(masterKey)
-}
-
-function toggleGroupSelected(masterKey, evt) {
-  // 그룹 헤더 행 클릭과 충돌 방지 — 이벤트 stop 은 호출처에서
-  evt?.stopPropagation?.()
-  const skus = filteredRows.value.filter((r) => r.type === 'sku' && r.masterKey === masterKey)
-  const set = new Set(selectedSkus.value)
-  const allSelected = skus.every((s) => set.has(s.skuCode))
-  for (const s of skus) {
-    if (allSelected) set.delete(s.skuCode)
-    else set.add(s.skuCode)
-  }
-  selectedSkus.value = set
-}
+// isInCart / toggleSkuSelected / isGroupAllSelected / isGroupSomeSelected / toggleGroupSelected
+// 모두 PurchaseOrderCatalog child 안으로 이동.
 
 function clearSelection() {
   selectedSkus.value = new Set()
@@ -200,7 +148,7 @@ function handleBulkApply(qty) {
   }
   // 선택된 SKU 들의 vendorCode 가 cart 공급처와 다른 게 섞여 있으면 거절 (한 공급처 룰)
   const selectedRows = []
-  for (const r of catalogSkuRows.value) {
+  for (const r of poStore.catalogSkuRows) {
     if (r.type === 'sku' && selectedSkus.value.has(r.skuCode)) selectedRows.push(r)
   }
   if (selectedRows.length === 0) return
@@ -241,14 +189,11 @@ function handleKeydown(e) {
       e.preventDefault()
       return
     }
-    if (target === searchInputRef.value) {
-      searchInputRef.value?.blur?.()
-    }
     return
   }
 
   if (e.key === '/' && !inEditable) {
-    searchInputRef.value?.focus?.()
+    catalogRef.value?.focusSearch?.()
     e.preventDefault()
     return
   }
@@ -273,156 +218,9 @@ onBeforeUnmount(() => {
 // toast / triggerToast 는 useToast() composable 에서 제공 (timer cleanup 도 composable 안에서).
 
 // ─── computed ────────────────────────────────────────────────────────────────
-// 카탈로그 = poStore 의 평탄 row 배열 (header + sku 행 섞여 있음).
-// 검색·정렬·필터·그룹 접힘은 view 단에서 적용해 filteredRows 만들어 v-for.
-const catalogSkuRows = computed(() => poStore.catalogSkuRows)
-const catalogFacets = computed(() => poStore.catalogFacets)
-const catalogLoading = computed(() => poStore.catalogLoading)
-
-// 검색·정렬을 적용한 row 들. 정렬은 SKU 단가/제품명 기준 — 그룹 단위로 묶이도록 group key 우선 정렬.
-const filteredRows = computed(() => {
-  const kw = keyword.value.trim().toLowerCase()
-  const all = catalogSkuRows.value
-  if (all.length === 0) return []
-
-  // 1) SKU 행만 추출해서 검색·정렬·facet 필터 적용
-  let skus = all.filter((r) => r.type === 'sku')
-  if (kw) {
-    skus = skus.filter((r) =>
-      [r.vendorName, r.productName, r.productCode, r.skuCode, r.color, r.size, r.displayOption]
-        .some((s) => (s ?? '').toLowerCase().includes(kw)),
-    )
-  }
-  skus = skus.filter(skuMatchesFacets)
-
-  // 부족만 보기 — SKU 단위 stock 임계 기준
-  if (shortageOnly.value && selectedWarehouseCode.value) {
-    skus = skus.filter((r) => {
-      const level = rowStockLevel(r.skuCode)
-      return level === 'critical' || level === 'warning'
-    })
-  }
-  switch (sortBy.value) {
-    case 'shortage':
-      // 부족 SKU 우선 — 품절(0) > 부족(critical) > 주의(warning) > 정상 순. 같은 등급 안에선 productName 가나다.
-      skus = [...skus].sort((a, b) => {
-        const rankDiff = shortageRank(a.skuCode) - shortageRank(b.skuCode)
-        if (rankDiff !== 0) return rankDiff
-        return a.productName.localeCompare(b.productName, 'ko')
-          || a.optionValue.localeCompare(b.optionValue, 'ko')
-      })
-      break
-    case 'priceAsc':
-      skus = [...skus].sort((a, b) => a.unitPrice - b.unitPrice)
-      break
-    case 'priceDesc':
-      skus = [...skus].sort((a, b) => b.unitPrice - a.unitPrice)
-      break
-    case 'nameAsc':
-      skus = [...skus].sort((a, b) =>
-        a.productName.localeCompare(b.productName, 'ko') || (a.displayOption || '').localeCompare((b.displayOption || ''), 'ko'),
-      )
-      break
-    default:
-      // BE 응답 순서 그대로 (vendorName → productName → SKU id asc)
-      break
-  }
-
-  // 2) masterKey 기준으로 그룹 헤더 + SKU 행을 다시 묶어서 반환 (정렬은 그룹 안 SKU 순서 유지)
-  const skusByMaster = new Map()
-  for (const s of skus) {
-    if (!skusByMaster.has(s.masterKey)) skusByMaster.set(s.masterKey, [])
-    skusByMaster.get(s.masterKey).push(s)
-  }
-  const headerByMaster = new Map()
-  for (const r of all) {
-    if (r.type === 'header') headerByMaster.set(r.masterKey, r)
-  }
-
-  const baseResult = []
-  for (const [masterKey, skuList] of skusByMaster) {
-    const header = headerByMaster.get(masterKey)
-    if (!header) continue
-    baseResult.push(header)
-    if (!collapsed.value[masterKey]) {
-      baseResult.push(...skuList)
-    }
-  }
-
-  // 품목 중심 표시 — vendor sticky 그룹 행 제거. 공급처는 마스터 제품 헤더의 칩으로 표시.
-  return baseResult
-})
-
-// 매칭 SKU 수 (헤더 제외)
-const matchedSkuCount = computed(() => filteredRows.value.filter((r) => r.type === 'sku').length)
-
-// 카탈로그 부족 SKU 카운트 — SKU 단위
-const shortageCount = computed(() => {
-  if (!selectedWarehouseCode.value) return 0
-  const skuCodes = catalogSkuRows.value
-    .filter((r) => r.type === 'sku')
-    .map((r) => r.skuCode)
-  return stockStore.getSkuShortageCount(selectedWarehouseCode.value, skuCodes)
-})
-
-// SKU 행 [권장 N] 클릭 → 그 SKU 의 행 수량 input 에 set + 포커스
-function applySuggestedToSku(row) {
-  const suggested = rowSuggested(row.skuCode)
-  if (suggested <= 0) return
-  rowQuantities.value[row.skuCode] = suggested
-  nextTick(() => {
-    const el = document.querySelector(`[data-sku-code="${row.skuCode}"] input[type="number"]`)
-    if (el) {
-      el.focus()
-      el.select?.()
-    }
-  })
-}
-
-// 그룹 안 SKU 수 (펼침/접힘과 무관, 검색 매칭 후) — 헤더에 표시할 카운트용
-function groupMatchedCount(masterKey) {
-  return filteredRows.value.filter((r) => r.type === 'sku' && r.masterKey === masterKey).length
-}
-
-// vendorOptions — 카탈로그 안 unique vendor 만 (드롭다운 출처)
-const vendorOptions = computed(() => {
-  const seen = new Map()
-  for (const r of catalogSkuRows.value) {
-    if (r.type === 'header' && !seen.has(r.vendorCode)) {
-      seen.set(r.vendorCode, { id: r.vendorCode, code: r.vendorCode, name: r.vendorName })
-    }
-  }
-  return [...seen.values()].sort((a, b) => a.name.localeCompare(b.name, 'ko'))
-})
-
-function rowKey(row) {
-  if (row.type === 'vendor') return `v-${row.vendorCode}`
-  if (row.type === 'header') return `h-${row.masterKey}`
-  return `s-${row.skuCode}`
-}
-
-function priceRangeText(header) {
-  if (header.minSkuUnitPrice === header.maxSkuUnitPrice) {
-    return `₩${header.minSkuUnitPrice.toLocaleString()}`
-  }
-  return `₩${header.minSkuUnitPrice.toLocaleString()}~${header.maxSkuUnitPrice.toLocaleString()}`
-}
-
-function toggleGroup(masterKey) {
-  collapsed.value[masterKey] = !collapsed.value[masterKey]
-}
-
-function expandAll() {
-  collapsed.value = {}
-}
-
-function collapseAll() {
-  const next = {}
-  for (const r of catalogSkuRows.value) {
-    if (r.type === 'header') next[r.masterKey] = true
-  }
-  collapsed.value = next
-}
+// 카탈로그 관련 computed/헬퍼(filteredRows/matchedSkuCount/shortageCount/vendorOptions/
+// applySuggestedToSku/groupMatchedCount/priceRangeText/rowKey/toggleGroup/expandAll/collapseAll)
+// 는 모두 PurchaseOrderCatalog child 안으로 이동. 부모는 cart 도메인 책임만.
 
 const cartTotal = computed(() =>
   cart.value.reduce((sum, item) => sum + item.unitPrice * item.quantity, 0),
@@ -806,293 +604,22 @@ watch(vendorFilter, () => {
 
       <!-- 본문: 좌(카탈로그) + 우(장바구니) — viewport 높이 기준 자체 스크롤 -->
       <section class="flex min-h-0 flex-1 flex-col gap-4 xl:flex-row">
-        <!-- ── 좌측: 카탈로그 ── -->
-        <div
-          class="flex min-w-0 flex-1 flex-col overflow-hidden border border-gray-300 bg-white shadow-sm"
-        >
-          <!-- 필터 헤더 -->
-          <div
-            class="flex flex-wrap items-center gap-2 border-b border-gray-200 bg-gray-50 p-2 pr-[15px]"
-          >
-            <label class="relative block">
-              <SearchIcon
-                :size="14"
-                class="absolute left-2.5 top-1/2 -translate-y-1/2 text-gray-400"
-              />
-              <input
-                ref="searchInputRef"
-                v-model="keyword"
-                type="text"
-                placeholder='제품명/SKU코드/옵션값 검색  ("/" 로 포커스)'
-                class="w-72 border border-gray-300 bg-white py-1.5 pl-8 pr-3 text-xs outline-none focus:border-[#004D3C]"
-              />
-            </label>
-            <select
-              v-model="vendorFilter"
-              :disabled="isEditMode"
-              class="border border-gray-300 bg-white px-3 py-1.5 text-xs outline-none focus:border-[#004D3C] disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500"
-            >
-              <option value="all">전체 공급처</option>
-              <option v-for="v in vendorOptions" :key="v.code" :value="v.code">
-                {{ v.name }}
-              </option>
-            </select>
-            <select
-              v-model="sortBy"
-              class="border border-gray-300 bg-white px-3 py-1.5 text-xs outline-none focus:border-[#004D3C]"
-            >
-              <option value="default">정렬: 기본</option>
-              <option value="shortage">부족 SKU 우선</option>
-              <option value="priceAsc">단가 ↑</option>
-              <option value="priceDesc">단가 ↓</option>
-              <option value="nameAsc">제품명 ㄱ-ㄴ</option>
-            </select>
-            <button
-              type="button"
-              class="border border-gray-300 bg-white px-2 py-1.5 text-[11px] font-bold text-gray-600 hover:bg-gray-50"
-              @click="expandAll"
-            >
-              전체 펼치기
-            </button>
-            <button
-              type="button"
-              class="border border-gray-300 bg-white px-2 py-1.5 text-[11px] font-bold text-gray-600 hover:bg-gray-50"
-              @click="collapseAll"
-            >
-              전체 접기
-            </button>
-            <button
-              type="button"
-              class="border px-3 py-1.5 text-[11px] font-black transition-colors disabled:cursor-not-allowed disabled:opacity-50"
-              :class="
-                shortageOnly
-                  ? 'border-red-400 bg-red-50 text-red-700'
-                  : shortageCount > 0
-                    ? 'border-red-300 bg-white text-red-600 hover:bg-red-50'
-                    : 'border-gray-300 bg-white text-gray-600 hover:bg-gray-50'
-              "
-              :disabled="!selectedWarehouseCode || shortageCount === 0"
-              :title="!selectedWarehouseCode ? '먼저 창고를 선택하세요' : (shortageCount === 0 ? '재고 부족 품목 없음' : '가용재고가 안전재고 1.5배 미만인 마스터만 표시')"
-              @click="shortageOnly = !shortageOnly"
-            >
-              {{ shortageOnly ? `✓ 부족만 (${shortageCount})` : (selectedWarehouseCode && shortageCount > 0 ? `부족만 보기 (${shortageCount})` : '부족만 보기') }}
-            </button>
-            <span class="ml-auto text-[11px] font-bold text-gray-500">
-              SKU {{ matchedSkuCount }}건
-            </span>
-          </div>
-
-          <!-- Facet 필터 칩 (옵션 axis 별) -->
-          <div
-            v-if="catalogFacets.length > 0"
-            class="flex flex-wrap items-center gap-2 border-b border-gray-200 bg-white px-2 py-2 pr-[15px]"
-          >
-            <div v-for="facet in catalogFacets" :key="facet.name" class="flex items-center gap-1">
-              <span class="text-[10px] font-black uppercase tracking-wider text-gray-400">
-                {{ facet.name }}
-              </span>
-              <button
-                v-for="value in facet.values"
-                :key="`${facet.name}-${value}`"
-                type="button"
-                class="border px-2 py-0.5 text-[10px] font-bold transition-colors"
-                :class="isFacetActive(facet.name, value)
-                  ? 'border-[#004D3C] bg-[#004D3C] text-white'
-                  : 'border-gray-300 bg-white text-gray-600 hover:bg-gray-50'"
-                @click="toggleFacet(facet.name, value)"
-              >
-                {{ value }}
-              </button>
-            </div>
-            <button
-              v-if="Object.keys(activeFacetFilters).length > 0"
-              type="button"
-              class="ml-auto text-[10px] font-bold text-gray-500 hover:text-gray-700 underline"
-              @click="clearFacets"
-            >
-              필터 초기화
-            </button>
-          </div>
-
-          <!-- 창고 미선택 안내 -->
-          <div
-            v-if="!selectedWarehouseCode"
-            class="border-b border-amber-200 bg-amber-50 px-3 py-2 pr-[15px] text-[11px] font-bold text-amber-700"
-          >
-            입고 창고를 먼저 선택해주세요. 창고가 정해져야 발주서를 만들 수 있습니다.
-          </div>
-
-          <!-- 카탈로그 테이블 — 카드 내부 자체 스크롤. 그룹 헤더 sticky. -->
-          <div class="min-h-0 flex-1 overflow-auto">
-            <table class="w-full table-fixed border-collapse text-xs">
-              <thead class="bg-gray-100 text-xs text-gray-500">
-                <tr>
-                  <th class="w-8 px-1 py-2 text-center font-black"></th>
-                  <th class="w-44 px-2 py-2 text-left font-black">옵션</th>
-                  <th class="w-28 px-2 py-2 text-left font-black">SKU 코드</th>
-                  <th class="w-20 px-2 py-2 text-right font-black">단가</th>
-                  <th class="w-12 px-2 py-2 text-right font-black" title="실재고 + 입고예정 - 출고예정">가용</th>
-                  <th class="w-12 px-2 py-2 text-right font-black" title="실재고 (현재 보유)">실</th>
-                  <th class="w-12 px-2 py-2 text-right font-black" title="안전재고 (이 밑으로 떨어지면 안 됨)">안전</th>
-                  <th class="w-14 px-2 py-2 text-right font-black" title="안전재고 × 1.5 까지 채우는 권장 발주 수량">권장</th>
-                  <th class="w-14 px-1 py-2 text-center font-black">상태</th>
-                  <th class="w-14 px-1 py-2 text-center font-black">수량</th>
-                  <th class="w-12 px-2 py-2 text-center font-black"></th>
-                </tr>
-              </thead>
-              <tbody :class="!selectedWarehouseCode ? 'pointer-events-none opacity-50' : ''">
-                <template v-for="row in filteredRows" :key="rowKey(row)">
-                  <!-- 제품 헤더 — 미니멀 실무 ERP 스타일. 텍스트 위계로만 정보 구분, 강한 시각요소 X -->
-                  <tr
-                    v-if="row.type === 'header'"
-                    class="bg-gray-50 hover:bg-gray-100 border-t border-gray-200 cursor-pointer select-none"
-                    @click="toggleGroup(row.masterKey)"
-                  >
-                    <td class="px-1 py-2.5 text-center">
-                      <input
-                        v-if="!collapsed[row.masterKey]"
-                        type="checkbox"
-                        :checked="isGroupAllSelected(row.masterKey)"
-                        :indeterminate.prop="isGroupSomeSelected(row.masterKey)"
-                        class="cursor-pointer"
-                        @click.stop
-                        @change="toggleGroupSelected(row.masterKey, $event)"
-                      />
-                    </td>
-                    <td colspan="10" class="px-3 py-2.5">
-                      <div class="flex items-center gap-3 flex-wrap">
-                        <span class="text-[11px] font-black text-gray-500 shrink-0">
-                          {{ collapsed[row.masterKey] ? '▸' : '▾' }}
-                        </span>
-                        <span class="text-xs font-black text-gray-900 truncate">{{ row.productName }}</span>
-                        <span class="font-mono text-[10px] font-bold text-gray-400 shrink-0">{{ row.productCode }}</span>
-                        <span class="ml-auto text-[10px] font-bold text-gray-400 shrink-0">
-                          공급처
-                          <span class="ml-1 font-black text-gray-700">{{ row.vendorName }}</span>
-                        </span>
-                      </div>
-                    </td>
-                  </tr>
-                  <!-- SKU 행 -->
-                  <tr
-                    v-else
-                    class="border-b border-gray-100 hover:bg-[#F4FAF8]"
-                    :class="selectedSkus.has(row.skuCode) ? 'bg-emerald-50' : ''"
-                    :data-sku-code="row.skuCode"
-                  >
-                    <td class="px-1 py-2 text-center align-middle">
-                      <input
-                        type="checkbox"
-                        :checked="selectedSkus.has(row.skuCode)"
-                        class="cursor-pointer"
-                        @change="toggleSkuSelected(row.skuCode)"
-                      />
-                    </td>
-                    <td class="px-2 py-2 align-middle">
-                      <div class="text-xs font-bold text-gray-800">{{ row.displayOption }}</div>
-                    </td>
-                    <td class="px-2 py-2 text-[11px] text-gray-500 align-middle">{{ row.skuCode }}</td>
-                    <td class="px-2 py-2 text-right font-bold text-[#004D3C] align-middle">
-                      ₩{{ row.unitPrice.toLocaleString() }}
-                    </td>
-                    <!-- 가용재고 -->
-                    <td class="px-2 py-2 text-right font-bold align-middle" :class="stockLevelClass(rowStockLevel(row.skuCode))">
-                      <template v-if="rowStock(row.skuCode)">{{ rowStock(row.skuCode).available }}</template>
-                      <span v-else class="text-gray-300">—</span>
-                    </td>
-                    <!-- 실재고 -->
-                    <td class="px-2 py-2 text-right font-bold text-gray-500 align-middle">
-                      <template v-if="rowStock(row.skuCode)">{{ rowStock(row.skuCode).onHand }}</template>
-                      <span v-else class="text-gray-300">—</span>
-                    </td>
-                    <!-- 안전재고 -->
-                    <td class="px-2 py-2 text-right font-bold text-gray-500 align-middle">
-                      <template v-if="rowStock(row.skuCode)">{{ rowStock(row.skuCode).safetyStock }}</template>
-                      <span v-else class="text-gray-300">—</span>
-                    </td>
-                    <!-- 권장 발주 -->
-                    <td class="px-2 py-2 text-right align-middle">
-                      <template v-if="rowStock(row.skuCode)">
-                        <button
-                          v-if="rowSuggested(row.skuCode) > 0"
-                          type="button"
-                          class="border border-red-300 bg-red-50 px-2 py-0.5 text-[10px] font-black text-red-700 hover:bg-red-100"
-                          :title="`권장 발주 ${rowSuggested(row.skuCode)}개를 수량 입력란에 채웁니다`"
-                          @click="applySuggestedToSku(row)"
-                        >
-                          {{ rowSuggested(row.skuCode) }}
-                        </button>
-                        <span v-else class="text-gray-300">—</span>
-                      </template>
-                      <span v-else class="text-gray-300">—</span>
-                    </td>
-                    <!-- 상태 칩 -->
-                    <td class="px-1 py-2 text-center align-middle">
-                      <template v-if="statusChipForSku(row.skuCode)">
-                        <span
-                          class="inline-flex min-w-9 justify-center px-1.5 py-0.5 text-[10px] font-black"
-                          :class="statusChipForSku(row.skuCode).class"
-                        >
-                          {{ statusChipForSku(row.skuCode).label }}
-                        </span>
-                      </template>
-                      <span v-else class="text-gray-300">—</span>
-                    </td>
-                    <td class="px-1 py-2 align-middle">
-                      <input
-                        type="number"
-                        min="0"
-                        :placeholder="'0'"
-                        class="w-full border border-gray-300 px-1 py-1 text-center text-xs outline-none focus:border-[#004D3C]"
-                        :value="rowQuantities[row.skuCode] ?? ''"
-                        @input="rowQuantities[row.skuCode] = Number($event.target.value) || 0"
-                        @keydown.enter.exact="addSkuToCart(row)"
-                        @keydown.enter.shift.prevent="addGroupToCart(row.masterKey)"
-                      />
-                    </td>
-                    <td class="px-2 py-2 text-center align-middle">
-                      <div class="inline-flex items-center gap-1">
-                        <button
-                          type="button"
-                          class="inline-flex items-center justify-center border border-[#004D3C] bg-white p-1 text-[#004D3C] hover:bg-[#E6F2F0] disabled:cursor-not-allowed disabled:opacity-40"
-                          :disabled="!(Number(rowQuantities[row.skuCode]) > 0)"
-                          title="장바구니 담기 (Enter)"
-                          @click="addSkuToCart(row)"
-                        >
-                          <PlusIcon :size="12" />
-                        </button>
-                        <button
-                          v-if="isInCart(row.skuCode)"
-                          type="button"
-                          class="text-[10px] font-bold text-[#004D3C] hover:underline"
-                          title="장바구니에서 보기"
-                          @click="scrollToCartSku(row.skuCode)"
-                        >
-                          ●
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
-                </template>
-                <tr v-if="!catalogLoading && catalogSkuRows.length === 0">
-                  <td colspan="11" class="px-3 py-8 text-center text-xs text-gray-400">
-                    노출 가능한 계약 제품이 없습니다.
-                  </td>
-                </tr>
-                <tr v-else-if="!catalogLoading && filteredRows.length === 0">
-                  <td colspan="11" class="px-3 py-8 text-center text-xs text-gray-400">
-                    검색 결과가 없습니다.
-                  </td>
-                </tr>
-                <tr v-if="catalogLoading">
-                  <td colspan="11" class="px-3 py-8 text-center text-xs text-gray-400">
-                    카탈로그를 불러오는 중...
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div>
+        <PurchaseOrderCatalog
+          ref="catalogRef"
+          v-model:keyword="keyword"
+          v-model:vendor-filter="vendorFilter"
+          v-model:sort-by="sortBy"
+          v-model:shortage-only="shortageOnly"
+          v-model:selected-skus="selectedSkus"
+          v-model:collapsed="collapsed"
+          v-model:row-quantities="rowQuantities"
+          :selected-warehouse-code="selectedWarehouseCode"
+          :is-edit-mode="isEditMode"
+          :cart="cart"
+          @add-sku-to-cart="addSkuToCart"
+          @add-group-to-cart="addGroupToCart"
+          @scroll-to-cart-sku="scrollToCartSku"
+        />
 
         <!-- ── 우측: 장바구니 ── -->
         <aside

--- a/src/views/hq/purchase-order/HqPurchaseOrderCreateView.vue
+++ b/src/views/hq/purchase-order/HqPurchaseOrderCreateView.vue
@@ -6,7 +6,6 @@ import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
 import { usePurchaseOrderStore } from '@/stores/purchaseOrder.js'
 import {
-  AlertTriangleIcon,
   ArrowLeftIcon,
   PlusIcon,
   SearchIcon,
@@ -14,7 +13,9 @@ import {
   TrashIcon,
 } from '@/components/hq/purchase-order/icons.js'
 import PurchaseOrderBulkQtyModal from '@/components/hq/purchase-order/PurchaseOrderBulkQtyModal.vue'
+import PurchaseOrderConfirmModal from '@/components/hq/purchase-order/PurchaseOrderConfirmModal.vue'
 import PurchaseOrderFloatingBar from '@/components/hq/purchase-order/PurchaseOrderFloatingBar.vue'
+import PurchaseOrderSubmitConfirmModal from '@/components/hq/purchase-order/PurchaseOrderSubmitConfirmModal.vue'
 import { useToast } from '@/composables/useToast.js'
 import { useFacets } from '@/composables/hq/purchaseOrder/useFacets.js'
 import { usePurchaseOrderStockSim } from '@/composables/hq/purchaseOrder/useStockSim.js'
@@ -1222,173 +1223,61 @@ watch(vendorFilter, () => {
       </section>
     </div>
 
-    <!-- ───────── 모달: 창고 변경 confirm (비파괴, signature) ───────── -->
-    <div
-      v-if="showWarehouseChangeConfirm"
-      class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
-      @click.self="cancelWarehouseChange"
+    <PurchaseOrderConfirmModal
+      :open="showWarehouseChangeConfirm"
+      variant="signature"
+      title="입고 창고 변경"
+      confirm-label="변경"
+      @cancel="cancelWarehouseChange"
+      @confirm="confirmWarehouseChange"
     >
-      <div class="w-full max-w-sm overflow-hidden bg-white shadow-xl">
-        <div class="bg-[#004D3C] px-5 py-3 text-white">
-          <h2 class="text-sm font-black">입고 창고 변경</h2>
-        </div>
-        <div class="p-5 text-xs text-gray-700">
-          <p>
-            장바구니 <strong>{{ cart.length }}건</strong>이 초기화됩니다. 입고 창고를
-            <strong>{{ pendingWarehouseName }}</strong>으로 변경할까요?
-          </p>
-        </div>
-        <div class="flex items-center justify-end gap-2 border-t border-gray-200 bg-gray-50 px-5 py-3">
-          <button
-            type="button"
-            class="border border-gray-300 bg-white px-4 py-2 text-xs font-black text-gray-700 hover:bg-gray-100"
-            @click="cancelWarehouseChange"
-          >
-            취소
-          </button>
-          <button
-            type="button"
-            class="border border-[#004D3C] bg-[#004D3C] px-4 py-2 text-xs font-black text-white hover:bg-[#1f4b3a]"
-            @click="confirmWarehouseChange"
-          >
-            변경
-          </button>
-        </div>
-      </div>
-    </div>
+      <p>
+        장바구니 <strong>{{ cart.length }}건</strong>이 초기화됩니다. 입고 창고를
+        <strong>{{ pendingWarehouseName }}</strong>으로 변경할까요?
+      </p>
+    </PurchaseOrderConfirmModal>
 
-    <!-- ───────── 모달: 공급처 변경 confirm (amber, 주의) ───────── -->
-    <div
-      v-if="showVendorSwitchConfirm"
-      class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
-      @click.self="cancelVendorSwitch"
+    <PurchaseOrderConfirmModal
+      :open="showVendorSwitchConfirm"
+      variant="amber"
+      title="공급처 변경"
+      confirm-label="새로 시작"
+      @cancel="cancelVendorSwitch"
+      @confirm="confirmVendorSwitch"
     >
-      <div class="w-full max-w-sm overflow-hidden bg-white shadow-xl">
-        <div class="flex items-center gap-2 bg-amber-600 px-5 py-3 text-white">
-          <AlertTriangleIcon :size="14" />
-          <h2 class="text-sm font-black">공급처 변경</h2>
-        </div>
-        <div class="p-5 text-xs text-gray-700">
-          <p>
-            장바구니의 <strong>{{ currentCartVendorName }}</strong> 품목
-            <strong>{{ cart.length }}건</strong>이 초기화됩니다.
-            <strong>{{ pendingNewVendorName }}</strong> 공급처로 새로 시작할까요?
-          </p>
-          <p class="mt-2 text-[11px] text-gray-500">
-            한 발주서에는 한 공급처 품목만 담을 수 있습니다.
-          </p>
-        </div>
-        <div class="flex items-center justify-end gap-2 border-t border-gray-200 bg-gray-50 px-5 py-3">
-          <button
-            type="button"
-            class="border border-gray-300 bg-white px-4 py-2 text-xs font-black text-gray-700 hover:bg-gray-100"
-            @click="cancelVendorSwitch"
-          >
-            취소
-          </button>
-          <button
-            type="button"
-            class="border border-amber-600 bg-amber-600 px-4 py-2 text-xs font-black text-white hover:bg-amber-500"
-            @click="confirmVendorSwitch"
-          >
-            새로 시작
-          </button>
-        </div>
-      </div>
-    </div>
+      <p>
+        장바구니의 <strong>{{ currentCartVendorName }}</strong> 품목
+        <strong>{{ cart.length }}건</strong>이 초기화됩니다.
+        <strong>{{ pendingNewVendorName }}</strong> 공급처로 새로 시작할까요?
+      </p>
+      <p class="mt-2 text-[11px] text-gray-500">
+        한 발주서에는 한 공급처 품목만 담을 수 있습니다.
+      </p>
+    </PurchaseOrderConfirmModal>
 
-    <!-- ───────── 모달: 장바구니 비우기 confirm (파괴, red) ───────── -->
-    <div
-      v-if="showClearCartConfirm"
-      class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
-      @click.self="cancelClearCart"
+    <PurchaseOrderConfirmModal
+      :open="showClearCartConfirm"
+      variant="red"
+      title="장바구니 비우기"
+      confirm-label="삭제"
+      @cancel="cancelClearCart"
+      @confirm="confirmClearCart"
     >
-      <div class="w-full max-w-sm overflow-hidden bg-white shadow-xl">
-        <div class="bg-red-700 px-5 py-3 text-white">
-          <h2 class="text-sm font-black">장바구니 비우기</h2>
-        </div>
-        <div class="p-5 text-xs text-gray-700">
-          <p>
-            장바구니 <strong>{{ cart.length }}건</strong>이 모두 삭제됩니다. 계속할까요?
-          </p>
-        </div>
-        <div class="flex items-center justify-end gap-2 border-t border-gray-200 bg-gray-50 px-5 py-3">
-          <button
-            type="button"
-            class="border border-gray-300 bg-white px-4 py-2 text-xs font-black text-gray-700 hover:bg-gray-100"
-            @click="cancelClearCart"
-          >
-            취소
-          </button>
-          <button
-            type="button"
-            class="border border-red-700 bg-red-700 px-4 py-2 text-xs font-black text-white hover:bg-red-600"
-            @click="confirmClearCart"
-          >
-            삭제
-          </button>
-        </div>
-      </div>
-    </div>
+      <p>
+        장바구니 <strong>{{ cart.length }}건</strong>이 모두 삭제됩니다. 계속할까요?
+      </p>
+    </PurchaseOrderConfirmModal>
 
-    <!-- ───────── 모달: 발주 요청/수정 최종 확인 (signature, 비파괴) ───────── -->
-    <div
-      v-if="showSubmitConfirm"
-      class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
-      @click.self="cancelSubmitOrder"
-    >
-      <div class="w-full max-w-sm overflow-hidden bg-white shadow-xl">
-        <div class="bg-[#004D3C] px-5 py-3 text-white">
-          <h2 class="text-sm font-black">{{ isEditMode ? '발주 수정 확인' : '발주 요청 확인' }}</h2>
-        </div>
-        <div class="space-y-2 p-5 text-xs text-gray-700">
-          <p class="text-[10px] font-bold uppercase tracking-wider text-gray-400">발주서 요약</p>
-          <dl class="space-y-1.5">
-            <div class="flex justify-between gap-2">
-              <dt class="text-gray-500">입고 창고</dt>
-              <dd class="font-bold text-gray-800">{{ selectedWarehouseName }}</dd>
-            </div>
-            <div class="flex justify-between gap-2">
-              <dt class="text-gray-500">공급처</dt>
-              <dd class="font-bold text-gray-800">{{ currentCartVendorName }}</dd>
-            </div>
-            <div class="flex justify-between gap-2">
-              <dt class="text-gray-500">품목</dt>
-              <dd class="font-bold text-gray-800">{{ cart.length }}건</dd>
-            </div>
-            <div class="flex justify-between gap-2">
-              <dt class="text-gray-500">총액</dt>
-              <dd class="font-black text-[#004D3C]">₩{{ cartTotal.toLocaleString() }}</dd>
-            </div>
-          </dl>
-          <p class="pt-2 text-[11px] leading-relaxed text-gray-500">
-            <template v-if="isEditMode">
-              이 내용으로 발주를 수정합니다. 공급처 승인 전까지만 가능합니다.
-            </template>
-            <template v-else>
-              이 내용으로 공급처에 발주 요청합니다.
-              요청 후 공급처 응답 받기 전까지 [취소] 가능합니다.
-            </template>
-          </p>
-        </div>
-        <div class="flex items-center justify-end gap-2 border-t border-gray-200 bg-gray-50 px-5 py-3">
-          <button
-            type="button"
-            class="border border-gray-300 bg-white px-4 py-2 text-xs font-black text-gray-700 hover:bg-gray-100"
-            @click="cancelSubmitOrder"
-          >
-            취소
-          </button>
-          <button
-            type="button"
-            class="border border-[#004D3C] bg-[#004D3C] px-4 py-2 text-xs font-black text-white hover:bg-[#1f4b3a]"
-            @click="confirmSubmitOrder"
-          >
-            {{ isEditMode ? '수정 저장' : '발주 요청' }}
-          </button>
-        </div>
-      </div>
-    </div>
+    <PurchaseOrderSubmitConfirmModal
+      :open="showSubmitConfirm"
+      :is-edit-mode="isEditMode"
+      :warehouse-name="selectedWarehouseName"
+      :vendor-name="currentCartVendorName"
+      :item-count="cart.length"
+      :total-amount="cartTotal"
+      @cancel="cancelSubmitOrder"
+      @confirm="confirmSubmitOrder"
+    />
 
     <PurchaseOrderFloatingBar
       :selected-count="selectedSkus.size"

--- a/src/views/hq/purchase-order/HqPurchaseOrderCreateView.vue
+++ b/src/views/hq/purchase-order/HqPurchaseOrderCreateView.vue
@@ -13,6 +13,8 @@ import {
   ShoppingCartIcon,
   TrashIcon,
 } from '@/components/hq/purchase-order/icons.js'
+import PurchaseOrderBulkQtyModal from '@/components/hq/purchase-order/PurchaseOrderBulkQtyModal.vue'
+import PurchaseOrderFloatingBar from '@/components/hq/purchase-order/PurchaseOrderFloatingBar.vue'
 import { useToast } from '@/composables/useToast.js'
 import { useFacets } from '@/composables/hq/purchaseOrder/useFacets.js'
 import { usePurchaseOrderStockSim } from '@/composables/hq/purchaseOrder/useStockSim.js'
@@ -91,9 +93,8 @@ const shortageOnly = ref(false)
 // 다중 선택: skuCode set
 const selectedSkus = ref(new Set())
 // activeFacetFilters / toggleFacet / ... 는 useFacets() composable 에서 제공.
-// 일괄 입력 모달
+// Bulk 수량 모달 — 입력값은 모달 컴포넌트 로컬 state (open/close 만 부모 관리)
 const showBulkQtyModal = ref(false)
-const bulkQtyInput = ref(0)
 // 검색창 ref (단축키용)
 const searchInputRef = ref(null)
 // cart 강조용 — [좌측에서 보기] / [장바구니에서 보기] 점프 시 잠시 highlight
@@ -176,20 +177,18 @@ function selectAllVisible() {
   selectedSkus.value = set
 }
 
-// 일괄 입력 모달
+// Bulk 수량 모달 트리거 (Floating bar 에서 호출).
 function openBulkQtyModal() {
   if (selectedSkus.value.size === 0) return
-  bulkQtyInput.value = 0
   showBulkQtyModal.value = true
 }
 
 function closeBulkQtyModal() {
   showBulkQtyModal.value = false
-  bulkQtyInput.value = 0
 }
 
-function applyBulkQty() {
-  const qty = Number(bulkQtyInput.value) || 0
+// 모달의 [적용] emit 핸들러 — vendor 검증 + cart push + draft 저장 + 선택 reset 까지.
+function handleBulkApply(qty) {
   if (qty <= 0) {
     triggerToast('수량을 입력하세요.')
     return
@@ -1391,78 +1390,18 @@ watch(vendorFilter, () => {
       </div>
     </div>
 
-    <!-- ───────── Floating Action Bar (Power 모드: 다중 선택 시 노출) ───────── -->
-    <Transition
-      enter-active-class="transition-all duration-200"
-      leave-active-class="transition-all duration-200"
-      enter-from-class="opacity-0 translate-y-2"
-      leave-to-class="opacity-0 translate-y-2"
-    >
-      <div
-        v-if="selectedSkus.size > 0"
-        class="fixed bottom-6 left-1/2 z-40 -translate-x-1/2 transform"
-      >
-        <div class="flex items-center gap-3 border border-[#004D3C] bg-[#004D3C] px-4 py-2.5 text-white shadow-xl">
-          <span class="text-xs font-black">{{ selectedSkus.size }}개 SKU 선택됨</span>
-          <button
-            type="button"
-            class="border border-white bg-white px-3 py-1 text-[11px] font-black text-[#004D3C] hover:bg-gray-100"
-            @click="openBulkQtyModal"
-          >
-            수량 일괄 입력
-          </button>
-          <button
-            type="button"
-            class="text-[11px] font-bold text-white/80 hover:text-white underline"
-            @click="clearSelection"
-          >
-            선택 해제
-          </button>
-        </div>
-      </div>
-    </Transition>
+    <PurchaseOrderFloatingBar
+      :selected-count="selectedSkus.size"
+      @open-bulk-qty="openBulkQtyModal"
+      @clear-selection="clearSelection"
+    />
 
-    <!-- ───────── 모달: 수량 일괄 입력 ───────── -->
-    <div
-      v-if="showBulkQtyModal"
-      class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
-      @click.self="closeBulkQtyModal"
-    >
-      <div class="w-full max-w-sm overflow-hidden bg-white shadow-xl">
-        <div class="bg-[#004D3C] px-5 py-3 text-white">
-          <h2 class="text-sm font-black">수량 일괄 입력</h2>
-        </div>
-        <div class="p-5 text-xs text-gray-700">
-          <p class="mb-3">
-            선택한 <strong>{{ selectedSkus.size }}개 SKU</strong> 모두에 동일한 수량을 적용합니다.
-          </p>
-          <input
-            v-model.number="bulkQtyInput"
-            type="number"
-            min="1"
-            placeholder="수량"
-            class="w-full border border-gray-300 px-3 py-2 text-center text-sm outline-none focus:border-[#004D3C]"
-            @keydown.enter="applyBulkQty"
-          />
-        </div>
-        <div class="flex items-center justify-end gap-2 border-t border-gray-200 bg-gray-50 px-5 py-3">
-          <button
-            type="button"
-            class="border border-gray-300 bg-white px-4 py-2 text-xs font-black text-gray-700 hover:bg-gray-100"
-            @click="closeBulkQtyModal"
-          >
-            취소
-          </button>
-          <button
-            type="button"
-            class="border border-[#004D3C] bg-[#004D3C] px-4 py-2 text-xs font-black text-white hover:bg-[#1f4b3a]"
-            @click="applyBulkQty"
-          >
-            적용
-          </button>
-        </div>
-      </div>
-    </div>
+    <PurchaseOrderBulkQtyModal
+      :open="showBulkQtyModal"
+      :selected-count="selectedSkus.size"
+      @close="closeBulkQtyModal"
+      @apply="handleBulkApply"
+    />
 
     <!-- ───────── 토스트 ───────── -->
     <Transition

--- a/src/views/hq/purchase-order/HqPurchaseOrderCreateView.vue
+++ b/src/views/hq/purchase-order/HqPurchaseOrderCreateView.vue
@@ -5,12 +5,9 @@ import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
 import { usePurchaseOrderStore } from '@/stores/purchaseOrder.js'
-import {
-  ArrowLeftIcon,
-  ShoppingCartIcon,
-  TrashIcon,
-} from '@/components/hq/purchase-order/icons.js'
+import { ArrowLeftIcon } from '@/components/hq/purchase-order/icons.js'
 import PurchaseOrderBulkQtyModal from '@/components/hq/purchase-order/PurchaseOrderBulkQtyModal.vue'
+import PurchaseOrderCart from '@/components/hq/purchase-order/PurchaseOrderCart.vue'
 import PurchaseOrderCatalog from '@/components/hq/purchase-order/PurchaseOrderCatalog.vue'
 import PurchaseOrderConfirmModal from '@/components/hq/purchase-order/PurchaseOrderConfirmModal.vue'
 import PurchaseOrderFloatingBar from '@/components/hq/purchase-order/PurchaseOrderFloatingBar.vue'
@@ -621,132 +618,21 @@ watch(vendorFilter, () => {
           @scroll-to-cart-sku="scrollToCartSku"
         />
 
-        <!-- ── 우측: 장바구니 ── -->
-        <aside
-          class="flex w-full shrink-0 flex-col overflow-hidden border border-gray-300 bg-white shadow-sm xl:w-96"
-        >
-          <!-- 헤더 -->
-          <div
-            class="flex items-center justify-between bg-[#004D3C] px-4 py-3 text-white"
-          >
-            <h3
-              class="inline-flex items-center gap-2 text-[11px] font-black uppercase tracking-wider"
-            >
-              <ShoppingCartIcon :size="14" />
-              발주 요청서
-            </h3>
-            <span class="text-[10px] font-bold opacity-80">{{ cart.length }}건</span>
-          </div>
-
-          <!-- 공급처 표시 -->
-          <div
-            v-if="currentCartVendorName"
-            class="border-b border-gray-200 bg-[#E6F2F0] px-4 py-2 text-[10px] font-black uppercase tracking-wider text-[#004D3C]"
-          >
-            {{ currentCartVendorName }}
-          </div>
-
-          <!-- 본문 -->
-          <div class="flex-1 overflow-y-auto p-3">
-            <div v-if="cart.length === 0" class="py-10 text-center text-xs text-gray-400">
-              왼쪽 카탈로그에서 품목을 담아주세요
-            </div>
-            <ul v-else class="space-y-2">
-              <li
-                v-for="(item, idx) in cart"
-                :key="(item.skuCode || item.productCode) + '-' + idx"
-                class="border bg-white p-2 transition-colors"
-                :class="highlightedSkuCode === item.skuCode ? 'border-[#004D3C] ring-2 ring-[#004D3C]/30' : 'border-gray-200'"
-                :data-cart-sku-code="item.skuCode"
-              >
-                <div class="flex items-start justify-between gap-2">
-                  <div class="min-w-0 flex-1">
-                    <p class="text-xs font-black text-gray-800">{{ item.productName }}</p>
-                    <p v-if="item.displayOption" class="text-[10px] font-bold text-[#004D3C]">
-                      {{ item.displayOption }}
-                    </p>
-                    <p class="text-[10px] text-gray-400">
-                      {{ item.skuCode || item.productCode }} · ₩{{ item.unitPrice.toLocaleString() }}
-                    </p>
-                  </div>
-                  <button
-                    v-if="item.skuCode"
-                    type="button"
-                    class="text-[10px] font-bold text-gray-500 hover:text-[#004D3C] underline"
-                    title="좌측 카탈로그에서 보기"
-                    @click="scrollToCatalogSku(item.skuCode)"
-                  >
-                    ← 카탈로그
-                  </button>
-                  <button
-                    type="button"
-                    class="text-red-400 hover:text-red-600"
-                    aria-label="삭제"
-                    @click="removeItem(idx)"
-                  >
-                    <TrashIcon :size="12" />
-                  </button>
-                </div>
-                <div class="mt-2 flex items-center justify-between">
-                  <div class="flex items-center gap-1">
-                    <button
-                      type="button"
-                      class="flex h-6 w-6 items-center justify-center border border-gray-300 bg-white text-xs hover:bg-gray-50"
-                      @click="decreaseQty(idx)"
-                    >
-                      −
-                    </button>
-                    <input
-                      :value="item.quantity"
-                      type="number"
-                      min="1"
-                      class="w-12 border border-gray-300 py-0.5 text-center text-xs outline-none focus:border-[#004D3C]"
-                      @change="updateQty(idx, $event.target.value)"
-                    />
-                    <button
-                      type="button"
-                      class="flex h-6 w-6 items-center justify-center border border-gray-300 bg-white text-xs hover:bg-gray-50"
-                      @click="increaseQty(idx)"
-                    >
-                      +
-                    </button>
-                  </div>
-                  <span class="text-xs font-bold text-gray-700">
-                    ₩{{ (item.unitPrice * item.quantity).toLocaleString() }}
-                  </span>
-                </div>
-              </li>
-            </ul>
-          </div>
-
-          <!-- 푸터 -->
-          <div class="space-y-2 border-t border-gray-200 bg-gray-50 p-3">
-            <div class="flex items-center justify-between">
-              <span class="text-[11px] font-bold uppercase text-gray-500">총액</span>
-              <span class="text-sm font-black text-[#004D3C]">
-                ₩{{ cartTotal.toLocaleString() }}
-              </span>
-            </div>
-            <div class="grid grid-cols-2 gap-2">
-              <button
-                type="button"
-                class="border border-gray-400 bg-white px-2 py-2 text-[11px] font-black text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
-                :disabled="cart.length === 0"
-                @click="openClearCartConfirm"
-              >
-                장바구니 비우기
-              </button>
-              <button
-                type="button"
-                class="border border-[#004D3C] bg-[#004D3C] px-2 py-2 text-[11px] font-black text-white hover:bg-[#1f4b3a] disabled:cursor-not-allowed disabled:opacity-50"
-                :disabled="!canSubmit"
-                @click="openSubmitConfirm"
-              >
-                {{ isEditMode ? '수정 저장' : '발주 요청' }}
-              </button>
-            </div>
-          </div>
-        </aside>
+        <PurchaseOrderCart
+          :cart="cart"
+          :current-cart-vendor-name="currentCartVendorName"
+          :cart-total="cartTotal"
+          :can-submit="canSubmit"
+          :is-edit-mode="isEditMode"
+          :highlighted-sku-code="highlightedSkuCode"
+          @increase-qty="increaseQty"
+          @decrease-qty="decreaseQty"
+          @update-qty="updateQty"
+          @remove-item="removeItem"
+          @scroll-to-catalog-sku="scrollToCatalogSku"
+          @open-clear-cart-confirm="openClearCartConfirm"
+          @open-submit-confirm="openSubmitConfirm"
+        />
       </section>
     </div>
 


### PR DESCRIPTION
## 📌 요약
- HqPurchaseOrderCreateView 1482 → 723 (-51%, -759줄). 5개 child 컴포넌트로 책임 분리해 root CLAUDE.md 의 1000줄 금지 + 500줄 가이드 정정.

<br><br>

## 🎯 작업 내용
- `PurchaseOrderBulkQtyModal` + `PurchaseOrderFloatingBar` — Power 모드 다중 선택 일괄 수량 입력. open/selected-count props + close/apply emit (`78f7f47`)
- `PurchaseOrderConfirmModal` (variant=signature/amber/red) + `PurchaseOrderSubmitConfirmModal` — 4 confirm 모달 통합·도메인 특수 분리 (`77dea57`)
- `PurchaseOrderCatalog` (smart, 525줄) — 좌측 카탈로그 검색·필터·정렬·그룹·SKU 다중선택·재고 시뮬레이션. v-model 7개 + emit 3개 + defineExpose 2개. store/composable 직접 import (`70ad915`)
- `PurchaseOrderCart` (dumb) — 우측 발주서 헤더/공급처/SKU 라인/수량 +/-/푸터. cart props + 7개 emit (`dec532d`)
- 부모 view 는 cart 도메인 액션 + 모달 오케스트레이션 + 라우트 mode 분기 + AppLayout 레이아웃만 책임. useFacets / usePurchaseOrderStockSim composable 호출도 카탈로그 자식 안으로 이동.

<br><br>

## ✔️ 참고 사항
- 빌드 통과 (`vite build` 성공). 동작 보존 — props/emits 인터페이스만 변경, 도메인 로직 변경 0.
- 이번 사이클은 1차 (PR #415, composable + icons 추출) 의 후속. 누적 1625 → 723 (-902, -55%).
- 카탈로그 안 toggleSkuSelected/isGroupAllSelected/isGroupSomeSelected/toggleGroupSelected/applySuggestedToSku/expandAll/collapseAll/toggleGroup/rowKey/priceRangeText/groupMatchedCount/isInCart 함수와 catalogSkuRows/catalogFacets/catalogLoading/filteredRows/matchedSkuCount/shortageCount/vendorOptions computed 모두 자식이 자체 보유.
- 다음 사이클 (별 브랜치) 후보: `HqPurchaseOrderView.vue` 809줄, `WarehouseInboundView.vue` 784줄, `stores/purchaseOrder.js` 506줄.

<br><br>

## ✔️ 관련 이슈

- 

<br><br>
