### PR TITLE
refactor(purchase-order): HqPurchaseOrderView 책임 단위 컴포넌트 분리

### DIFF
--- a/src/components/hq/purchase-order/PurchaseOrderCancelModal.vue
+++ b/src/components/hq/purchase-order/PurchaseOrderCancelModal.vue
@@ -1,0 +1,77 @@
+<script setup>
+import { ref, watch } from 'vue'
+
+// 발주 취소 모달 — REQUESTED 단계만 취소 가능 (CEN-038).
+// cancelReason textarea 는 모달 로컬 state, 모달 닫을 때 초기화.
+const props = defineProps({
+  open: { type: Boolean, required: true },
+  order: { type: Object, default: null },
+})
+const emit = defineEmits(['cancel', 'confirm'])
+
+const reason = ref('')
+
+watch(
+  () => props.open,
+  (next) => {
+    if (next) reason.value = ''
+  },
+)
+
+function onConfirm() {
+  emit('confirm', reason.value)
+}
+</script>
+
+<template>
+  <div
+    v-if="open && order"
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+    @click.self="emit('cancel')"
+  >
+    <div class="w-full max-w-sm overflow-hidden bg-white shadow-xl">
+      <div class="bg-red-700 px-5 py-3 text-white">
+        <h2 class="text-sm font-black">발주 취소</h2>
+      </div>
+      <div class="space-y-3 p-5 text-xs text-gray-700">
+        <p class="text-[10px] font-bold uppercase tracking-wider text-gray-400">발주 정보</p>
+        <p>
+          <strong>{{ order.id }}</strong> ·
+          {{ order.vendorName }} ·
+          <span class="font-bold text-[#004D3C]">₩{{ order.totalPrice.toLocaleString() }}</span>
+        </p>
+        <label class="block">
+          <span class="text-[10px] font-bold uppercase tracking-wider text-gray-500">
+            취소 사유 (선택)
+          </span>
+          <textarea
+            v-model="reason"
+            rows="3"
+            maxlength="500"
+            placeholder="예: 공급처 단가 변경, 수량 잘못 입력 등"
+            class="mt-1 w-full resize-none border border-gray-300 px-2 py-1.5 text-xs outline-none focus:border-red-500"
+          />
+        </label>
+        <p class="text-[11px] leading-relaxed text-red-600">
+          취소 후에는 되돌릴 수 없습니다. 같은 발주가 필요하면 새 발주로 다시 만들어야 합니다.
+        </p>
+      </div>
+      <div class="flex items-center justify-end gap-2 border-t border-gray-200 bg-gray-50 px-5 py-3">
+        <button
+          type="button"
+          class="border border-gray-300 bg-white px-4 py-2 text-xs font-black text-gray-700 hover:bg-gray-100"
+          @click="emit('cancel')"
+        >
+          취소
+        </button>
+        <button
+          type="button"
+          class="border border-red-700 bg-red-700 px-4 py-2 text-xs font-black text-white hover:bg-red-600"
+          @click="onConfirm"
+        >
+          취소 확정
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/hq/purchase-order/PurchaseOrderDetailPanel.vue
+++ b/src/components/hq/purchase-order/PurchaseOrderDetailPanel.vue
@@ -1,0 +1,218 @@
+<script setup>
+// 본사 발주 목록 우측 상세 패널.
+// REQUESTED 단계만 본사 권한(수정/취소) 노출 — 그 외 자동 전환 단계는 안내문만.
+import {
+  EditIcon,
+  InfoIcon,
+  UserIcon,
+  XIcon,
+} from '@/components/hq/purchase-order/icons.js'
+import { useStatusFormat } from '@/composables/hq/purchaseOrder/useStatusFormat.js'
+
+defineProps({
+  order: { type: Object, required: true },
+})
+defineEmits(['close', 'edit', 'cancel'])
+
+const { statusClass, statusLabel, historyDotClass, historyTextClass, formatDate } = useStatusFormat()
+</script>
+
+<template>
+  <aside
+    class="flex w-full shrink-0 flex-col overflow-hidden border border-gray-300 bg-white shadow-sm xl:w-[420px]"
+  >
+    <!-- 상세 패널 헤더 -->
+    <div class="flex items-center justify-between bg-[#004D3C] px-4 py-3 text-white">
+      <h3 class="inline-flex items-center gap-2 text-[11px] font-black uppercase tracking-wider">
+        <InfoIcon :size="14" />
+        발주 상세
+      </h3>
+      <div class="flex items-center gap-3">
+        <span class="inline-flex px-2 py-1 text-[10px] font-black" :class="statusClass(order.status)">
+          {{ statusLabel(order.status) }}
+        </span>
+        <button
+          type="button"
+          class="p-1 text-white/80 hover:bg-white/10"
+          aria-label="닫기"
+          @click="$emit('close')"
+        >
+          <XIcon :size="16" />
+        </button>
+      </div>
+    </div>
+
+    <!-- 상세 내용 -->
+    <div class="flex flex-1 flex-col gap-4 overflow-y-auto p-4">
+      <!-- 기본 정보 카드 -->
+      <section class="space-y-3">
+        <div class="flex items-start justify-between gap-2">
+          <div>
+            <p class="text-[10px] font-bold uppercase text-gray-400">발주번호</p>
+            <p class="mt-0.5 text-sm font-black text-gray-900">{{ order.id }}</p>
+          </div>
+        </div>
+
+        <div class="grid grid-cols-2 gap-3">
+          <div>
+            <p class="text-[10px] font-bold uppercase text-gray-400">공급처</p>
+            <p class="mt-0.5 text-xs font-black text-gray-800">{{ order.vendorName }}</p>
+          </div>
+          <div>
+            <p class="text-[10px] font-bold uppercase text-gray-400">입고 창고</p>
+            <p class="mt-0.5 text-xs font-black text-gray-800">{{ order.warehouseName }}</p>
+          </div>
+          <div>
+            <p class="inline-flex items-center gap-1 text-[10px] font-bold uppercase text-gray-400">
+              <UserIcon :size="10" />
+              담당자
+            </p>
+            <p class="mt-0.5 text-xs font-black text-gray-800">{{ order.memberName }}</p>
+          </div>
+          <div>
+            <p class="text-[10px] font-bold uppercase text-gray-400">생성일시</p>
+            <p class="mt-0.5 text-xs font-bold text-gray-500">{{ formatDate(order.createdAt) }}</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- 품목 테이블 -->
+      <section>
+        <p class="mb-2 text-[10px] font-black uppercase text-gray-400">발주 품목</p>
+        <table class="w-full text-xs">
+          <thead class="bg-gray-100 text-[10px] uppercase text-gray-500">
+            <tr>
+              <th class="px-2 py-2 text-left font-black">제품명</th>
+              <th class="w-10 px-2 py-2 text-right font-black">수량</th>
+              <th class="w-20 px-2 py-2 text-right font-black">단가</th>
+              <th class="w-20 px-2 py-2 text-right font-black">소계</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-100">
+            <tr v-for="item in order.items" :key="item.skuCode || item.productId">
+              <td class="px-2 py-2 align-top">
+                <div class="font-bold text-gray-800">{{ item.productName }}</div>
+                <div v-if="item.displayOption" class="mt-0.5 text-[11px] font-bold text-[#004D3C]">
+                  {{ item.displayOption }}
+                </div>
+                <div v-if="item.skuCode" class="text-[10px] text-gray-400">{{ item.skuCode }}</div>
+              </td>
+              <td class="px-2 py-2 text-right font-bold text-gray-700 align-top">
+                {{ item.quantity }}
+              </td>
+              <td class="px-2 py-2 text-right text-gray-500 align-top">
+                ₩{{ item.unitPrice.toLocaleString() }}
+              </td>
+              <td class="px-2 py-2 text-right font-bold text-gray-700 align-top">
+                ₩{{ item.subtotal.toLocaleString() }}
+              </td>
+            </tr>
+          </tbody>
+          <tfoot class="border-t border-gray-300 bg-gray-50 font-black text-gray-900">
+            <tr>
+              <td colspan="3" class="px-2 py-2">총계</td>
+              <td class="px-2 py-2 text-right text-[#004D3C]">
+                ₩{{ order.totalPrice.toLocaleString() }}
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+      </section>
+
+      <!-- 진행 이력 타임라인 -->
+      <section v-if="order.statusHistory?.length">
+        <p class="mb-2 text-[10px] font-black uppercase text-gray-400">진행 이력</p>
+        <ol class="ml-2">
+          <li
+            v-for="(h, idx) in order.statusHistory"
+            :key="idx"
+            class="relative pb-3 pl-5 last:pb-0"
+          >
+            <span class="absolute left-0 top-1 block h-2.5 w-2.5" :class="historyDotClass(h.status)" />
+            <span
+              v-if="idx < order.statusHistory.length - 1"
+              class="absolute bottom-0 left-[4px] top-3.5 w-px bg-gray-300"
+            />
+            <p class="text-[11px] font-black" :class="historyTextClass(h.status)">
+              {{ statusLabel(h.status) }}
+            </p>
+            <p class="text-[10px] text-gray-500">{{ formatDate(h.at) }} · {{ h.byName }}</p>
+          </li>
+        </ol>
+      </section>
+    </div>
+
+    <!-- 액션/안내 (상태별 조건부) -->
+    <div class="space-y-4 px-4 pb-6 pt-2">
+      <template v-if="order.status === 'REQUESTED'">
+        <div class="grid grid-cols-2 gap-2">
+          <button
+            type="button"
+            class="inline-flex items-center justify-center gap-1 border border-gray-400 bg-white px-2 py-2.5 text-[11px] font-black text-gray-700 hover:bg-gray-50"
+            @click="$emit('edit')"
+          >
+            <EditIcon :size="12" />
+            수정
+          </button>
+          <button
+            type="button"
+            class="inline-flex items-center justify-center gap-1 border border-red-500 bg-red-50 px-2 py-2.5 text-[11px] font-black text-red-700 hover:bg-red-100"
+            @click="$emit('cancel')"
+          >
+            <XIcon :size="12" />
+            취소
+          </button>
+        </div>
+        <p class="pt-1 text-center text-[11px] leading-relaxed text-gray-500">
+          30분 후 시스템이 자동으로 공급처 승인을 처리합니다.<br />
+          그 전에 [수정] 또는 [취소] 가능합니다.
+        </p>
+      </template>
+
+      <template v-else-if="order.status === 'APPROVED'">
+        <p class="text-center text-xs leading-relaxed text-gray-500">
+          승인 완료 · 30분 후 시스템이 자동으로 배송 준비 처리합니다.
+        </p>
+      </template>
+
+      <template v-else-if="order.status === 'READY_TO_SHIP'">
+        <p class="text-center text-xs leading-relaxed text-gray-500">
+          배송 준비 중 · 30분 후 시스템이 자동으로 배송 시작 처리합니다.
+        </p>
+      </template>
+
+      <template v-else-if="order.status === 'IN_TRANSIT'">
+        <p class="text-center text-xs leading-relaxed text-gray-500">
+          배송 중 · 30분 후 시스템이 자동으로 배송 완료 처리합니다.
+        </p>
+      </template>
+
+      <template v-else-if="order.status === 'ARRIVED'">
+        <p class="text-center text-xs text-gray-500">배송 완료 · 창고 입고 확정 대기</p>
+      </template>
+
+      <template v-else>
+        <p
+          v-if="order.status === 'CANCELLED' && order.cancelReason"
+          class="border border-red-200 bg-red-50 px-3 py-2.5 text-[11px] font-bold leading-relaxed text-red-700"
+        >
+          취소 사유: {{ order.cancelReason }}
+        </p>
+        <p class="pt-2 text-center text-xs text-gray-400">
+          {{ order.status === 'COMPLETED' ? '종료된 발주입니다.' : '취소된 발주입니다.' }}
+        </p>
+      </template>
+    </div>
+
+    <!-- 하단: 닫기 버튼 -->
+    <div class="border-t border-gray-200">
+      <button
+        type="button"
+        class="w-full px-4 py-2.5 text-center text-[11px] font-bold text-gray-500 hover:bg-gray-50"
+        @click="$emit('close')"
+      >
+        닫기 (ESC)
+      </button>
+    </div>
+  </aside>
+</template>

--- a/src/components/hq/purchase-order/icons.js
+++ b/src/components/hq/purchase-order/icons.js
@@ -57,3 +57,41 @@ export const AlertTriangleIcon = IconBase([
   { tag: 'path', attrs: { d: 'M12 9v4' } },
   { tag: 'path', attrs: { d: 'M12 17h.01' } },
 ])
+
+export const XIcon = IconBase([
+  { tag: 'path', attrs: { d: 'M18 6 6 18' } },
+  { tag: 'path', attrs: { d: 'm6 6 12 12' } },
+])
+
+export const EditIcon = IconBase([
+  { tag: 'path', attrs: { d: 'M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7' } },
+  { tag: 'path', attrs: { d: 'M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5Z' } },
+])
+
+export const InfoIcon = IconBase([
+  { tag: 'circle', attrs: { cx: '12', cy: '12', r: '9' } },
+  { tag: 'path', attrs: { d: 'M12 10v6' } },
+  { tag: 'path', attrs: { d: 'M12 7h.01' } },
+])
+
+export const WarehouseIcon = IconBase([
+  { tag: 'path', attrs: { d: 'M3 10.5 12 4l9 6.5' } },
+  { tag: 'path', attrs: { d: 'M5 9.5V20h14V9.5' } },
+  { tag: 'path', attrs: { d: 'M10 20v-5h4v5' } },
+])
+
+export const UserIcon = IconBase([
+  { tag: 'path', attrs: { d: 'M20 21a8 8 0 0 0-16 0' } },
+  { tag: 'circle', attrs: { cx: '12', cy: '8', r: '4' } },
+])
+
+export const ZapIcon = IconBase([
+  { tag: 'polygon', attrs: { points: '13 2 3 14 12 14 11 22 21 10 12 10 13 2' } },
+])
+
+export const TruckIcon = IconBase([
+  { tag: 'path', attrs: { d: 'M10 17H5a2 2 0 0 1-2-2V7h11v10Z' } },
+  { tag: 'path', attrs: { d: 'M14 17h-1V9h3l3 3v5h-1' } },
+  { tag: 'circle', attrs: { cx: '7.5', cy: '17.5', r: '1.5' } },
+  { tag: 'circle', attrs: { cx: '17.5', cy: '17.5', r: '1.5' } },
+])

--- a/src/composables/hq/purchaseOrder/useStatusFormat.js
+++ b/src/composables/hq/purchaseOrder/useStatusFormat.js
@@ -1,0 +1,71 @@
+// 본사 발주 상태 라벨/색상 매핑 — 본사 시점 (COMPLETED = "종료").
+// 진행 이력 타임라인의 점/텍스트 색상도 같은 7단계 enum 매핑.
+// 창고 시점 라벨이 다른 곳(WarehouseInboundView 의 COMPLETED = "입고 완료") 은 별 헬퍼 권장.
+
+const STATUS_BADGE = {
+  REQUESTED: 'bg-amber-50 text-amber-700',
+  APPROVED: 'bg-emerald-50 text-emerald-700',
+  READY_TO_SHIP: 'bg-sky-50 text-sky-700',
+  IN_TRANSIT: 'bg-blue-50 text-blue-600',
+  ARRIVED: 'bg-violet-50 text-violet-700',
+  COMPLETED: 'bg-gray-100 text-gray-500',
+  CANCELLED: 'bg-red-50 text-red-600',
+}
+
+const STATUS_LABEL_HQ = {
+  REQUESTED: '승인 대기',
+  APPROVED: '승인 완료',
+  READY_TO_SHIP: '배송 준비 중',
+  IN_TRANSIT: '배송 중',
+  ARRIVED: '배송 완료',
+  COMPLETED: '종료',
+  CANCELLED: '취소',
+}
+
+const HISTORY_DOT = {
+  REQUESTED: 'bg-amber-500',
+  APPROVED: 'bg-emerald-500',
+  READY_TO_SHIP: 'bg-sky-500',
+  IN_TRANSIT: 'bg-blue-500',
+  ARRIVED: 'bg-violet-500',
+  COMPLETED: 'bg-gray-700',
+  CANCELLED: 'bg-red-600',
+}
+
+const HISTORY_TEXT = {
+  REQUESTED: 'text-amber-700',
+  APPROVED: 'text-emerald-700',
+  READY_TO_SHIP: 'text-sky-700',
+  IN_TRANSIT: 'text-blue-600',
+  ARRIVED: 'text-violet-700',
+  COMPLETED: 'text-gray-700',
+  CANCELLED: 'text-red-700',
+}
+
+export function useStatusFormat() {
+  function statusClass(status) {
+    return STATUS_BADGE[status] ?? 'bg-gray-100 text-gray-500'
+  }
+
+  function statusLabel(status) {
+    return STATUS_LABEL_HQ[status] ?? status
+  }
+
+  function historyDotClass(status) {
+    return HISTORY_DOT[status] ?? 'bg-gray-400'
+  }
+
+  function historyTextClass(status) {
+    return HISTORY_TEXT[status] ?? 'text-gray-700'
+  }
+
+  function formatDate(iso) {
+    if (!iso) return '-'
+    const d = new Date(iso)
+    if (Number.isNaN(d.getTime())) return '-'
+    const pad = (n) => String(n).padStart(2, '0')
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
+  }
+
+  return { statusClass, statusLabel, historyDotClass, historyTextClass, formatDate }
+}

--- a/src/views/hq/purchase-order/HqPurchaseOrderView.vue
+++ b/src/views/hq/purchase-order/HqPurchaseOrderView.vue
@@ -1,14 +1,20 @@
 <script setup>
-import { computed, h, onMounted, onUnmounted, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
 import { usePurchaseOrderStore } from '@/stores/purchaseOrder.js'
+import { PlusIcon, TruckIcon, ZapIcon } from '@/components/hq/purchase-order/icons.js'
+import PurchaseOrderCancelModal from '@/components/hq/purchase-order/PurchaseOrderCancelModal.vue'
+import PurchaseOrderDetailPanel from '@/components/hq/purchase-order/PurchaseOrderDetailPanel.vue'
+import { useStatusFormat } from '@/composables/hq/purchaseOrder/useStatusFormat.js'
 
 const router = useRouter()
 const auth = useAuthStore()
 const poStore = usePurchaseOrderStore()
+
+const { statusClass, statusLabel, historyDotClass, historyTextClass, formatDate } = useStatusFormat()
 
 // ─── 레이아웃 설정 ───────────────────────────────────────────────────────────
 const hqMenus = roleMenus.hq
@@ -47,8 +53,8 @@ function selectOrder(id) {
 // ─── 발주 취소 confirm ──────────────────────────────────────────────────────
 // 공급처 승인(PENDING→APPROVED)·출고 시작(APPROVED→SHIPPING) 두 단계는 SYS-001 배치가
 // 자동 처리한다 (5분 주기, 30분 경과 조건). 본사는 발주 작성·취소 + 시연용 강제 트리거만.
+// cancelReason 은 모달 로컬 state — 부모는 open/close 만 관리.
 const showCancelConfirm = ref(false)
-const cancelReason = ref('')
 
 const toast = ref({ show: false, message: '' })
 let toastTimer = null
@@ -92,7 +98,6 @@ async function runBatchTrigger() {
 // REQUESTED (승인 대기) 단계에서만 취소 가능. 그 이후는 공급처가 이미 받았으므로 차단.
 function openCancelConfirm() {
   if (poStore.selectedOrder?.status !== 'REQUESTED') return
-  cancelReason.value = '' // 모달 열 때마다 초기화
   showCancelConfirm.value = true
 }
 
@@ -100,12 +105,12 @@ function cancelCancelConfirm() {
   showCancelConfirm.value = false
 }
 
-async function confirmCancelOrder() {
+async function confirmCancelOrder(reason) {
   const id = poStore.selectedOrder?.id
   if (!id) return
   showCancelConfirm.value = false
   try {
-    await poStore.cancelOrder(id, cancelReason.value.trim())
+    await poStore.cancelOrder(id, (reason ?? '').trim())
     triggerToast('발주가 취소되었습니다')
   } catch (e) {
     triggerToast(e?.message ?? '취소 처리에 실패했습니다')
@@ -118,69 +123,8 @@ function changeTab(key) {
   poStore.selectedOrderId = null
 }
 
-// 상태 뱃지 클래스
-function statusClass(status) {
-  const map = {
-    REQUESTED: 'bg-amber-50 text-amber-700',
-    APPROVED: 'bg-emerald-50 text-emerald-700',
-    READY_TO_SHIP: 'bg-sky-50 text-sky-700',
-    IN_TRANSIT: 'bg-blue-50 text-blue-600',
-    ARRIVED: 'bg-violet-50 text-violet-700',
-    COMPLETED: 'bg-gray-100 text-gray-500',
-    CANCELLED: 'bg-red-50 text-red-600',
-  }
-  return map[status] ?? 'bg-gray-100 text-gray-500'
-}
-
-// 상태 한국어 라벨 — 본사 화면 시점 (COMPLETED = "종료")
-function statusLabel(status) {
-  const map = {
-    REQUESTED: '승인 대기',
-    APPROVED: '승인 완료',
-    READY_TO_SHIP: '배송 준비 중',
-    IN_TRANSIT: '배송 중',
-    ARRIVED: '배송 완료',
-    COMPLETED: '종료',
-    CANCELLED: '취소',
-  }
-  return map[status] ?? status
-}
-
-// 날짜 포맷
-function formatDate(iso) {
-  if (!iso) return '-'
-  const d = new Date(iso)
-  if (Number.isNaN(d.getTime())) return '-'
-  const pad = (n) => String(n).padStart(2, '0')
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
-}
-
-// 진행 이력 타임라인 — 점/텍스트 색상
-function historyDotClass(status) {
-  const map = {
-    REQUESTED: 'bg-amber-500',
-    APPROVED: 'bg-emerald-500',
-    READY_TO_SHIP: 'bg-sky-500',
-    IN_TRANSIT: 'bg-blue-500',
-    ARRIVED: 'bg-violet-500',
-    COMPLETED: 'bg-gray-700',
-    CANCELLED: 'bg-red-600',
-  }
-  return map[status] ?? 'bg-gray-400'
-}
-
-function historyTextClass(status) {
-  const map = {
-    REQUESTED: 'text-amber-700',
-    APPROVED: 'text-emerald-700',
-    READY_TO_SHIP: 'text-sky-700',
-    IN_TRANSIT: 'text-blue-600',
-    ARRIVED: 'text-violet-700',
-    COMPLETED: 'text-gray-700',
-    CANCELLED: 'text-red-700',
-  }
-  return map[status] ?? 'text-gray-700'
-}
+// statusClass / statusLabel / historyDotClass / historyTextClass / formatDate
+// 는 useStatusFormat() composable 에서 제공.
 
 // ─── 발주 작성/수정 페이지 라우팅 ──────────────────────────────────────────
 function goCreatePage() {
@@ -207,78 +151,7 @@ onMounted(() => {
 })
 onUnmounted(() => window.removeEventListener('keydown', handleKeydown))
 
-// ─── inline SVG 아이콘 (render 함수 방식) ────────────────────────────────────
-const IconBase = (paths) => ({
-  props: {
-    size: { type: Number, default: 16 },
-    strokeWidth: { type: Number, default: 2 },
-  },
-  render() {
-    return h(
-      'svg',
-      {
-        width: this.size,
-        height: this.size,
-        viewBox: '0 0 24 24',
-        fill: 'none',
-        stroke: 'currentColor',
-        'stroke-width': this.strokeWidth,
-        'stroke-linecap': 'round',
-        'stroke-linejoin': 'round',
-        'aria-hidden': 'true',
-      },
-      paths.map((p) => h(p.tag, p.attrs)),
-    )
-  },
-})
-
-const PlusIcon = IconBase([
-  { tag: 'path', attrs: { d: 'M12 5v14' } },
-  { tag: 'path', attrs: { d: 'M5 12h14' } },
-])
-
-const SearchIcon = IconBase([
-  { tag: 'circle', attrs: { cx: '11', cy: '11', r: '7' } },
-  { tag: 'path', attrs: { d: 'm20 20-3.5-3.5' } },
-])
-
-const XIcon = IconBase([
-  { tag: 'path', attrs: { d: 'M18 6 6 18' } },
-  { tag: 'path', attrs: { d: 'm6 6 12 12' } },
-])
-
-const EditIcon = IconBase([
-  { tag: 'path', attrs: { d: 'M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7' } },
-  { tag: 'path', attrs: { d: 'M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5Z' } },
-])
-
-const InfoIcon = IconBase([
-  { tag: 'circle', attrs: { cx: '12', cy: '12', r: '9' } },
-  { tag: 'path', attrs: { d: 'M12 10v6' } },
-  { tag: 'path', attrs: { d: 'M12 7h.01' } },
-])
-
-const WarehouseIcon = IconBase([
-  { tag: 'path', attrs: { d: 'M3 10.5 12 4l9 6.5' } },
-  { tag: 'path', attrs: { d: 'M5 9.5V20h14V9.5' } },
-  { tag: 'path', attrs: { d: 'M10 20v-5h4v5' } },
-])
-
-const UserIcon = IconBase([
-  { tag: 'path', attrs: { d: 'M20 21a8 8 0 0 0-16 0' } },
-  { tag: 'circle', attrs: { cx: '12', cy: '8', r: '4' } },
-])
-
-const ZapIcon = IconBase([
-  { tag: 'polygon', attrs: { points: '13 2 3 14 12 14 11 22 21 10 12 10 13 2' } },
-])
-
-const TruckIcon = IconBase([
-  { tag: 'path', attrs: { d: 'M10 17H5a2 2 0 0 1-2-2V7h11v10Z' } },
-  { tag: 'path', attrs: { d: 'M14 17h-1V9h3l3 3v5h-1' } },
-  { tag: 'circle', attrs: { cx: '7.5', cy: '17.5', r: '1.5' } },
-  { tag: 'circle', attrs: { cx: '17.5', cy: '17.5', r: '1.5' } },
-])
+// 아이콘은 @/components/hq/purchase-order/icons.js 에서 import.
 </script>
 
 <template>
@@ -496,300 +369,22 @@ const TruckIcon = IconBase([
           </div>
         </div>
 
-        <!-- ── 우측: 발주 상세 패널 (선택 시에만 표시) ── -->
-        <aside
+        <PurchaseOrderDetailPanel
           v-if="poStore.selectedOrder"
-          class="flex w-full shrink-0 flex-col overflow-hidden border border-gray-300 bg-white shadow-sm xl:w-[420px]"
-        >
-          <!-- 상세 패널 헤더 -->
-          <div class="flex items-center justify-between bg-[#004D3C] px-4 py-3 text-white">
-            <h3
-              class="inline-flex items-center gap-2 text-[11px] font-black uppercase tracking-wider"
-            >
-              <InfoIcon :size="14" />
-              발주 상세
-            </h3>
-            <div class="flex items-center gap-3">
-              <span
-                class="inline-flex px-2 py-1 text-[10px] font-black"
-                :class="statusClass(poStore.selectedOrder.status)"
-              >
-                {{ statusLabel(poStore.selectedOrder.status) }}
-              </span>
-              <button
-                type="button"
-                class="p-1 text-white/80 hover:bg-white/10"
-                aria-label="닫기"
-                @click="poStore.selectedOrderId = null"
-              >
-                <XIcon :size="16" />
-              </button>
-            </div>
-          </div>
-
-          <!-- 상세 내용 -->
-          <div class="flex flex-1 flex-col gap-4 overflow-y-auto p-4">
-            <!-- 기본 정보 카드 -->
-            <section class="space-y-3">
-              <div class="flex items-start justify-between gap-2">
-                <div>
-                  <p class="text-[10px] font-bold uppercase text-gray-400">발주번호</p>
-                  <p class="mt-0.5 text-sm font-black text-gray-900">
-                    {{ poStore.selectedOrder.id }}
-                  </p>
-                </div>
-              </div>
-
-              <div class="grid grid-cols-2 gap-3">
-                <div>
-                  <p class="text-[10px] font-bold uppercase text-gray-400">공급처</p>
-                  <p class="mt-0.5 text-xs font-black text-gray-800">
-                    {{ poStore.selectedOrder.vendorName }}
-                  </p>
-                </div>
-                <div>
-                  <p class="text-[10px] font-bold uppercase text-gray-400">입고 창고</p>
-                  <p class="mt-0.5 text-xs font-black text-gray-800">
-                    {{ poStore.selectedOrder.warehouseName }}
-                  </p>
-                </div>
-                <div>
-                  <p
-                    class="inline-flex items-center gap-1 text-[10px] font-bold uppercase text-gray-400"
-                  >
-                    <UserIcon :size="10" />
-                    담당자
-                  </p>
-                  <p class="mt-0.5 text-xs font-black text-gray-800">
-                    {{ poStore.selectedOrder.memberName }}
-                  </p>
-                </div>
-                <div>
-                  <p class="text-[10px] font-bold uppercase text-gray-400">생성일시</p>
-                  <p class="mt-0.5 text-xs font-bold text-gray-500">
-                    {{ formatDate(poStore.selectedOrder.createdAt) }}
-                  </p>
-                </div>
-              </div>
-            </section>
-
-            <!-- 품목 테이블 -->
-            <section>
-              <p class="mb-2 text-[10px] font-black uppercase text-gray-400">발주 품목</p>
-              <table class="w-full text-xs">
-                <thead class="bg-gray-100 text-[10px] uppercase text-gray-500">
-                  <tr>
-                    <th class="px-2 py-2 text-left font-black">제품명</th>
-                    <th class="w-10 px-2 py-2 text-right font-black">수량</th>
-                    <th class="w-20 px-2 py-2 text-right font-black">단가</th>
-                    <th class="w-20 px-2 py-2 text-right font-black">소계</th>
-                  </tr>
-                </thead>
-                <tbody class="divide-y divide-gray-100">
-                  <tr
-                    v-for="item in poStore.selectedOrder.items"
-                    :key="item.skuCode || item.productId"
-                  >
-                    <td class="px-2 py-2 align-top">
-                      <div class="font-bold text-gray-800">{{ item.productName }}</div>
-                      <div
-                        v-if="item.displayOption"
-                        class="mt-0.5 text-[11px] font-bold text-[#004D3C]"
-                      >
-                        {{ item.displayOption }}
-                      </div>
-                      <div v-if="item.skuCode" class="text-[10px] text-gray-400">
-                        {{ item.skuCode }}
-                      </div>
-                    </td>
-                    <td class="px-2 py-2 text-right font-bold text-gray-700 align-top">
-                      {{ item.quantity }}
-                    </td>
-                    <td class="px-2 py-2 text-right text-gray-500 align-top">
-                      ₩{{ item.unitPrice.toLocaleString() }}
-                    </td>
-                    <td class="px-2 py-2 text-right font-bold text-gray-700 align-top">
-                      ₩{{ item.subtotal.toLocaleString() }}
-                    </td>
-                  </tr>
-                </tbody>
-                <tfoot class="border-t border-gray-300 bg-gray-50 font-black text-gray-900">
-                  <tr>
-                    <td colspan="3" class="px-2 py-2">총계</td>
-                    <td class="px-2 py-2 text-right text-[#004D3C]">
-                      ₩{{ poStore.selectedOrder.totalPrice.toLocaleString() }}
-                    </td>
-                  </tr>
-                </tfoot>
-              </table>
-            </section>
-
-            <!-- 진행 이력 타임라인 -->
-            <section v-if="poStore.selectedOrder.statusHistory?.length">
-              <p class="mb-2 text-[10px] font-black uppercase text-gray-400">진행 이력</p>
-              <ol class="ml-2">
-                <li
-                  v-for="(h, idx) in poStore.selectedOrder.statusHistory"
-                  :key="idx"
-                  class="relative pb-3 pl-5 last:pb-0"
-                >
-                  <!-- 점 -->
-                  <span
-                    class="absolute left-0 top-1 block h-2.5 w-2.5"
-                    :class="historyDotClass(h.status)"
-                  />
-                  <!-- 다음 항목까지 잇는 세로선 (마지막 항목 제외) -->
-                  <span
-                    v-if="idx < poStore.selectedOrder.statusHistory.length - 1"
-                    class="absolute bottom-0 left-[4px] top-3.5 w-px bg-gray-300"
-                  />
-                  <p class="text-[11px] font-black" :class="historyTextClass(h.status)">
-                    {{ statusLabel(h.status) }}
-                  </p>
-                  <p class="text-[10px] text-gray-500">{{ formatDate(h.at) }} · {{ h.byName }}</p>
-                </li>
-              </ol>
-            </section>
-          </div>
-
-          <!-- 액션/안내 (상태별 조건부) -->
-          <!-- REQUESTED 단계에서만 본사 권한(수정/취소) 노출. 승인 이후 단계는 SYS-001 자동 전환 및 창고관리자 영역이라 조회만. -->
-          <div class="space-y-4 px-4 pb-6 pt-2">
-            <template v-if="poStore.selectedOrder.status === 'REQUESTED'">
-              <div class="grid grid-cols-2 gap-2">
-                <button
-                  type="button"
-                  class="inline-flex items-center justify-center gap-1 border border-gray-400 bg-white px-2 py-2.5 text-[11px] font-black text-gray-700 hover:bg-gray-50"
-                  @click="goEditPage"
-                >
-                  <EditIcon :size="12" />
-                  수정
-                </button>
-                <button
-                  type="button"
-                  class="inline-flex items-center justify-center gap-1 border border-red-500 bg-red-50 px-2 py-2.5 text-[11px] font-black text-red-700 hover:bg-red-100"
-                  @click="openCancelConfirm"
-                >
-                  <XIcon :size="12" />
-                  취소
-                </button>
-              </div>
-              <p class="pt-1 text-center text-[11px] leading-relaxed text-gray-500">
-                30분 후 시스템이 자동으로 공급처 승인을 처리합니다.<br />
-                그 전에 [수정] 또는 [취소] 가능합니다.
-              </p>
-            </template>
-
-            <template v-else-if="poStore.selectedOrder.status === 'APPROVED'">
-              <p class="text-center text-xs leading-relaxed text-gray-500">
-                승인 완료 · 30분 후 시스템이 자동으로 배송 준비 처리합니다.
-              </p>
-            </template>
-
-            <template v-else-if="poStore.selectedOrder.status === 'READY_TO_SHIP'">
-              <p class="text-center text-xs leading-relaxed text-gray-500">
-                배송 준비 중 · 30분 후 시스템이 자동으로 배송 시작 처리합니다.
-              </p>
-            </template>
-
-            <template v-else-if="poStore.selectedOrder.status === 'IN_TRANSIT'">
-              <p class="text-center text-xs leading-relaxed text-gray-500">
-                배송 중 · 30분 후 시스템이 자동으로 배송 완료 처리합니다.
-              </p>
-            </template>
-
-            <template v-else-if="poStore.selectedOrder.status === 'ARRIVED'">
-              <p class="text-center text-xs text-gray-500">배송 완료 · 창고 입고 확정 대기</p>
-            </template>
-
-            <template v-else>
-              <p
-                v-if="
-                  poStore.selectedOrder.status === 'CANCELLED' && poStore.selectedOrder.cancelReason
-                "
-                class="border border-red-200 bg-red-50 px-3 py-2.5 text-[11px] font-bold leading-relaxed text-red-700"
-              >
-                취소 사유: {{ poStore.selectedOrder.cancelReason }}
-              </p>
-              <p class="pt-2 text-center text-xs text-gray-400">
-                {{
-                  poStore.selectedOrder.status === 'COMPLETED'
-                    ? '종료된 발주입니다.'
-                    : '취소된 발주입니다.'
-                }}
-              </p>
-            </template>
-          </div>
-
-          <!-- 하단: 닫기 버튼 -->
-          <div class="border-t border-gray-200">
-            <button
-              type="button"
-              class="w-full px-4 py-2.5 text-center text-[11px] font-bold text-gray-500 hover:bg-gray-50"
-              @click="poStore.selectedOrderId = null"
-            >
-              닫기 (ESC)
-            </button>
-          </div>
-        </aside>
+          :order="poStore.selectedOrder"
+          @close="poStore.selectedOrderId = null"
+          @edit="goEditPage"
+          @cancel="openCancelConfirm"
+        />
       </section>
     </div>
 
-    <!-- ───────── 모달: 발주 취소 confirm (파괴, red) ───────── -->
-    <div
-      v-if="showCancelConfirm && poStore.selectedOrder"
-      class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
-      @click.self="cancelCancelConfirm"
-    >
-      <div class="w-full max-w-sm overflow-hidden bg-white shadow-xl">
-        <div class="bg-red-700 px-5 py-3 text-white">
-          <h2 class="text-sm font-black">발주 취소</h2>
-        </div>
-        <div class="space-y-3 p-5 text-xs text-gray-700">
-          <p class="text-[10px] font-bold uppercase tracking-wider text-gray-400">발주 정보</p>
-          <p>
-            <strong>{{ poStore.selectedOrder.id }}</strong> ·
-            {{ poStore.selectedOrder.vendorName }} ·
-            <span class="font-bold text-[#004D3C]">
-              ₩{{ poStore.selectedOrder.totalPrice.toLocaleString() }}
-            </span>
-          </p>
-          <label class="block">
-            <span class="text-[10px] font-bold uppercase tracking-wider text-gray-500">
-              취소 사유 (선택)
-            </span>
-            <textarea
-              v-model="cancelReason"
-              rows="3"
-              maxlength="500"
-              placeholder="예: 공급처 단가 변경, 수량 잘못 입력 등"
-              class="mt-1 w-full resize-none border border-gray-300 px-2 py-1.5 text-xs outline-none focus:border-red-500"
-            />
-          </label>
-          <p class="text-[11px] leading-relaxed text-red-600">
-            취소 후에는 되돌릴 수 없습니다. 같은 발주가 필요하면 새 발주로 다시 만들어야 합니다.
-          </p>
-        </div>
-        <div
-          class="flex items-center justify-end gap-2 border-t border-gray-200 bg-gray-50 px-5 py-3"
-        >
-          <button
-            type="button"
-            class="border border-gray-300 bg-white px-4 py-2 text-xs font-black text-gray-700 hover:bg-gray-100"
-            @click="cancelCancelConfirm"
-          >
-            취소
-          </button>
-          <button
-            type="button"
-            class="border border-red-700 bg-red-700 px-4 py-2 text-xs font-black text-white hover:bg-red-600"
-            @click="confirmCancelOrder"
-          >
-            취소 확정
-          </button>
-        </div>
-      </div>
-    </div>
+    <PurchaseOrderCancelModal
+      :open="showCancelConfirm"
+      :order="poStore.selectedOrder"
+      @cancel="cancelCancelConfirm"
+      @confirm="confirmCancelOrder"
+    />
 
     <!-- ───────── 토스트 ───────── -->
     <Transition


### PR DESCRIPTION
## 📌 요약
- 본사 발주 목록 화면(`HqPurchaseOrderView.vue`) 809 → 404 (-50%, -405줄). SFC ~500 가이드 도달. 인라인 아이콘·상태 매핑·상세 패널·취소 모달 4개 영역 책임 분리.

<br><br>

## 🎯 작업 내용
- `icons.js` 7개 아이콘 신규 추가 (`XIcon/EditIcon/InfoIcon/WarehouseIcon/UserIcon/ZapIcon/TruckIcon`) — PR #416 의 기존 모듈에 통합.
- `composables/hq/purchaseOrder/useStatusFormat.js` 신규 — `statusClass/statusLabel/historyDotClass/historyTextClass/formatDate`. 본사 시점 7단계 라벨 매핑 + 진행 이력 타임라인 색상까지 재사용 가능 형태.
- `PurchaseOrderDetailPanel.vue` 신규 (~225줄) — 우측 발주 상세 패널 전체 (헤더/기본정보/품목 테이블/진행 이력/상태별 액션/닫기). `order` props + `close/edit/cancel` emit. 단계별 안내문 분기까지 자식이 책임.
- `PurchaseOrderCancelModal.vue` 신규 (~70줄) — 발주 취소 textarea 모달. `cancelReason` 은 모달 로컬 state, `confirm(reason)` emit 으로 부모에 전달.
- 부모 view 의 IconBase 정의 + 5개 상태 헬퍼 + 235줄 상세 패널 template + 55줄 취소 모달 template 모두 제거. 미사용 import 5개도 정리.

<br><br>

## ✔️ 참고 사항
- 빌드 통과 (`vite build` ✓). 동작 보존 — props/emits 인터페이스만 변경, 도메인 로직 변경 0.
- `useStatusFormat` 은 다른 발주 관련 view (창고 입고 등) 에서도 import 가능 — 라벨이 본사 시점 (`COMPLETED='종료'`) 이라 창고 시점(`'입고 완료'`) 이 필요한 곳은 별 헬퍼 권장.
- 다음 사이클 후보: `WarehouseInboundView.vue` 784줄, `stores/purchaseOrder.js` 506줄.

<br><br>

## ✔️ 관련 이슈

- 

<br><br>
