### PR TITLE
refactor(warehouse-inbound): 책임 단위 컴포넌트로 분리

### DIFF
--- a/src/components/warehouse/inbound/WarehouseInboundConfirmModal.vue
+++ b/src/components/warehouse/inbound/WarehouseInboundConfirmModal.vue
@@ -1,0 +1,100 @@
+<script setup>
+// 입고 확정 confirm 모달.
+// preview 는 부모(view) 의 stockStore.getInboundPreview 결과 — 입고 후 실재고 변화 + 안전재고 미달 경고.
+defineProps({
+  open: { type: Boolean, required: true },
+  order: { type: Object, default: null },
+  preview: { type: Array, default: () => [] },
+  hasShortage: { type: Boolean, default: false },
+})
+const emit = defineEmits(['cancel', 'confirm'])
+</script>
+
+<template>
+  <div
+    v-if="open && order"
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+    @click.self="emit('cancel')"
+  >
+    <div class="w-full max-w-lg overflow-hidden bg-white shadow-xl">
+      <div class="bg-[#004D3C] px-5 py-3 text-white">
+        <h2 class="text-sm font-black">입고 확정</h2>
+      </div>
+      <div class="space-y-3 p-5 text-xs text-gray-700">
+        <div>
+          <p class="text-[10px] font-bold uppercase tracking-wider text-gray-400">발주 정보</p>
+          <p class="mt-1">
+            <strong>{{ order.id }}</strong> ·
+            {{ order.vendorName }} ·
+            <span class="font-bold text-[#004D3C]">
+              ₩{{ order.totalPrice.toLocaleString() }}
+            </span>
+          </p>
+        </div>
+
+        <!-- 입고 후 재고 변화 미리보기 -->
+        <div v-if="preview.length > 0">
+          <p class="text-[10px] font-bold uppercase tracking-wider text-gray-400">
+            입고 후 재고 변화 ({{ order.warehouseName }})
+          </p>
+          <table class="mt-1 w-full table-fixed border-collapse text-[11px]">
+            <thead class="bg-gray-50 text-[9px] uppercase tracking-wider text-gray-500">
+              <tr>
+                <th class="px-2 py-1.5 text-left font-black">품목</th>
+                <th class="w-12 px-2 py-1.5 text-right font-black">입고</th>
+                <th class="w-20 px-2 py-1.5 text-right font-black">실재고</th>
+                <th class="w-12 px-2 py-1.5 text-right font-black">안전</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100">
+              <tr v-for="row in preview" :key="row.productCode">
+                <td class="truncate px-2 py-1.5 font-bold text-gray-800">{{ row.productName }}</td>
+                <td class="px-2 py-1.5 text-right font-black text-[#004D3C]">+{{ row.quantity }}</td>
+                <td class="px-2 py-1.5 text-right font-bold">
+                  <template v-if="row.before">
+                    <span class="text-gray-400">{{ row.before.onHand }}</span>
+                    <span class="mx-1 text-gray-300">→</span>
+                    <span :class="row.shortageAfter ? 'text-red-600' : 'text-gray-800'">
+                      {{ row.after.onHand }}
+                    </span>
+                  </template>
+                  <span v-else class="text-gray-300">—</span>
+                </td>
+                <td class="px-2 py-1.5 text-right font-bold text-gray-500">
+                  <template v-if="row.before">{{ row.before.safetyStock }}</template>
+                  <span v-else class="text-gray-300">—</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <p
+            v-if="hasShortage"
+            class="mt-2 border border-amber-300 bg-amber-50 px-2 py-1.5 text-[11px] font-bold text-amber-800"
+          >
+            ⚠ 입고 확정 후에도 안전재고 미달 품목이 있습니다 — 추가 발주 검토 필요.
+          </p>
+        </div>
+
+        <p class="pt-1 text-[11px] text-gray-500">
+          창고 자산으로 등록되며 발주 상태가 <strong>입고 완료</strong>로 변경됩니다.
+        </p>
+      </div>
+      <div class="flex items-center justify-end gap-2 border-t border-gray-200 bg-gray-50 px-5 py-3">
+        <button
+          type="button"
+          class="border border-gray-300 bg-white px-4 py-2 text-xs font-black text-gray-700 hover:bg-gray-100"
+          @click="emit('cancel')"
+        >
+          취소
+        </button>
+        <button
+          type="button"
+          class="border border-[#004D3C] bg-[#004D3C] px-4 py-2 text-xs font-black text-white hover:bg-[#1f4b3a]"
+          @click="emit('confirm')"
+        >
+          입고 확정
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/warehouse/inbound/WarehouseInboundDetailPanel.vue
+++ b/src/components/warehouse/inbound/WarehouseInboundDetailPanel.vue
@@ -1,0 +1,258 @@
+<script setup>
+// 창고 입고 우측 상세 패널.
+// inboundType 분기 — PURCHASE_ORDER 면 품목 테이블 + 단가/소계, WAREHOUSE_TRANSFER 는 placeholder.
+// ARRIVED 일 때만 [입고 확정] 버튼 노출, 그 외는 안내 문구.
+import { computed } from 'vue'
+import {
+  CheckIcon,
+  InfoIcon,
+  UserIcon,
+  XIcon,
+} from '@/components/warehouse/inbound/icons.js'
+import { useWarehouseStatusFormat } from '@/composables/warehouse/useWarehouseStatusFormat.js'
+
+const props = defineProps({
+  order: { type: Object, required: true },
+  itemStocks: { type: Map, default: () => new Map() },
+})
+defineEmits(['close', 'confirm-inbound'])
+
+const {
+  statusClass,
+  statusLabel,
+  historyDotClass,
+  historyTextClass,
+  inboundTypeClass,
+  inboundTypeLabel,
+  formatDate,
+} = useWarehouseStatusFormat()
+
+function getItemStock(item) {
+  return props.itemStocks.get(item.id) ?? null
+}
+
+function isItemShortage(item) {
+  const s = getItemStock(item)
+  return !!(s && s.onHand < s.safetyStock)
+}
+
+// 창고 관점 진행 이력 — 거래처 단계(READY_TO_SHIP/IN_TRANSIT/ARRIVED) + COMPLETED 노출.
+// REQUESTED/APPROVED 는 본사 승인 영역, CANCELLED 는 창고 화면 미노출이라 필터.
+const visibleHistory = computed(() => {
+  const list = props.order?.statusHistory ?? []
+  return list.filter((h) =>
+    h.status === 'READY_TO_SHIP'
+    || h.status === 'IN_TRANSIT'
+    || h.status === 'ARRIVED'
+    || h.status === 'COMPLETED'
+  )
+})
+</script>
+
+<template>
+  <aside
+    class="flex w-full shrink-0 flex-col overflow-hidden border border-gray-300 bg-white shadow-sm xl:w-[420px]"
+  >
+    <!-- 상세 패널 헤더 -->
+    <div class="flex items-center justify-between bg-[#004D3C] px-4 py-3 text-white">
+      <h3 class="inline-flex items-center gap-2 text-[11px] font-black uppercase tracking-wider">
+        <InfoIcon :size="14" />
+        입고 상세
+      </h3>
+      <div class="flex items-center gap-3">
+        <span class="inline-flex px-2 py-1 text-[10px] font-black" :class="statusClass(order.status)">
+          {{ statusLabel(order.status) }}
+        </span>
+        <button
+          type="button"
+          class="p-1 text-white/80 hover:bg-white/10"
+          aria-label="닫기"
+          @click="$emit('close')"
+        >
+          <XIcon :size="16" />
+        </button>
+      </div>
+    </div>
+
+    <!-- 상세 내용 -->
+    <div class="flex flex-1 flex-col gap-4 overflow-y-auto p-4">
+      <!-- 기본 정보 (공통) -->
+      <section class="space-y-3">
+        <div class="grid grid-cols-2 gap-3">
+          <div>
+            <p class="text-[10px] font-bold uppercase text-gray-400">입고번호</p>
+            <p class="mt-0.5 text-sm font-black text-gray-900">{{ order.inboundCode }}</p>
+          </div>
+          <div>
+            <p class="text-[10px] font-bold uppercase text-gray-400">출처번호</p>
+            <p class="mt-0.5 text-xs font-black text-gray-700">{{ order.sourceRefNo }}</p>
+          </div>
+        </div>
+
+        <div class="grid grid-cols-2 gap-3">
+          <div>
+            <p class="text-[10px] font-bold uppercase text-gray-400">
+              {{ order.inboundType === 'WAREHOUSE_TRANSFER' ? '출발 창고' : '공급처' }}
+            </p>
+            <p class="mt-0.5 text-xs font-black text-gray-800">{{ order.sourceName }}</p>
+          </div>
+          <div>
+            <p class="text-[10px] font-bold uppercase text-gray-400">입고 창고</p>
+            <p class="mt-0.5 text-xs font-black text-gray-800">{{ order.warehouseName }}</p>
+          </div>
+          <div>
+            <p class="inline-flex items-center gap-1 text-[10px] font-bold uppercase text-gray-400">
+              <UserIcon :size="10" />
+              종류
+            </p>
+            <p class="mt-0.5">
+              <span
+                class="inline-flex px-2 py-1 text-[10px] font-black"
+                :class="inboundTypeClass(order.inboundType)"
+              >
+                {{ inboundTypeLabel(order.inboundType) }}
+              </span>
+            </p>
+          </div>
+          <div>
+            <p class="text-[10px] font-bold uppercase text-gray-400">생성일시</p>
+            <p class="mt-0.5 text-xs font-bold text-gray-500">{{ formatDate(order.createdAt) }}</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- 발주 입고 분기 (PURCHASE_ORDER) — 품목 테이블 + 단가/소계 -->
+      <section v-if="order.inboundType === 'PURCHASE_ORDER'">
+        <p class="mb-2 text-[10px] font-black uppercase text-gray-400">발주 품목</p>
+        <table class="w-full text-xs">
+          <thead class="bg-gray-100 text-[10px] uppercase text-gray-500">
+            <tr>
+              <th class="px-2 py-2 text-left font-black">제품명</th>
+              <th class="w-10 px-2 py-2 text-right font-black">수량</th>
+              <th class="w-12 px-2 py-2 text-right font-black">실재고</th>
+              <th class="w-10 px-2 py-2 text-right font-black">안전</th>
+              <th class="w-16 px-2 py-2 text-right font-black">단가</th>
+              <th class="w-16 px-2 py-2 text-right font-black">소계</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-100">
+            <tr v-for="item in order.items" :key="item.id">
+              <td class="px-2 py-2 font-bold text-gray-800">
+                <div>{{ item.productName }}</div>
+                <div
+                  v-if="item.displayOption"
+                  class="mt-0.5 text-[10px] font-bold text-[#004D3C]"
+                >
+                  {{ item.displayOption }}
+                </div>
+              </td>
+              <td class="px-2 py-2 text-right font-bold text-gray-700">{{ item.quantity }}</td>
+              <td
+                class="px-2 py-2 text-right font-black"
+                :class="isItemShortage(item) ? 'text-red-600' : 'text-gray-800'"
+              >
+                <template v-if="getItemStock(item)">{{ getItemStock(item).onHand }}</template>
+                <span v-else class="text-gray-300">—</span>
+              </td>
+              <td class="px-2 py-2 text-right font-bold text-gray-500">
+                <template v-if="getItemStock(item)">{{ getItemStock(item).safetyStock }}</template>
+                <span v-else class="text-gray-300">—</span>
+              </td>
+              <td class="px-2 py-2 text-right text-gray-500">
+                ₩{{ item.unitPrice.toLocaleString() }}
+              </td>
+              <td class="px-2 py-2 text-right font-bold text-gray-700">
+                ₩{{ item.subtotal.toLocaleString() }}
+              </td>
+            </tr>
+          </tbody>
+          <tfoot class="border-t border-gray-300 bg-gray-50 font-black text-gray-900">
+            <tr>
+              <td colspan="5" class="px-2 py-2">총계</td>
+              <td class="px-2 py-2 text-right text-[#004D3C]">
+                <template v-if="order.totalAmount != null">
+                  ₩{{ order.totalAmount.toLocaleString() }}
+                </template>
+                <span v-else class="text-gray-300">—</span>
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+      </section>
+
+      <!-- 이동 입고 분기 (WAREHOUSE_TRANSFER) — 후속 사이클 -->
+      <div
+        v-else-if="order.inboundType === 'WAREHOUSE_TRANSFER'"
+        class="border border-dashed border-gray-300 bg-gray-50 px-3 py-6 text-center text-xs text-gray-400"
+      >
+        창고간 이동 입고 상세는 outbound 도메인 합류 후 사이클에서 추가됩니다.
+      </div>
+
+      <!-- 진행 이력 타임라인 — 모든 inboundType 공통 -->
+      <section v-if="visibleHistory.length">
+        <p class="mb-2 text-[10px] font-black uppercase text-gray-400">진행 이력</p>
+        <ol class="ml-2">
+          <li
+            v-for="(h, idx) in visibleHistory"
+            :key="idx"
+            class="relative pb-3 pl-5 last:pb-0"
+          >
+            <span class="absolute left-0 top-1 block h-2.5 w-2.5" :class="historyDotClass(h.status)" />
+            <span
+              v-if="idx < visibleHistory.length - 1"
+              class="absolute bottom-0 left-[4px] top-3.5 w-px bg-gray-300"
+            />
+            <p class="text-[11px] font-black" :class="historyTextClass(h.status)">
+              {{ statusLabel(h.status) }}
+            </p>
+            <p class="text-[10px] text-gray-500">{{ formatDate(h.at) }} · {{ h.byName }}</p>
+          </li>
+        </ol>
+      </section>
+    </div>
+
+    <!-- 액션/안내 (상태별 분기) -->
+    <div class="space-y-3 px-4 pb-6 pt-2">
+      <template v-if="order.status === 'READY_TO_SHIP'">
+        <p class="pt-2 text-center text-xs leading-relaxed text-gray-500">
+          공급처에서 배송 준비 중입니다. 배송 시작 시 자동으로 다음 단계로 전환됩니다.
+        </p>
+      </template>
+
+      <template v-else-if="order.status === 'IN_TRANSIT'">
+        <p class="pt-2 text-center text-xs leading-relaxed text-gray-500">
+          배송 중입니다. 도착 시 자동으로 [배송 완료] 단계로 전환됩니다.
+        </p>
+      </template>
+
+      <template v-else-if="order.status === 'ARRIVED'">
+        <button
+          type="button"
+          class="inline-flex w-full items-center justify-center gap-1.5 border border-[#004D3C] bg-[#004D3C] px-2 py-3 text-[11px] font-black text-white hover:bg-[#1f4b3a]"
+          @click="$emit('confirm-inbound')"
+        >
+          <CheckIcon :size="12" />
+          입고 확정
+        </button>
+        <p class="pt-1 text-center text-[11px] leading-relaxed text-gray-400">
+          배송 완료된 발주입니다. [입고 확정] 을 누르면 창고 자산으로 등록됩니다.
+        </p>
+      </template>
+
+      <template v-else-if="order.status === 'COMPLETED'">
+        <p class="pt-2 text-center text-xs text-gray-400">입고 완료된 발주입니다.</p>
+      </template>
+    </div>
+
+    <!-- 하단: 닫기 -->
+    <div class="border-t border-gray-200">
+      <button
+        type="button"
+        class="w-full px-4 py-2.5 text-center text-[11px] font-bold text-gray-500 hover:bg-gray-50"
+        @click="$emit('close')"
+      >
+        닫기 (ESC)
+      </button>
+    </div>
+  </aside>
+</template>

--- a/src/components/warehouse/inbound/icons.js
+++ b/src/components/warehouse/inbound/icons.js
@@ -1,0 +1,50 @@
+import { h } from 'vue'
+
+const IconBase = (paths) => ({
+  props: {
+    size: { type: Number, default: 16 },
+    strokeWidth: { type: Number, default: 2 },
+  },
+  render() {
+    return h(
+      'svg',
+      {
+        width: this.size,
+        height: this.size,
+        viewBox: '0 0 24 24',
+        fill: 'none',
+        stroke: 'currentColor',
+        'stroke-width': this.strokeWidth,
+        'stroke-linecap': 'round',
+        'stroke-linejoin': 'round',
+        'aria-hidden': 'true',
+      },
+      paths.map((p) => h(p.tag, p.attrs)),
+    )
+  },
+})
+
+export const SearchIcon = IconBase([
+  { tag: 'circle', attrs: { cx: '11', cy: '11', r: '7' } },
+  { tag: 'path', attrs: { d: 'm20 20-3.5-3.5' } },
+])
+
+export const XIcon = IconBase([
+  { tag: 'path', attrs: { d: 'M18 6 6 18' } },
+  { tag: 'path', attrs: { d: 'm6 6 12 12' } },
+])
+
+export const InfoIcon = IconBase([
+  { tag: 'circle', attrs: { cx: '12', cy: '12', r: '9' } },
+  { tag: 'path', attrs: { d: 'M12 10v6' } },
+  { tag: 'path', attrs: { d: 'M12 7h.01' } },
+])
+
+export const UserIcon = IconBase([
+  { tag: 'path', attrs: { d: 'M20 21a8 8 0 0 0-16 0' } },
+  { tag: 'circle', attrs: { cx: '12', cy: '8', r: '4' } },
+])
+
+export const CheckIcon = IconBase([
+  { tag: 'polyline', attrs: { points: '20 6 9 17 4 12' } },
+])

--- a/src/composables/warehouse/useWarehouseStatusFormat.js
+++ b/src/composables/warehouse/useWarehouseStatusFormat.js
@@ -1,0 +1,96 @@
+// 창고 시점 발주 상태 라벨/색상 매핑 — COMPLETED = "입고 완료" (본사 화면은 "종료").
+// 발주(HqPurchaseOrderView) 측 useStatusFormat 과 라벨만 다르고 7단계 enum 동일.
+
+const STATUS_BADGE = {
+  REQUESTED: 'bg-amber-50 text-amber-700',
+  APPROVED: 'bg-emerald-50 text-emerald-700',
+  READY_TO_SHIP: 'bg-sky-50 text-sky-700',
+  IN_TRANSIT: 'bg-blue-50 text-blue-600',
+  ARRIVED: 'bg-violet-50 text-violet-700',
+  COMPLETED: 'bg-gray-100 text-gray-500',
+  CANCELLED: 'bg-red-50 text-red-600',
+}
+
+const STATUS_LABEL_WAREHOUSE = {
+  REQUESTED: '승인 대기',
+  APPROVED: '승인 완료',
+  READY_TO_SHIP: '배송 준비 중',
+  IN_TRANSIT: '배송 중',
+  ARRIVED: '배송 완료',
+  COMPLETED: '입고 완료',
+  CANCELLED: '취소',
+}
+
+const HISTORY_DOT = {
+  REQUESTED: 'bg-amber-500',
+  APPROVED: 'bg-emerald-500',
+  READY_TO_SHIP: 'bg-sky-500',
+  IN_TRANSIT: 'bg-blue-500',
+  ARRIVED: 'bg-violet-500',
+  COMPLETED: 'bg-gray-700',
+  CANCELLED: 'bg-red-600',
+}
+
+const HISTORY_TEXT = {
+  REQUESTED: 'text-amber-700',
+  APPROVED: 'text-emerald-700',
+  READY_TO_SHIP: 'text-sky-700',
+  IN_TRANSIT: 'text-blue-600',
+  ARRIVED: 'text-violet-700',
+  COMPLETED: 'text-gray-700',
+  CANCELLED: 'text-red-700',
+}
+
+const INBOUND_TYPE_BADGE = {
+  PURCHASE_ORDER: 'bg-emerald-50 text-emerald-700',
+  WAREHOUSE_TRANSFER: 'bg-indigo-50 text-indigo-700',
+}
+
+const INBOUND_TYPE_LABEL = {
+  PURCHASE_ORDER: '발주',
+  WAREHOUSE_TRANSFER: '이동',
+}
+
+export function useWarehouseStatusFormat() {
+  function statusClass(status) {
+    return STATUS_BADGE[status] ?? 'bg-gray-100 text-gray-500'
+  }
+
+  function statusLabel(status) {
+    return STATUS_LABEL_WAREHOUSE[status] ?? status
+  }
+
+  function historyDotClass(status) {
+    return HISTORY_DOT[status] ?? 'bg-gray-400'
+  }
+
+  function historyTextClass(status) {
+    return HISTORY_TEXT[status] ?? 'text-gray-700'
+  }
+
+  function inboundTypeClass(type) {
+    return INBOUND_TYPE_BADGE[type] ?? 'bg-gray-100 text-gray-500'
+  }
+
+  function inboundTypeLabel(type) {
+    return INBOUND_TYPE_LABEL[type] ?? type ?? '-'
+  }
+
+  function formatDate(iso) {
+    if (!iso) return '-'
+    const d = new Date(iso)
+    if (Number.isNaN(d.getTime())) return '-'
+    const pad = (n) => String(n).padStart(2, '0')
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
+  }
+
+  return {
+    statusClass,
+    statusLabel,
+    historyDotClass,
+    historyTextClass,
+    inboundTypeClass,
+    inboundTypeLabel,
+    formatDate,
+  }
+}

--- a/src/views/warehouse/inbound/WarehouseInboundView.vue
+++ b/src/views/warehouse/inbound/WarehouseInboundView.vue
@@ -1,8 +1,13 @@
 <script setup>
-import { computed, h, onMounted, onUnmounted, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import AppLayout from '@/components/common/AppLayout.vue'
+import WarehouseInboundConfirmModal from '@/components/warehouse/inbound/WarehouseInboundConfirmModal.vue'
+import WarehouseInboundDetailPanel from '@/components/warehouse/inbound/WarehouseInboundDetailPanel.vue'
+import { SearchIcon } from '@/components/warehouse/inbound/icons.js'
 import { roleMenus } from '@/config/roleMenus.js'
+import { useToast } from '@/composables/useToast.js'
+import { useWarehouseStatusFormat } from '@/composables/warehouse/useWarehouseStatusFormat.js'
 import { useAuthStore } from '@/stores/auth.js'
 import { useWarehouseInboundStore } from '@/stores/warehouse/warehouseInbound.js'
 import { useWarehouseStockStore } from '@/stores/warehouse/warehouseStock.js'
@@ -11,6 +16,41 @@ const router = useRouter()
 const auth = useAuthStore()
 const inbound = useWarehouseInboundStore()
 const stockStore = useWarehouseStockStore()
+const { toast, triggerToast } = useToast()
+const { statusClass, statusLabel, inboundTypeClass, inboundTypeLabel, formatDate } =
+  useWarehouseStatusFormat()
+
+// ─── 레이아웃 ────────────────────────────────────────────────────────────────
+const activeSideMenu = ref('입고 관리')
+const topMenus = roleMenus.warehouse
+const sideMenus = roleMenus.warehouse.find((menu) => menu.label === '입/출고 관리')?.children ?? []
+
+function handleLogout() {
+  auth.logout()
+  router.push('/dev-login')
+}
+
+// ─── 상태 탭 ────────────────────────────────────────────────────────────────
+// 5탭 — [전체] + 거래처 책임 4단계 (READY_TO_SHIP 부터 노출). [입고 확정] 은 ARRIVED 일 때만.
+const STATUS_TABS = [
+  { key: '전체', label: '전체' },
+  { key: 'READY_TO_SHIP', label: '배송 준비 중' },
+  { key: 'IN_TRANSIT', label: '배송 중' },
+  { key: 'ARRIVED', label: '입고 예정' },
+  { key: 'COMPLETED', label: '입고 완료' },
+]
+
+function changeTab(key) {
+  inbound.activeStatusTab = key
+  inbound.selectedOrderId = null
+}
+
+function selectOrder(id) {
+  inbound.selectOrder(id)
+}
+
+// ─── 입고 확정 confirm ───────────────────────────────────────────────────────
+const showConfirmInbound = ref(false)
 
 // 입고 확정 시 재고 변화 미리보기 — 선택된 발주의 items 와 warehouseId 로 산출
 const inboundPreview = computed(() => {
@@ -35,53 +75,12 @@ const itemStocks = computed(() => {
   return map
 })
 
-function getItemStock(item) {
-  return itemStocks.value.get(item.id) ?? null
-}
-
-function isItemShortage(item) {
-  const s = getItemStock(item)
-  return !!(s && s.onHand < s.safetyStock)
-}
-
-// ─── 레이아웃 ────────────────────────────────────────────────────────────────
-const activeSideMenu = ref('입고 관리')
-const topMenus = roleMenus.warehouse
-const sideMenus = roleMenus.warehouse.find((menu) => menu.label === '입/출고 관리')?.children ?? []
-
-function handleLogout() {
-  auth.logout()
-  router.push('/dev-login')
-}
-
-// ─── 상태 탭 ────────────────────────────────────────────────────────────────
-// 5탭 — [전체] + 거래처 책임 4단계 (사용자 결정: READY_TO_SHIP 부터 보여야 함).
-// [입고 확정] 액션은 ARRIVED 일 때만 가능.
-const STATUS_TABS = [
-  { key: '전체', label: '전체' },
-  { key: 'READY_TO_SHIP', label: '배송 준비 중' },
-  { key: 'IN_TRANSIT', label: '배송 중' },
-  { key: 'ARRIVED', label: '입고 예정' },
-  { key: 'COMPLETED', label: '입고 완료' },
-]
-
-// 탭 변경 시 선택 클리어 — 좌측 목록과 우측 상세의 컨텍스트 일치 유지
-function changeTab(key) {
-  inbound.activeStatusTab = key
-  inbound.selectedOrderId = null
-}
-
-// ─── 입고 확정 confirm ───────────────────────────────────────────────────────
-const showConfirmInbound = ref(false)
-
 function openConfirmInbound() {
   // ARRIVED(배송 완료, 도착됨) 상태에서만 입고 확정 가능 — markCompleted 검증
   if (inbound.selectedOrder?.status !== 'ARRIVED') return
   showConfirmInbound.value = true
 }
-function cancelConfirmInbound() {
-  showConfirmInbound.value = false
-}
+
 async function confirmInbound() {
   const id = inbound.selectedOrder?.id
   if (!id) return
@@ -94,172 +93,19 @@ async function confirmInbound() {
   }
 }
 
-// ─── 토스트 ─────────────────────────────────────────────────────────────────
-const toast = ref({ show: false, message: '' })
-let toastTimer = null
-function triggerToast(message) {
-  if (toastTimer) clearTimeout(toastTimer)
-  toast.value = { show: true, message }
-  toastTimer = setTimeout(() => {
-    toast.value = { show: false, message: '' }
-  }, 3000)
-}
-
-// ─── 헬퍼 ────────────────────────────────────────────────────────────────────
-function statusClass(status) {
-  const map = {
-    REQUESTED: 'bg-amber-50 text-amber-700',
-    APPROVED: 'bg-emerald-50 text-emerald-700',
-    READY_TO_SHIP: 'bg-sky-50 text-sky-700',
-    IN_TRANSIT: 'bg-blue-50 text-blue-600',
-    ARRIVED: 'bg-violet-50 text-violet-700',
-    COMPLETED: 'bg-gray-100 text-gray-500',
-    CANCELLED: 'bg-red-50 text-red-600',
-  }
-  return map[status] ?? 'bg-gray-100 text-gray-500'
-}
-
-// inboundType 분기 — 발주(emerald) / 이동(indigo)
-function inboundTypeClass(type) {
-  const map = {
-    PURCHASE_ORDER: 'bg-emerald-50 text-emerald-700',
-    WAREHOUSE_TRANSFER: 'bg-indigo-50 text-indigo-700',
-  }
-  return map[type] ?? 'bg-gray-100 text-gray-500'
-}
-
-function inboundTypeLabel(type) {
-  const map = {
-    PURCHASE_ORDER: '발주',
-    WAREHOUSE_TRANSFER: '이동',
-  }
-  return map[type] ?? type ?? '-'
-}
-
-// 창고 화면 시점 라벨 (COMPLETED = "입고 완료", 본사 화면은 "종료")
-function statusLabel(status) {
-  const map = {
-    REQUESTED: '승인 대기',
-    APPROVED: '승인 완료',
-    READY_TO_SHIP: '배송 준비 중',
-    IN_TRANSIT: '배송 중',
-    ARRIVED: '배송 완료',
-    COMPLETED: '입고 완료',
-    CANCELLED: '취소',
-  }
-  return map[status] ?? status
-}
-
-function formatDate(iso) {
-  if (!iso) return '-'
-  const d = new Date(iso)
-  if (Number.isNaN(d.getTime())) return '-'
-  const pad = (n) => String(n).padStart(2, '0')
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
-}
-
-function historyDotClass(status) {
-  const map = {
-    REQUESTED: 'bg-amber-500',
-    APPROVED: 'bg-emerald-500',
-    READY_TO_SHIP: 'bg-sky-500',
-    IN_TRANSIT: 'bg-blue-500',
-    ARRIVED: 'bg-violet-500',
-    COMPLETED: 'bg-gray-700',
-    CANCELLED: 'bg-red-600',
-  }
-  return map[status] ?? 'bg-gray-400'
-}
-
-function historyTextClass(status) {
-  const map = {
-    REQUESTED: 'text-amber-700',
-    APPROVED: 'text-emerald-700',
-    READY_TO_SHIP: 'text-sky-700',
-    IN_TRANSIT: 'text-blue-600',
-    ARRIVED: 'text-violet-700',
-    COMPLETED: 'text-gray-700',
-    CANCELLED: 'text-red-700',
-  }
-  return map[status] ?? 'text-gray-700'
-}
-
-function selectOrder(id) {
-  inbound.selectOrder(id)
-}
-
-// 창고 관점 진행 이력 — 거래처 단계(READY_TO_SHIP/IN_TRANSIT/ARRIVED) + COMPLETED 노출.
-// REQUESTED/APPROVED 는 본사 승인 영역, CANCELLED 는 창고 화면 미노출이라 필터.
-const visibleHistory = computed(() => {
-  const list = inbound.selectedOrder?.statusHistory ?? []
-  return list.filter((h) =>
-    h.status === 'READY_TO_SHIP'
-    || h.status === 'IN_TRANSIT'
-    || h.status === 'ARRIVED'
-    || h.status === 'COMPLETED'
-  )
-})
-
 // ─── ESC 키로 상세 패널 닫기 ────────────────────────────────────────────────
 function handleKeydown(e) {
   if (e.key === 'Escape' && inbound.selectedOrderId) {
     inbound.selectedOrderId = null
   }
 }
+
 // 화면 진입 시 입고 목록 강제 fetch — 다른 화면에서 status 변경됐을 수 있으므로 stale 방지.
 onMounted(() => {
   window.addEventListener('keydown', handleKeydown)
   inbound.fetchAll().catch(() => {})
 })
 onUnmounted(() => window.removeEventListener('keydown', handleKeydown))
-
-// ─── inline SVG 아이콘 ────────────────────────────────────────────────────
-const IconBase = (paths) => ({
-  props: {
-    size: { type: Number, default: 16 },
-    strokeWidth: { type: Number, default: 2 },
-  },
-  render() {
-    return h(
-      'svg',
-      {
-        width: this.size,
-        height: this.size,
-        viewBox: '0 0 24 24',
-        fill: 'none',
-        stroke: 'currentColor',
-        'stroke-width': this.strokeWidth,
-        'stroke-linecap': 'round',
-        'stroke-linejoin': 'round',
-        'aria-hidden': 'true',
-      },
-      paths.map((p) => h(p.tag, p.attrs)),
-    )
-  },
-})
-
-const SearchIcon = IconBase([
-  { tag: 'circle', attrs: { cx: '11', cy: '11', r: '7' } },
-  { tag: 'path', attrs: { d: 'm20 20-3.5-3.5' } },
-])
-
-const XIcon = IconBase([
-  { tag: 'path', attrs: { d: 'M18 6 6 18' } },
-  { tag: 'path', attrs: { d: 'm6 6 12 12' } },
-])
-
-const InfoIcon = IconBase([
-  { tag: 'circle', attrs: { cx: '12', cy: '12', r: '9' } },
-  { tag: 'path', attrs: { d: 'M12 10v6' } },
-  { tag: 'path', attrs: { d: 'M12 7h.01' } },
-])
-
-const UserIcon = IconBase([
-  { tag: 'path', attrs: { d: 'M20 21a8 8 0 0 0-16 0' } },
-  { tag: 'circle', attrs: { cx: '12', cy: '8', r: '4' } },
-])
-
-const CheckIcon = IconBase([{ tag: 'polyline', attrs: { points: '20 6 9 17 4 12' } }])
 </script>
 
 <template>
@@ -307,7 +153,6 @@ const CheckIcon = IconBase([{ tag: 'polyline', attrs: { points: '20 6 9 17 4 12'
         <div
           class="flex min-w-0 flex-1 flex-col overflow-hidden border border-gray-300 bg-white shadow-sm"
         >
-          <!-- 테이블 상단 바: 건수 -->
           <div
             class="flex flex-wrap items-center justify-between gap-2 border-b border-gray-200 bg-white px-3 py-2"
           >
@@ -433,338 +278,25 @@ const CheckIcon = IconBase([{ tag: 'polyline', attrs: { points: '20 6 9 17 4 12'
         </div>
 
         <!-- ── 우측: 입고 상세 패널 (선택 시) ── -->
-        <aside
+        <WarehouseInboundDetailPanel
           v-if="inbound.selectedOrder"
-          class="flex w-full shrink-0 flex-col overflow-hidden border border-gray-300 bg-white shadow-sm xl:w-[420px]"
-        >
-          <!-- 상세 패널 헤더 -->
-          <div class="flex items-center justify-between bg-[#004D3C] px-4 py-3 text-white">
-            <h3
-              class="inline-flex items-center gap-2 text-[11px] font-black uppercase tracking-wider"
-            >
-              <InfoIcon :size="14" />
-              입고 상세
-            </h3>
-            <div class="flex items-center gap-3">
-              <span
-                class="inline-flex px-2 py-1 text-[10px] font-black"
-                :class="statusClass(inbound.selectedOrder.status)"
-              >
-                {{ statusLabel(inbound.selectedOrder.status) }}
-              </span>
-              <button
-                type="button"
-                class="p-1 text-white/80 hover:bg-white/10"
-                aria-label="닫기"
-                @click="inbound.selectedOrderId = null"
-              >
-                <XIcon :size="16" />
-              </button>
-            </div>
-          </div>
-
-          <!-- 상세 내용 -->
-          <div class="flex flex-1 flex-col gap-4 overflow-y-auto p-4">
-            <!-- 기본 정보 (공통) -->
-            <section class="space-y-3">
-              <div class="grid grid-cols-2 gap-3">
-                <div>
-                  <p class="text-[10px] font-bold uppercase text-gray-400">입고번호</p>
-                  <p class="mt-0.5 text-sm font-black text-gray-900">
-                    {{ inbound.selectedOrder.inboundCode }}
-                  </p>
-                </div>
-                <div>
-                  <p class="text-[10px] font-bold uppercase text-gray-400">출처번호</p>
-                  <p class="mt-0.5 text-xs font-black text-gray-700">
-                    {{ inbound.selectedOrder.sourceRefNo }}
-                  </p>
-                </div>
-              </div>
-
-              <div class="grid grid-cols-2 gap-3">
-                <div>
-                  <p class="text-[10px] font-bold uppercase text-gray-400">
-                    {{ inbound.selectedOrder.inboundType === 'WAREHOUSE_TRANSFER' ? '출발 창고' : '공급처' }}
-                  </p>
-                  <p class="mt-0.5 text-xs font-black text-gray-800">
-                    {{ inbound.selectedOrder.sourceName }}
-                  </p>
-                </div>
-                <div>
-                  <p class="text-[10px] font-bold uppercase text-gray-400">입고 창고</p>
-                  <p class="mt-0.5 text-xs font-black text-gray-800">
-                    {{ inbound.selectedOrder.warehouseName }}
-                  </p>
-                </div>
-                <div>
-                  <p
-                    class="inline-flex items-center gap-1 text-[10px] font-bold uppercase text-gray-400"
-                  >
-                    <UserIcon :size="10" />
-                    종류
-                  </p>
-                  <p class="mt-0.5">
-                    <span
-                      class="inline-flex px-2 py-1 text-[10px] font-black"
-                      :class="inboundTypeClass(inbound.selectedOrder.inboundType)"
-                    >
-                      {{ inboundTypeLabel(inbound.selectedOrder.inboundType) }}
-                    </span>
-                  </p>
-                </div>
-                <div>
-                  <p class="text-[10px] font-bold uppercase text-gray-400">생성일시</p>
-                  <p class="mt-0.5 text-xs font-bold text-gray-500">
-                    {{ formatDate(inbound.selectedOrder.createdAt) }}
-                  </p>
-                </div>
-              </div>
-            </section>
-
-            <!-- 발주 입고 분기 (PURCHASE_ORDER) — 품목 테이블 + 단가/소계 -->
-            <template v-if="inbound.selectedOrder.inboundType === 'PURCHASE_ORDER'">
-            <section>
-              <p class="mb-2 text-[10px] font-black uppercase text-gray-400">발주 품목</p>
-              <table class="w-full text-xs">
-                <thead class="bg-gray-100 text-[10px] uppercase text-gray-500">
-                  <tr>
-                    <th class="px-2 py-2 text-left font-black">제품명</th>
-                    <th class="w-10 px-2 py-2 text-right font-black">수량</th>
-                    <th class="w-12 px-2 py-2 text-right font-black">실재고</th>
-                    <th class="w-10 px-2 py-2 text-right font-black">안전</th>
-                    <th class="w-16 px-2 py-2 text-right font-black">단가</th>
-                    <th class="w-16 px-2 py-2 text-right font-black">소계</th>
-                  </tr>
-                </thead>
-                <tbody class="divide-y divide-gray-100">
-                  <tr v-for="item in inbound.selectedOrder.items" :key="item.id">
-                    <td class="px-2 py-2 font-bold text-gray-800">
-                      <div>{{ item.productName }}</div>
-                      <div
-                        v-if="item.displayOption"
-                        class="mt-0.5 text-[10px] font-bold text-[#004D3C]"
-                      >
-                        {{ item.displayOption }}
-                      </div>
-                    </td>
-                    <td class="px-2 py-2 text-right font-bold text-gray-700">
-                      {{ item.quantity }}
-                    </td>
-                    <td
-                      class="px-2 py-2 text-right font-black"
-                      :class="isItemShortage(item) ? 'text-red-600' : 'text-gray-800'"
-                    >
-                      <template v-if="getItemStock(item)">
-                        {{ getItemStock(item).onHand }}
-                      </template>
-                      <span v-else class="text-gray-300">—</span>
-                    </td>
-                    <td class="px-2 py-2 text-right font-bold text-gray-500">
-                      <template v-if="getItemStock(item)">
-                        {{ getItemStock(item).safetyStock }}
-                      </template>
-                      <span v-else class="text-gray-300">—</span>
-                    </td>
-                    <td class="px-2 py-2 text-right text-gray-500">
-                      ₩{{ item.unitPrice.toLocaleString() }}
-                    </td>
-                    <td class="px-2 py-2 text-right font-bold text-gray-700">
-                      ₩{{ item.subtotal.toLocaleString() }}
-                    </td>
-                  </tr>
-                </tbody>
-                <tfoot class="border-t border-gray-300 bg-gray-50 font-black text-gray-900">
-                  <tr>
-                    <td colspan="5" class="px-2 py-2">총계</td>
-                    <td class="px-2 py-2 text-right text-[#004D3C]">
-                      <template v-if="inbound.selectedOrder.totalAmount != null">
-                        ₩{{ inbound.selectedOrder.totalAmount.toLocaleString() }}
-                      </template>
-                      <span v-else class="text-gray-300">—</span>
-                    </td>
-                  </tr>
-                </tfoot>
-              </table>
-            </section>
-            </template>
-
-            <!-- 이동 입고 분기 (WAREHOUSE_TRANSFER) — 후속 사이클 -->
-            <div
-              v-else-if="inbound.selectedOrder.inboundType === 'WAREHOUSE_TRANSFER'"
-              class="border border-dashed border-gray-300 bg-gray-50 px-3 py-6 text-center text-xs text-gray-400"
-            >
-              창고간 이동 입고 상세는 outbound 도메인 합류 후 사이클에서 추가됩니다.
-            </div>
-
-            <!-- 진행 이력 타임라인 — 모든 inboundType 공통 -->
-            <section v-if="visibleHistory.length">
-              <p class="mb-2 text-[10px] font-black uppercase text-gray-400">진행 이력</p>
-              <ol class="ml-2">
-                <li
-                  v-for="(h, idx) in visibleHistory"
-                  :key="idx"
-                  class="relative pb-3 pl-5 last:pb-0"
-                >
-                  <span
-                    class="absolute left-0 top-1 block h-2.5 w-2.5"
-                    :class="historyDotClass(h.status)"
-                  />
-                  <span
-                    v-if="idx < visibleHistory.length - 1"
-                    class="absolute bottom-0 left-[4px] top-3.5 w-px bg-gray-300"
-                  />
-                  <p class="text-[11px] font-black" :class="historyTextClass(h.status)">
-                    {{ statusLabel(h.status) }}
-                  </p>
-                  <p class="text-[10px] text-gray-500">
-                    {{ formatDate(h.at) }} · {{ h.byName }}
-                  </p>
-                </li>
-              </ol>
-            </section>
-          </div>
-
-          <!-- 액션/안내 (상태별 분기) -->
-          <div class="space-y-3 px-4 pb-6 pt-2">
-            <template v-if="inbound.selectedOrder.status === 'READY_TO_SHIP'">
-              <p class="pt-2 text-center text-xs leading-relaxed text-gray-500">
-                공급처에서 배송 준비 중입니다. 배송 시작 시 자동으로 다음 단계로 전환됩니다.
-              </p>
-            </template>
-
-            <template v-else-if="inbound.selectedOrder.status === 'IN_TRANSIT'">
-              <p class="pt-2 text-center text-xs leading-relaxed text-gray-500">
-                배송 중입니다. 도착 시 자동으로 [배송 완료] 단계로 전환됩니다.
-              </p>
-            </template>
-
-            <template v-else-if="inbound.selectedOrder.status === 'ARRIVED'">
-              <button
-                type="button"
-                class="inline-flex w-full items-center justify-center gap-1.5 border border-[#004D3C] bg-[#004D3C] px-2 py-3 text-[11px] font-black text-white hover:bg-[#1f4b3a]"
-                @click="openConfirmInbound"
-              >
-                <CheckIcon :size="12" />
-                입고 확정
-              </button>
-              <p class="pt-1 text-center text-[11px] leading-relaxed text-gray-400">
-                배송 완료된 발주입니다. [입고 확정] 을 누르면 창고 자산으로 등록됩니다.
-              </p>
-            </template>
-
-            <template v-else-if="inbound.selectedOrder.status === 'COMPLETED'">
-              <p class="pt-2 text-center text-xs text-gray-400">입고 완료된 발주입니다.</p>
-            </template>
-          </div>
-
-          <!-- 하단: 닫기 -->
-          <div class="border-t border-gray-200">
-            <button
-              type="button"
-              class="w-full px-4 py-2.5 text-center text-[11px] font-bold text-gray-500 hover:bg-gray-50"
-              @click="inbound.selectedOrderId = null"
-            >
-              닫기 (ESC)
-            </button>
-          </div>
-        </aside>
+          :order="inbound.selectedOrder"
+          :item-stocks="itemStocks"
+          @close="inbound.selectedOrderId = null"
+          @confirm-inbound="openConfirmInbound"
+        />
       </section>
     </div>
 
     <!-- ───────── 모달: 입고 확정 confirm ───────── -->
-    <div
-      v-if="showConfirmInbound && inbound.selectedOrder"
-      class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
-      @click.self="cancelConfirmInbound"
-    >
-      <div class="w-full max-w-lg overflow-hidden bg-white shadow-xl">
-        <div class="bg-[#004D3C] px-5 py-3 text-white">
-          <h2 class="text-sm font-black">입고 확정</h2>
-        </div>
-        <div class="space-y-3 p-5 text-xs text-gray-700">
-          <div>
-            <p class="text-[10px] font-bold uppercase tracking-wider text-gray-400">발주 정보</p>
-            <p class="mt-1">
-              <strong>{{ inbound.selectedOrder.id }}</strong> ·
-              {{ inbound.selectedOrder.vendorName }} ·
-              <span class="font-bold text-[#004D3C]">
-                ₩{{ inbound.selectedOrder.totalPrice.toLocaleString() }}
-              </span>
-            </p>
-          </div>
-
-          <!-- 입고 후 재고 변화 미리보기 -->
-          <div v-if="inboundPreview.length > 0">
-            <p class="text-[10px] font-bold uppercase tracking-wider text-gray-400">
-              입고 후 재고 변화 ({{ inbound.selectedOrder.warehouseName }})
-            </p>
-            <table class="mt-1 w-full table-fixed border-collapse text-[11px]">
-              <thead class="bg-gray-50 text-[9px] uppercase tracking-wider text-gray-500">
-                <tr>
-                  <th class="px-2 py-1.5 text-left font-black">품목</th>
-                  <th class="w-12 px-2 py-1.5 text-right font-black">입고</th>
-                  <th class="w-20 px-2 py-1.5 text-right font-black">실재고</th>
-                  <th class="w-12 px-2 py-1.5 text-right font-black">안전</th>
-                </tr>
-              </thead>
-              <tbody class="divide-y divide-gray-100">
-                <tr v-for="row in inboundPreview" :key="row.productCode">
-                  <td class="truncate px-2 py-1.5 font-bold text-gray-800">
-                    {{ row.productName }}
-                  </td>
-                  <td class="px-2 py-1.5 text-right font-black text-[#004D3C]">
-                    +{{ row.quantity }}
-                  </td>
-                  <td class="px-2 py-1.5 text-right font-bold">
-                    <template v-if="row.before">
-                      <span class="text-gray-400">{{ row.before.onHand }}</span>
-                      <span class="mx-1 text-gray-300">→</span>
-                      <span :class="row.shortageAfter ? 'text-red-600' : 'text-gray-800'">
-                        {{ row.after.onHand }}
-                      </span>
-                    </template>
-                    <span v-else class="text-gray-300">—</span>
-                  </td>
-                  <td class="px-2 py-1.5 text-right font-bold text-gray-500">
-                    <template v-if="row.before">{{ row.before.safetyStock }}</template>
-                    <span v-else class="text-gray-300">—</span>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <p
-              v-if="previewHasShortage"
-              class="mt-2 border border-amber-300 bg-amber-50 px-2 py-1.5 text-[11px] font-bold text-amber-800"
-            >
-              ⚠ 입고 확정 후에도 안전재고 미달 품목이 있습니다 — 추가 발주 검토 필요.
-            </p>
-          </div>
-
-          <p class="pt-1 text-[11px] text-gray-500">
-            창고 자산으로 등록되며 발주 상태가 <strong>입고 완료</strong>로 변경됩니다.
-          </p>
-        </div>
-        <div
-          class="flex items-center justify-end gap-2 border-t border-gray-200 bg-gray-50 px-5 py-3"
-        >
-          <button
-            type="button"
-            class="border border-gray-300 bg-white px-4 py-2 text-xs font-black text-gray-700 hover:bg-gray-100"
-            @click="cancelConfirmInbound"
-          >
-            취소
-          </button>
-          <button
-            type="button"
-            class="border border-[#004D3C] bg-[#004D3C] px-4 py-2 text-xs font-black text-white hover:bg-[#1f4b3a]"
-            @click="confirmInbound"
-          >
-            입고 확정
-          </button>
-        </div>
-      </div>
-    </div>
+    <WarehouseInboundConfirmModal
+      :open="showConfirmInbound"
+      :order="inbound.selectedOrder"
+      :preview="inboundPreview"
+      :has-shortage="previewHasShortage"
+      @cancel="showConfirmInbound = false"
+      @confirm="confirmInbound"
+    />
 
     <!-- ───────── 토스트 ───────── -->
     <Transition


### PR DESCRIPTION
## 📌 요약
- WarehouseInboundView.vue (784줄) 를 책임 단위 child 컴포넌트·composable 로 분리하여 메인 view 를 316줄까지 축소 (-60%).

<br><br>

## 🎯 작업 내용
- `useWarehouseStatusFormat` composable 추출 — 창고 시점 상태 라벨(COMPLETED = 입고 완료) + inboundType 매핑.
- `WarehouseInboundDetailPanel` 컴포넌트 추출 — 우측 상세 (PURCHASE_ORDER 품목 테이블 + WAREHOUSE_TRANSFER placeholder + 진행 이력 + 상태별 액션 분기).
- `WarehouseInboundConfirmModal` 컴포넌트 추출 — 입고 확정 confirm (재고 변화 미리보기 + 안전재고 미달 경고 포함).
- `icons.js` 도메인 전용 SVG 5개(Search/X/Info/User/Check) 추출, 메인 view 의 토스트도 `useToast` composable 로 통일.

<br><br>

## ✔️ 참고 사항
- 

<br><br>

## ✔️ 관련 이슈

- Close #418

<br><br>
