### PR TITLE
refactor(purchase-order): 발주 store BE↔FE 매핑 헬퍼 분리

### DIFF
--- a/src/stores/purchaseOrder.js
+++ b/src/stores/purchaseOrder.js
@@ -3,141 +3,16 @@ import { ref, computed } from 'vue'
 import { purchaseOrderApi } from '@/api/hq/purchaseOrder.js'
 import { getInfrastructures } from '@/api/hq/infrastructure.js'
 import { useAuthStore } from '@/stores/auth.js'
+import {
+  VENDOR_PROCESSING_STATUSES,
+  toBeCreateReq,
+  toBeUpdateReq,
+  toFeCatalogFacet,
+  toFeCatalogMaster,
+  toFeOrder,
+} from '@/stores/purchaseOrder/mappers.js'
 
-// SYS-001 배치가 자동 처리하는 공급처 책임 단계 묶음.
-// 본사 관리자는 액션 불가 — UI 탭에서 하나로 그루핑한다.
-export const VENDOR_PROCESSING_STATUSES = ['APPROVED', 'READY_TO_SHIP', 'IN_TRANSIT', 'ARRIVED']
-
-// ─── BE ↔ FE 매핑 헬퍼 ─────────────────────────────────────────────────────
-// BE (PurchaseOrder DetailRes/ListRes) ↔ FE store 형식 변환.
-// 매핑:
-//   BE code               → FE id
-//   BE vendorCode         → FE vendorId
-//   BE totalAmount        → FE totalPrice
-//   BE items[].vendorProductCode → FE items[].productId
-//   BE statusHistory[].changedAt    → FE statusHistory[].at
-//   BE statusHistory[].changedByName → FE statusHistory[].byName
-// 그 외 필드는 동일 이름 그대로.
-
-function toFeOrder(beOrder) {
-  if (!beOrder) return null
-  // BE ListRes 는 itemCount + productNames, DetailRes 는 items 배열만 보내므로 fallback 처리.
-  const itemCount = beOrder.itemCount ?? (Array.isArray(beOrder.items) ? beOrder.items.length : 0)
-  // ListRes 의 productNames 우선, DetailRes 면 items.productName 으로 fallback (목록 검색·표시 일관성).
-  const productNames = Array.isArray(beOrder.productNames)
-    ? beOrder.productNames
-    : Array.isArray(beOrder.items)
-      ? beOrder.items.map((it) => it.productName).filter(Boolean)
-      : []
-  return {
-    id: beOrder.code,
-    warehouseId: beOrder.warehouseId ?? '',
-    warehouseCode: beOrder.warehouseCode ?? '',
-    warehouseName: beOrder.warehouseName ?? '',
-    vendorId: beOrder.vendorCode,
-    vendorName: beOrder.vendorName ?? '',
-    memberId: beOrder.memberId ?? '',
-    memberName: beOrder.memberName ?? '',
-    status: beOrder.status,
-    totalPrice: beOrder.totalAmount ?? 0,
-    cancelReason: beOrder.cancelReason ?? '',
-    createdAt: beOrder.createdAt ?? '',
-    updatedAt: beOrder.updatedAt ?? '',
-    itemCount,
-    productNames,
-    items: Array.isArray(beOrder.items) ? beOrder.items.map(toFeItem) : [],
-    statusHistory: Array.isArray(beOrder.statusHistory)
-      ? beOrder.statusHistory.map(toFeHistory)
-      : [],
-  }
-}
-
-function toFeItem(beItem) {
-  return {
-    productId: beItem.vendorProductCode,
-    productCode: beItem.productCode,
-    productName: beItem.productName,
-    skuCode: beItem.skuCode ?? '',
-    color: beItem.color ?? '',
-    size: beItem.size ?? '',
-    displayOption: beItem.displayOption ?? [beItem.color, beItem.size].filter(Boolean).join('/'),
-    quantity: beItem.quantity,
-    unitPrice: beItem.unitPrice,
-    subtotal: beItem.subtotal,
-  }
-}
-
-function toFeHistory(beHistory) {
-  return {
-    status: beHistory.status,
-    at: beHistory.changedAt ?? '',
-    byName: beHistory.changedByName ?? '',
-    note: beHistory.note ?? '',
-  }
-}
-
-// ─── 카탈로그 매핑 헬퍼 (BE → FE) ────────────────────────────────────────
-// BE 키 ↔ FE 키 동일 유지 (이름 변환 0). 각 SKU 행에 그룹 컨텍스트 첨부해서
-// view 가 그룹 lookup 없이 자체 표시 가능하게.
-
-function toFeCatalogMaster(beMaster) {
-  return {
-    masterKey: beMaster.vendorProductCode,
-    vendorCode: beMaster.vendorCode,
-    vendorName: beMaster.vendorName,
-    vendorProductCode: beMaster.vendorProductCode,
-    productCode: beMaster.productCode,
-    productName: beMaster.productName,
-    contractUnitPrice: beMaster.contractUnitPrice,
-    minSkuUnitPrice: beMaster.minSkuUnitPrice,
-    maxSkuUnitPrice: beMaster.maxSkuUnitPrice,
-    skus: Array.isArray(beMaster.skus)
-      ? beMaster.skus.map((s) => ({
-          skuCode: s.skuCode,
-          color: s.color ?? '',
-          size: s.size ?? '',
-          displayOption: s.displayOption ?? [s.color, s.size].filter(Boolean).join('/'),
-          unitPrice: s.unitPrice,
-        }))
-      : [],
-  }
-}
-
-function toFeCatalogFacet(beFacet) {
-  return {
-    name: beFacet.name,
-    values: Array.isArray(beFacet.values) ? [...beFacet.values] : [],
-  }
-}
-
-// FE createOrder/updateOrder payload → BE 요청 변환
-// warehouseCode: vendor 패턴 일관 — code 로 식별, BE 가 findByCode 후 Long ID 박음.
-// warehouseName 은 BE 가 lookupWarehouse 후 자동 박음 — FE 가 안 보냄.
-// items: SKU 단위 — skuCode 필수.
-function toBeCreateReq({ vendorId, warehouseCode, memberId, memberName, items }) {
-  return {
-    vendorCode: vendorId,
-    warehouseCode: warehouseCode ?? '',
-    memberId: memberId ?? '',
-    memberName: memberName ?? '',
-    items: items.map((item) => ({
-      vendorProductCode: item.productId,
-      skuCode: item.skuCode,
-      quantity: item.quantity,
-    })),
-  }
-}
-
-function toBeUpdateReq({ warehouseCode, items }) {
-  return {
-    warehouseCode: warehouseCode ?? '',
-    items: items.map((item) => ({
-      vendorProductCode: item.productId,
-      skuCode: item.skuCode,
-      quantity: item.quantity,
-    })),
-  }
-}
+export { VENDOR_PROCESSING_STATUSES }
 
 export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
   // --- 상태(state) ---

--- a/src/stores/purchaseOrder/mappers.js
+++ b/src/stores/purchaseOrder/mappers.js
@@ -1,0 +1,139 @@
+// 본사 발주 store BE ↔ FE 변환 레이어.
+// store 본체(`stores/purchaseOrder.js`) 의 state/getter/action 흐름과 분리해서
+// BE 컨트랙트(PurchaseOrder DetailRes/ListRes/CatalogRes) 매핑 규칙을 한 곳에 모은다.
+//
+// 매핑:
+//   BE code               → FE id
+//   BE vendorCode         → FE vendorId
+//   BE totalAmount        → FE totalPrice
+//   BE items[].vendorProductCode      → FE items[].productId
+//   BE statusHistory[].changedAt      → FE statusHistory[].at
+//   BE statusHistory[].changedByName  → FE statusHistory[].byName
+// 그 외 필드는 동일 이름 그대로.
+
+// SYS-001 배치가 자동 처리하는 공급처 책임 단계 묶음.
+// 본사 관리자는 액션 불가 — UI 탭에서 하나로 그루핑한다.
+export const VENDOR_PROCESSING_STATUSES = ['APPROVED', 'READY_TO_SHIP', 'IN_TRANSIT', 'ARRIVED']
+
+// ─── BE → FE (DetailRes/ListRes) ────────────────────────────────────────────
+
+export function toFeOrder(beOrder) {
+  if (!beOrder) return null
+  // BE ListRes 는 itemCount + productNames, DetailRes 는 items 배열만 보내므로 fallback 처리.
+  const itemCount = beOrder.itemCount ?? (Array.isArray(beOrder.items) ? beOrder.items.length : 0)
+  // ListRes 의 productNames 우선, DetailRes 면 items.productName 으로 fallback (목록 검색·표시 일관성).
+  const productNames = Array.isArray(beOrder.productNames)
+    ? beOrder.productNames
+    : Array.isArray(beOrder.items)
+      ? beOrder.items.map((it) => it.productName).filter(Boolean)
+      : []
+  return {
+    id: beOrder.code,
+    warehouseId: beOrder.warehouseId ?? '',
+    warehouseCode: beOrder.warehouseCode ?? '',
+    warehouseName: beOrder.warehouseName ?? '',
+    vendorId: beOrder.vendorCode,
+    vendorName: beOrder.vendorName ?? '',
+    memberId: beOrder.memberId ?? '',
+    memberName: beOrder.memberName ?? '',
+    status: beOrder.status,
+    totalPrice: beOrder.totalAmount ?? 0,
+    cancelReason: beOrder.cancelReason ?? '',
+    createdAt: beOrder.createdAt ?? '',
+    updatedAt: beOrder.updatedAt ?? '',
+    itemCount,
+    productNames,
+    items: Array.isArray(beOrder.items) ? beOrder.items.map(toFeItem) : [],
+    statusHistory: Array.isArray(beOrder.statusHistory)
+      ? beOrder.statusHistory.map(toFeHistory)
+      : [],
+  }
+}
+
+export function toFeItem(beItem) {
+  return {
+    productId: beItem.vendorProductCode,
+    productCode: beItem.productCode,
+    productName: beItem.productName,
+    skuCode: beItem.skuCode ?? '',
+    color: beItem.color ?? '',
+    size: beItem.size ?? '',
+    displayOption: beItem.displayOption ?? [beItem.color, beItem.size].filter(Boolean).join('/'),
+    quantity: beItem.quantity,
+    unitPrice: beItem.unitPrice,
+    subtotal: beItem.subtotal,
+  }
+}
+
+export function toFeHistory(beHistory) {
+  return {
+    status: beHistory.status,
+    at: beHistory.changedAt ?? '',
+    byName: beHistory.changedByName ?? '',
+    note: beHistory.note ?? '',
+  }
+}
+
+// ─── BE → FE (CatalogRes) ──────────────────────────────────────────────────
+// BE 키 ↔ FE 키 동일 유지 (이름 변환 0). 각 SKU 행에 그룹 컨텍스트 첨부해서
+// view 가 그룹 lookup 없이 자체 표시 가능하게.
+
+export function toFeCatalogMaster(beMaster) {
+  return {
+    masterKey: beMaster.vendorProductCode,
+    vendorCode: beMaster.vendorCode,
+    vendorName: beMaster.vendorName,
+    vendorProductCode: beMaster.vendorProductCode,
+    productCode: beMaster.productCode,
+    productName: beMaster.productName,
+    contractUnitPrice: beMaster.contractUnitPrice,
+    minSkuUnitPrice: beMaster.minSkuUnitPrice,
+    maxSkuUnitPrice: beMaster.maxSkuUnitPrice,
+    skus: Array.isArray(beMaster.skus)
+      ? beMaster.skus.map((s) => ({
+          skuCode: s.skuCode,
+          color: s.color ?? '',
+          size: s.size ?? '',
+          displayOption: s.displayOption ?? [s.color, s.size].filter(Boolean).join('/'),
+          unitPrice: s.unitPrice,
+        }))
+      : [],
+  }
+}
+
+export function toFeCatalogFacet(beFacet) {
+  return {
+    name: beFacet.name,
+    values: Array.isArray(beFacet.values) ? [...beFacet.values] : [],
+  }
+}
+
+// ─── FE → BE (Create/Update Req) ────────────────────────────────────────────
+// warehouseCode: vendor 패턴 일관 — code 로 식별, BE 가 findByCode 후 Long ID 박음.
+// warehouseName 은 BE 가 lookupWarehouse 후 자동 박음 — FE 가 안 보냄.
+// items: SKU 단위 — skuCode 필수.
+
+export function toBeCreateReq({ vendorId, warehouseCode, memberId, memberName, items }) {
+  return {
+    vendorCode: vendorId,
+    warehouseCode: warehouseCode ?? '',
+    memberId: memberId ?? '',
+    memberName: memberName ?? '',
+    items: items.map((item) => ({
+      vendorProductCode: item.productId,
+      skuCode: item.skuCode,
+      quantity: item.quantity,
+    })),
+  }
+}
+
+export function toBeUpdateReq({ warehouseCode, items }) {
+  return {
+    warehouseCode: warehouseCode ?? '',
+    items: items.map((item) => ({
+      vendorProductCode: item.productId,
+      skuCode: item.skuCode,
+      quantity: item.quantity,
+    })),
+  }
+}


### PR DESCRIPTION
## 📌 요약
- stores/purchaseOrder.js (506줄) 의 BE↔FE 매핑 헬퍼를 별 모듈로 추출하여 메인 store 를 381줄까지 축소.

<br><br>

## 🎯 작업 내용
- `stores/purchaseOrder/mappers.js` 신설 — BE→FE 변환 5개(toFeOrder/toFeItem/toFeHistory/toFeCatalogMaster/toFeCatalogFacet) + FE→BE 변환 2개(toBeCreateReq/toBeUpdateReq) + VENDOR_PROCESSING_STATUSES 상수 이동.
- 메인 store 는 매핑 모듈을 import 후 state/getter/action 만 남김 — 506 → 381줄.
- 호출처(views/components 3곳) import 경로 변경 없음 — 외부 surface(`@/stores/purchaseOrder.js`) 그대로 유지.

<br><br>

## ✔️ 참고 사항
- 

<br><br>

## ✔️ 관련 이슈

- Close #421

<br><br>
