### PR TITLE
feat: 순환 재고 조회 페이지 페이징 처리

### DIFF
--- a/src/api/hq/inventory.js
+++ b/src/api/hq/inventory.js
@@ -20,8 +20,8 @@ export async function getCircularCandidates() {
   return unwrap(res)
 }
 
-export async function getCircularInventories() {
-  const res = await api.get('/api/hq/inventories/circular')
+export async function getCircularInventories(params = {}) {
+  const res = await api.get('/api/hq/inventories/circular', { params })
   return unwrap(res)
 }
 

--- a/src/api/hq/inventory.js
+++ b/src/api/hq/inventory.js
@@ -15,8 +15,8 @@ export async function refreshCircularCandidates() {
   return unwrap(res)
 }
 
-export async function getCircularCandidates() {
-  const res = await api.get('/api/hq/inventories/circular-candidates')
+export async function getCircularCandidates(params = {}) {
+  const res = await api.get('/api/hq/inventories/circular-candidates', { params })
   return unwrap(res)
 }
 

--- a/src/components/hq/circular-stock/CircularStockInventoryBrowseSection.vue
+++ b/src/components/hq/circular-stock/CircularStockInventoryBrowseSection.vue
@@ -44,13 +44,33 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  serverMode: {
+    type: Boolean,
+    default: false,
+  },
+  page: {
+    type: Number,
+    default: 0,
+  },
+  size: {
+    type: Number,
+    default: 20,
+  },
+  totalPages: {
+    type: Number,
+    default: 0,
+  },
+  totalElements: {
+    type: Number,
+    default: 0,
+  },
   inventoryRows: {
     type: Array,
     default: () => [],
   },
 })
 
-const emit = defineEmits(['row-click', 'toggle-all-visible'])
+const emit = defineEmits(['row-click', 'toggle-all-visible', 'query-change', 'page-change', 'size-change', 'sort-change'])
 const slots = useSlots()
 
 const searchTerm = ref('')
@@ -122,6 +142,16 @@ const warehouseSummaryLabel = computed(() => {
   if (selectedWarehouseCodes.value.length === 0) return '전체 창고'
   if (selectedWarehouseCodes.value.length === 1) return selectedWarehouseNames.value[0]
   return `${selectedWarehouseCodes.value.length}개 창고 선택됨`
+})
+
+const pageSizeOptions = [20, 50, 100]
+const pageNumbers = computed(() => {
+  if (!props.serverMode || props.totalPages <= 0) return []
+  const current = props.page + 1
+  const start = Math.max(1, current - 2)
+  const end = Math.min(props.totalPages, start + 4)
+  const adjustedStart = Math.max(1, end - 4)
+  return Array.from({ length: end - adjustedStart + 1 }, (_, idx) => adjustedStart + idx)
 })
 
 const normalizedInventoryData = computed(() =>
@@ -220,6 +250,8 @@ const filteredRowsBase = computed(() => {
 })
 
 const filteredRows = computed(() => {
+  if (props.serverMode) return filteredRowsBase.value
+
   const rows = [...filteredRowsBase.value]
   if (!sortKey.value) return rows
 
@@ -348,14 +380,17 @@ function addMaterialFilter() {
   const maxFilterCount = materialGroupOptions.length + materialOptions.length
   if (materialFilters.value.length >= maxFilterCount) return
   materialFilters.value = [...materialFilters.value, { materialGroup: '', material: '', minRatio: '' }]
+  emitQueryChange()
 }
 
 function removeMaterialFilter(index) {
   materialFilters.value = materialFilters.value.filter((_, filterIndex) => filterIndex !== index)
+  emitQueryChange()
 }
 
 function clearMaterialFilters() {
   materialFilters.value = []
+  emitQueryChange()
 }
 
 function toggleWarehouseDropdown() {
@@ -366,13 +401,23 @@ function toggleWarehouseCode(code) {
   selectedWarehouseCodes.value = selectedWarehouseCodes.value.includes(code)
     ? selectedWarehouseCodes.value.filter(value => value !== code)
     : [...selectedWarehouseCodes.value, code]
+  emitQueryChange()
 }
 
 function clearWarehouseCodes() {
   selectedWarehouseCodes.value = []
+  emitQueryChange()
 }
 
 function toggleSort(key) {
+  if (props.serverMode) {
+    const nextDirection = sortKey.value === key && sortDirection.value === 'asc' ? 'desc' : 'asc'
+    sortKey.value = key
+    sortDirection.value = nextDirection
+    emit('sort-change', { sort: `${key},${nextDirection}` })
+    return
+  }
+
   if (sortKey.value === key) {
     sortDirection.value = sortDirection.value === 'asc' ? 'desc' : 'asc'
     return
@@ -393,6 +438,15 @@ function resetFilters() {
   selectedWarehouseCodes.value = []
   isMaterialDropdownOpen.value = false
   isWarehouseDropdownOpen.value = false
+  if (props.serverMode) {
+    emit('query-change', {
+      keyword: '',
+      warehouseCodes: [],
+      materialGroup: '',
+      materialName: '',
+      minRatio: 0,
+    })
+  }
 }
 
 function handleDocumentClick(event) {
@@ -431,6 +485,25 @@ onMounted(() => {
 onBeforeUnmount(() => {
   document.removeEventListener('mousedown', handleDocumentClick)
 })
+
+function emitQueryChange() {
+  if (!props.serverMode) return
+  const first = activeMaterialFilters.value[0] ?? { materialGroup: '', material: '', minRatio: 0 }
+  emit('query-change', {
+    keyword: searchTerm.value.trim(),
+    warehouseCodes: [...selectedWarehouseCodes.value],
+    materialGroup: first.materialGroup || '',
+    materialName: first.material || '',
+    minRatio: Number(first.minRatio) || 0,
+  })
+}
+
+function goToPage(pageNumber) {
+  if (!props.serverMode) return
+  const nextPage = Math.max(0, pageNumber)
+  if (nextPage === props.page) return
+  emit('page-change', nextPage)
+}
 </script>
 
 <template>
@@ -481,7 +554,7 @@ onBeforeUnmount(() => {
                 <select
                   v-model="filter.materialGroup"
                   class="h-8 border border-gray-200 bg-gray-50 px-2 text-[11px] font-bold text-gray-900 outline-none focus:border-[#004D3C] focus:bg-white"
-                  @change="filter.material = ''"
+                  @change="filter.material = ''; emitQueryChange()"
                 >
                   <option value="">소재 구분 선택</option>
                   <option v-for="group in materialGroupOptions" :key="group" :value="group">
@@ -493,6 +566,7 @@ onBeforeUnmount(() => {
                   v-model="filter.material"
                   class="h-8 border border-gray-200 bg-gray-50 px-2 text-[11px] font-bold text-gray-900 outline-none focus:border-[#004D3C] focus:bg-white"
                   :disabled="!filter.materialGroup"
+                  @change="emitQueryChange"
                 >
                   <option value="">소재 상세 선택</option>
                   <option
@@ -512,6 +586,7 @@ onBeforeUnmount(() => {
                   max="100"
                   class="h-8 border border-gray-200 bg-gray-50 px-2 text-right text-[11px] font-bold text-gray-900 outline-none focus:border-[#004D3C] focus:bg-white"
                   placeholder="0"
+                  @change="emitQueryChange"
                 />
                 <span class="text-[10px] font-black text-gray-400">% 이상</span>
                 <button
@@ -591,6 +666,8 @@ onBeforeUnmount(() => {
             type="search"
             class="h-9 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none placeholder:text-gray-400 focus:border-[#004D3C]"
             placeholder="품목 코드, 품목명, 소재 상세"
+            @keyup.enter="emitQueryChange"
+            @change="emitQueryChange"
           />
         </label>
 
@@ -610,7 +687,12 @@ onBeforeUnmount(() => {
           <h2 class="text-sm font-black text-gray-900">{{ title }}</h2>
           <p v-if="description" class="mt-1 text-[11px] font-bold text-gray-400">{{ description }}</p>
           <p class="mt-1 text-[11px] font-bold text-gray-400">
-            조회 품목 {{ filteredItemCount.toLocaleString() }}건 · 조회 SKU {{ filteredRows.length.toLocaleString() }}건
+            <template v-if="serverMode">
+              전체 SKU {{ totalElements.toLocaleString() }}건 · 현재 페이지 {{ filteredRows.length.toLocaleString() }}건
+            </template>
+            <template v-else>
+              조회 품목 {{ filteredItemCount.toLocaleString() }}건 · 조회 SKU {{ filteredRows.length.toLocaleString() }}건
+            </template>
             <template v-if="summaryText"> · {{ summaryText }}</template>
           </p>
         </div>
@@ -773,6 +855,51 @@ onBeforeUnmount(() => {
             </tr>
           </tbody>
         </table>
+      </div>
+
+      <div
+        v-if="serverMode"
+        class="flex flex-wrap items-center justify-between gap-3 border-t border-gray-100 px-4 py-3"
+      >
+        <div class="flex items-center gap-2 text-xs font-bold text-gray-600">
+          <span>페이지 크기</span>
+          <select
+            :value="size"
+            class="h-8 border border-gray-300 bg-white px-2 text-xs font-bold text-gray-900 outline-none focus:border-[#004D3C]"
+            @change="emit('size-change', Number($event.target.value))"
+          >
+            <option v-for="opt in pageSizeOptions" :key="opt" :value="opt">{{ opt }}</option>
+          </select>
+        </div>
+
+        <div class="flex items-center gap-1">
+          <button
+            type="button"
+            class="h-8 border border-gray-300 px-3 text-xs font-bold text-gray-700 disabled:cursor-not-allowed disabled:opacity-40"
+            :disabled="page <= 0"
+            @click="goToPage(page - 1)"
+          >
+            이전
+          </button>
+          <button
+            v-for="num in pageNumbers"
+            :key="num"
+            type="button"
+            class="h-8 min-w-8 border px-2 text-xs font-bold"
+            :class="num - 1 === page ? 'border-[#004D3C] bg-[#004D3C] text-white' : 'border-gray-300 text-gray-700'"
+            @click="goToPage(num - 1)"
+          >
+            {{ num }}
+          </button>
+          <button
+            type="button"
+            class="h-8 border border-gray-300 px-3 text-xs font-bold text-gray-700 disabled:cursor-not-allowed disabled:opacity-40"
+            :disabled="page >= totalPages - 1"
+            @click="goToPage(page + 1)"
+          >
+            다음
+          </button>
+        </div>
       </div>
     </section>
   </div>

--- a/src/stores/hq/circularStock/circularStock.js
+++ b/src/stores/hq/circularStock/circularStock.js
@@ -457,6 +457,18 @@ export const useCircularStockStore = defineStore('circularStock', () => {
   const saleStep = ref(1)
   const lockedMaterialType = ref('')
   const liveCircularInventoryRows = ref([])
+  const inventoryPage = ref(0)
+  const inventorySize = ref(20)
+  const inventoryTotalPages = ref(0)
+  const inventoryTotalElements = ref(0)
+  const inventoryHasNext = ref(false)
+  const inventoryHasPrevious = ref(false)
+  const inventorySort = ref('skuCode,asc')
+  const inventoryKeyword = ref('')
+  const inventoryWarehouseCodes = ref([])
+  const inventoryMaterialGroup = ref('')
+  const inventoryMaterialName = ref('')
+  const inventoryMinRatio = ref(0)
 
   // ADR-021 AI 거래처 추천 — Step 1 → Step 2 [다음] 클릭 시 1회 호출 (사용자 결정 2026-04-30).
   const recommendations = ref([])
@@ -631,13 +643,57 @@ export const useCircularStockStore = defineStore('circularStock', () => {
     }
   }
 
-  async function loadCircularInventoryRows() {
-    const rows = await getCircularInventories()
-    const mapped = Array.isArray(rows) ? rows.map(mapCircularApiRowToInventoryItem) : []
+  async function loadCircularInventoryRows(overrides = {}) {
+    const nextPage = Number.isInteger(overrides.page) ? overrides.page : inventoryPage.value
+    const nextSize = [20, 50, 100].includes(Number(overrides.size)) ? Number(overrides.size) : inventorySize.value
+    const nextSort = String((overrides.sort ?? inventorySort.value) || 'skuCode,asc')
+    const nextKeyword = String((overrides.keyword ?? inventoryKeyword.value) || '').trim()
+    const nextWarehouseCodes = Array.isArray(overrides.warehouseCodes)
+      ? overrides.warehouseCodes
+      : inventoryWarehouseCodes.value
+    const nextMaterialGroup = String((overrides.materialGroup ?? inventoryMaterialGroup.value) || '').trim()
+    const nextMaterialName = String((overrides.materialName ?? inventoryMaterialName.value) || '').trim()
+    const nextMinRatio = Number((overrides.minRatio ?? inventoryMinRatio.value) || 0)
+
+    const response = await getCircularInventories({
+      page: Math.max(0, Number(nextPage) || 0),
+      size: nextSize,
+      sort: nextSort,
+      keyword: nextKeyword || undefined,
+      warehouseCodes: nextWarehouseCodes.length > 0 ? nextWarehouseCodes : undefined,
+      materialGroup: nextMaterialGroup || undefined,
+      materialName: nextMaterialName || undefined,
+      minRatio: nextMaterialName ? Math.max(0, nextMinRatio) : undefined,
+    })
+
+    const rows = Array.isArray(response?.content) ? response.content : []
+    const mapped = rows.map(mapCircularApiRowToInventoryItem)
+
+    inventoryPage.value = Number(response?.page ?? 0)
+    inventorySize.value = Number(response?.size ?? nextSize)
+    inventoryTotalPages.value = Number(response?.totalPages ?? 0)
+    inventoryTotalElements.value = Number(response?.totalElements ?? 0)
+    inventoryHasNext.value = Boolean(response?.hasNext)
+    inventoryHasPrevious.value = Boolean(response?.hasPrevious)
+    inventorySort.value = nextSort
+    inventoryKeyword.value = nextKeyword
+    inventoryWarehouseCodes.value = [...nextWarehouseCodes]
+    inventoryMaterialGroup.value = nextMaterialGroup
+    inventoryMaterialName.value = nextMaterialName
+    inventoryMinRatio.value = Math.max(0, nextMinRatio)
+
     liveCircularInventoryRows.value = mapped
     inventoryItems.value = mapped.map(enrichInventoryItem)
     persistInventory()
-    return mapped
+    return {
+      rows: mapped,
+      page: inventoryPage.value,
+      size: inventorySize.value,
+      totalPages: inventoryTotalPages.value,
+      totalElements: inventoryTotalElements.value,
+      hasNext: inventoryHasNext.value,
+      hasPrevious: inventoryHasPrevious.value,
+    }
   }
 
   function getSaleById(saleId) {
@@ -980,6 +1036,18 @@ export const useCircularStockStore = defineStore('circularStock', () => {
 
   return {
     inventoryRows,
+    inventoryPage,
+    inventorySize,
+    inventoryTotalPages,
+    inventoryTotalElements,
+    inventoryHasNext,
+    inventoryHasPrevious,
+    inventorySort,
+    inventoryKeyword,
+    inventoryWarehouseCodes,
+    inventoryMaterialGroup,
+    inventoryMaterialName,
+    inventoryMinRatio,
     sortedSales,
     draftBuyerId,
     draftMemo,

--- a/src/views/hq/circular-stock/HqCircularStockCandidateView.vue
+++ b/src/views/hq/circular-stock/HqCircularStockCandidateView.vue
@@ -39,6 +39,7 @@ const totalPages = ref(1)
 const totalElements = ref(0)
 const sortKey = ref('convertibleStock')
 const sortDirection = ref('desc')
+const isBulkUpdatingFilters = ref(false)
 
 const conditionItems = [
   '최근 24개월 이상 판매 이력이 없는 SKU',
@@ -202,9 +203,8 @@ watch(selectedParentCategory, () => {
 })
 
 watch([selectedParentCategory, selectedChildCategory, selectedWarehouseCodes, selectedConditionCodes], () => {
-  if (!hasRefreshed.value) return
-  currentPage.value = 1
-  loadCandidates()
+  if (!hasRefreshed.value || isBulkUpdatingFilters.value) return
+  requestCandidates({ resetPage: true })
 }, { deep: true })
 
 const buildCandidateQueryParams = () => ({
@@ -250,16 +250,14 @@ const clearConditionCodes = () => {
 
 const applySearch = () => {
   if (!hasRefreshed.value) return
-  currentPage.value = 1
-  loadCandidates()
+  requestCandidates({ resetPage: true })
 }
 
-const changePageSize = async (value) => {
+const changePageSize = (value) => {
   const next = Number(value)
   if (!PAGE_SIZE_OPTIONS.includes(next)) return
   pageSize.value = next
-  currentPage.value = 1
-  await loadCandidates()
+  requestCandidates({ resetPage: true })
 }
 
 const handleDocumentClick = (event) => {
@@ -309,12 +307,17 @@ const loadCandidates = async () => {
   }
 }
 
+const requestCandidates = async ({ resetPage = false } = {}) => {
+  if (resetPage) currentPage.value = 1
+  await loadCandidates()
+}
+
 const refreshCandidates = async () => {
   isLoading.value = true
   loadError.value = ''
   try {
     await refreshCircularCandidates()
-    await loadCandidates()
+    isBulkUpdatingFilters.value = true
     selectedRowIds.value = []
     selectedParentCategory.value = ''
     selectedChildCategory.value = ''
@@ -326,8 +329,11 @@ const refreshCandidates = async () => {
     sortKey.value = 'convertibleStock'
     sortDirection.value = 'desc'
     selectedRowsSnapshot.value = []
+    isBulkUpdatingFilters.value = false
+    await requestCandidates()
   } catch (e) {
     loadError.value = e.message || '순환 재고 후보 갱신에 실패했습니다.'
+    isBulkUpdatingFilters.value = false
   } finally {
     isLoading.value = false
   }
@@ -364,7 +370,7 @@ const submitConversion = async () => {
       ? `부분 전환 완료: 성공 ${convertedCount}건, 실패 ${skippedCount}건`
       : `전환 완료: ${convertedCount}건`
 
-    await loadCandidates()
+    await requestCandidates()
     selectedRowIds.value = []
     selectedRowsSnapshot.value = []
     conversionInputs.value = {}
@@ -383,9 +389,7 @@ const toggleSort = (key) => {
     sortKey.value = key
     sortDirection.value = 'asc'
   }
-
-  currentPage.value = 1
-  loadCandidates()
+  requestCandidates({ resetPage: true })
 }
 
 const sortIcon = (key) => {
@@ -410,7 +414,7 @@ const toggleAllCurrentPage = () => {
 const goToPage = (page) => {
   if (page < 1 || page > totalPages.value) return
   currentPage.value = page
-  loadCandidates()
+  requestCandidates()
 }
 
 

--- a/src/views/hq/circular-stock/HqCircularStockCandidateView.vue
+++ b/src/views/hq/circular-stock/HqCircularStockCandidateView.vue
@@ -34,8 +34,11 @@ const isConvertModalOpen = ref(false)
 const isConverting = ref(false)
 const conversionInputs = ref({})
 
-const PAGE_SIZE = 20
+const PAGE_SIZE_OPTIONS = [20, 50, 100]
+const pageSize = ref(20)
 const currentPage = ref(1)
+const totalPages = ref(1)
+const totalElements = ref(0)
 const sortKey = ref('convertibleStock')
 const sortDirection = ref('desc')
 
@@ -126,68 +129,13 @@ const childCategoryOptions = computed(() => {
   )].sort((a, b) => a.localeCompare(b, 'ko'))
 })
 
-const filteredSkus = computed(() => {
-  const keyword = searchTerm.value.trim().toLowerCase()
-
-  return candidateSkus.value.filter((row) => {
-    const { parentCategory, childCategory } = parseCategory(row.category)
-    const matchesParentCategory = !selectedParentCategory.value || parentCategory === selectedParentCategory.value
-    const matchesChildCategory = !selectedChildCategory.value || childCategory === selectedChildCategory.value
-    const matchesWarehouse = selectedWarehouseCodes.value.length === 0
-      || selectedWarehouseCodes.value.includes(row.warehouseCode)
-    const matchesCondition = selectedConditionCodes.value.length === 0
-      || selectedConditionCodes.value.every(code => row.matchedConditionIndexes.includes(Number(code)))
-    const matchesKeyword = !keyword
-      || [row.skuCode, row.itemCode, row.itemName].join(' ').toLowerCase().includes(keyword)
-
-    return matchesParentCategory && matchesChildCategory && matchesWarehouse && matchesCondition && matchesKeyword
-  })
-})
-
-const sortedSkus = computed(() => {
-  const rows = [...filteredSkus.value]
-  const direction = sortDirection.value === 'asc' ? 1 : -1
-
-  const getComparable = (row) => {
-    switch (sortKey.value) {
-      case 'skuCode':
-        return row.skuCode
-      case 'availableStock':
-        return row.availableStock
-      case 'convertibleStock':
-        return row.convertibleStock
-      case 'updatedAt':
-        return row.updatedAt
-      default:
-        return row.convertibleStock
-    }
-  }
-
-  rows.sort((a, b) => {
-    const aValue = getComparable(a)
-    const bValue = getComparable(b)
-
-    if (typeof aValue === 'string' && typeof bValue === 'string') {
-      return aValue.localeCompare(bValue, 'ko') * direction
-    }
-
-    return (aValue - bValue) * direction
-  })
-
-  return rows
-})
-
-const totalPages = computed(() => Math.max(1, Math.ceil(sortedSkus.value.length / PAGE_SIZE)))
-
-const paginatedSkus = computed(() => {
-  const start = (currentPage.value - 1) * PAGE_SIZE
-  return sortedSkus.value.slice(start, start + PAGE_SIZE)
-})
+const sortedSkus = computed(() => candidateSkus.value)
+const paginatedSkus = computed(() => sortedSkus.value)
 
 const canConvertInventory = computed(() => selectedRowIds.value.length > 0)
 const selectedRows = computed(() => {
   const selectedSet = new Set(selectedRowIds.value)
-  return candidateSkus.value.filter(row => selectedSet.has(row.id))
+  return selectedRowsSnapshot.value.filter(row => selectedSet.has(row.id))
 })
 
 const conversionRows = computed(() =>
@@ -223,19 +171,55 @@ const isAllCurrentPageSelected = computed(() =>
   && paginatedSkus.value.every(row => selectedRowIds.value.includes(row.id)),
 )
 
-const rangeStart = computed(() => (sortedSkus.value.length === 0 ? 0 : (currentPage.value - 1) * PAGE_SIZE + 1))
-const rangeEnd = computed(() => Math.min(currentPage.value * PAGE_SIZE, sortedSkus.value.length))
-
-watch(totalPages, (pageCount) => {
-  if (currentPage.value > pageCount) currentPage.value = pageCount
+const rangeStart = computed(() => {
+  if (totalElements.value === 0) return 0
+  return (currentPage.value - 1) * pageSize.value + 1
 })
+const rangeEnd = computed(() => {
+  if (totalElements.value === 0) return 0
+  return Math.min(rangeStart.value + paginatedSkus.value.length - 1, totalElements.value)
+})
+
+const pageNumbers = computed(() => {
+  if (totalPages.value <= 0) return []
+  const start = Math.max(1, currentPage.value - 2)
+  const end = Math.min(totalPages.value, start + 4)
+  const adjustedStart = Math.max(1, end - 4)
+  return Array.from({ length: end - adjustedStart + 1 }, (_, idx) => adjustedStart + idx)
+})
+
+const selectedRowsSnapshot = ref([])
+const mergeSelectedRowsSnapshot = (rows) => {
+  const map = new Map(selectedRowsSnapshot.value.map(row => [row.id, row]))
+  for (const row of rows) {
+    if (selectedRowIds.value.includes(row.id)) {
+      map.set(row.id, row)
+    }
+  }
+  selectedRowsSnapshot.value = [...map.values()]
+}
 
 watch(selectedParentCategory, () => {
   selectedChildCategory.value = ''
 })
 
-watch([selectedParentCategory, selectedChildCategory, selectedWarehouseCodes, selectedConditionCodes, searchTerm], () => {
+watch([selectedParentCategory, selectedChildCategory, selectedWarehouseCodes, selectedConditionCodes], () => {
+  if (!hasRefreshed.value) return
   currentPage.value = 1
+  loadCandidates()
+}, { deep: true })
+
+const buildCandidateQueryParams = () => ({
+  page: Math.max(0, currentPage.value - 1),
+  size: pageSize.value,
+  sort: `${sortKey.value},${sortDirection.value}`,
+  keyword: searchTerm.value.trim() || undefined,
+  parentCategory: selectedParentCategory.value || undefined,
+  childCategory: selectedChildCategory.value || undefined,
+  warehouseCodes: selectedWarehouseCodes.value.length > 0 ? selectedWarehouseCodes.value : undefined,
+  conditionCodes: selectedConditionCodes.value.length > 0
+    ? selectedConditionCodes.value.map(code => Number(code))
+    : undefined,
 })
 
 const toggleWarehouseDropdown = () => {
@@ -266,6 +250,20 @@ const clearConditionCodes = () => {
   selectedConditionCodes.value = []
 }
 
+const applySearch = () => {
+  if (!hasRefreshed.value) return
+  currentPage.value = 1
+  loadCandidates()
+}
+
+const changePageSize = async (value) => {
+  const next = Number(value)
+  if (!PAGE_SIZE_OPTIONS.includes(next)) return
+  pageSize.value = next
+  currentPage.value = 1
+  await loadCandidates()
+}
+
 const handleDocumentClick = (event) => {
   if (!warehouseDropdownRef.value?.contains(event.target)) {
     isWarehouseDropdownOpen.value = false
@@ -293,12 +291,20 @@ const loadCandidates = async () => {
   isLoading.value = true
   loadError.value = ''
   try {
-    const rows = await getCircularCandidates()
-    candidateSkus.value = Array.isArray(rows) ? rows.map(mapCandidateRow) : []
+    const result = await getCircularCandidates(buildCandidateQueryParams())
+    const rows = Array.isArray(result?.content) ? result.content : []
+    candidateSkus.value = rows.map(mapCandidateRow)
+    totalElements.value = Number(result?.totalElements ?? 0)
+    totalPages.value = Math.max(1, Number(result?.totalPages ?? 1))
+    currentPage.value = Number(result?.page ?? 0) + 1
+    pageSize.value = Number(result?.size ?? pageSize.value)
+    mergeSelectedRowsSnapshot(candidateSkus.value)
     hasRefreshed.value = true
   } catch (e) {
     loadError.value = e.message || '순환 재고 후보 조회에 실패했습니다.'
     candidateSkus.value = []
+    totalElements.value = 0
+    totalPages.value = 1
     hasRefreshed.value = true
   } finally {
     isLoading.value = false
@@ -318,8 +324,10 @@ const refreshCandidates = async () => {
     selectedConditionCodes.value = []
     convertNotice.value = ''
     currentPage.value = 1
+    pageSize.value = 20
     sortKey.value = 'convertibleStock'
     sortDirection.value = 'desc'
+    selectedRowsSnapshot.value = []
   } catch (e) {
     loadError.value = e.message || '순환 재고 후보 갱신에 실패했습니다.'
   } finally {
@@ -360,6 +368,7 @@ const submitConversion = async () => {
 
     await loadCandidates()
     selectedRowIds.value = []
+    selectedRowsSnapshot.value = []
     conversionInputs.value = {}
     isConvertModalOpen.value = false
   } catch (e) {
@@ -378,6 +387,7 @@ const toggleSort = (key) => {
   }
 
   currentPage.value = 1
+  loadCandidates()
 }
 
 const sortIcon = (key) => {
@@ -402,6 +412,7 @@ const toggleAllCurrentPage = () => {
 const goToPage = (page) => {
   if (page < 1 || page > totalPages.value) return
   currentPage.value = page
+  loadCandidates()
 }
 
 function handleLogout() {
@@ -482,12 +493,9 @@ onBeforeUnmount(() => {
           <div>
             <h2 class="text-sm font-black text-gray-900">전환 후보 SKU 리스트</h2>
             <p class="mt-1 text-[11px] font-bold text-gray-400">
-              {{ hasRefreshed ? `조회 ${sortedSkus.length.toLocaleString()}건 · 선택 ${selectedRowIds.length.toLocaleString()}건` : '재고 새로고침 후 후보가 표시됩니다.' }}
+              {{ hasRefreshed ? `조회 ${totalElements.toLocaleString()}건 · 선택 ${selectedRowIds.length.toLocaleString()}건` : '재고 새로고침 후 후보가 표시됩니다.' }}
             </p>
           </div>
-          <p v-if="hasRefreshed" class="text-[11px] font-bold text-gray-400">
-            {{ rangeStart.toLocaleString() }}-{{ rangeEnd.toLocaleString() }} / 전체 {{ sortedSkus.length.toLocaleString() }}건
-          </p>
         </div>
 
         <div
@@ -613,6 +621,8 @@ onBeforeUnmount(() => {
               type="search"
               class="h-9 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none placeholder:text-gray-400 focus:border-[#004D3C]"
               placeholder="SKU 코드, 품목 코드, 품목명"
+              @keyup.enter="applySearch"
+              @change="applySearch"
             />
           </label>
         </div>
@@ -710,26 +720,36 @@ onBeforeUnmount(() => {
 
         <div
           v-if="hasRefreshed"
-          class="flex items-center justify-between border-t border-gray-100 bg-gray-50 px-3 py-2"
+          class="flex flex-wrap items-center justify-between gap-3 border-t border-gray-100 px-4 py-3"
         >
-          <span class="text-[11px] font-medium text-gray-400">
-            {{ rangeStart.toLocaleString() }}-{{ rangeEnd.toLocaleString() }} / 전체 {{ sortedSkus.length.toLocaleString() }}건
-          </span>
+          <div class="flex items-center gap-2">
+            <span class="text-xs font-bold text-gray-600">페이지 크기</span>
+            <select
+              :value="pageSize"
+              class="h-8 border border-gray-300 bg-white px-2 text-xs font-bold text-gray-900 outline-none focus:border-[#004D3C]"
+              @change="changePageSize($event.target.value)"
+            >
+              <option v-for="sizeOption in PAGE_SIZE_OPTIONS" :key="sizeOption" :value="sizeOption">
+                {{ sizeOption }}
+              </option>
+            </select>
+          </div>
+
           <div class="flex items-center gap-1">
             <button
               type="button"
               :disabled="currentPage === 1"
-              class="flex h-7 w-7 items-center justify-center border border-gray-300 bg-white text-[12px] text-gray-500 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
+              class="h-8 border border-gray-300 px-3 text-xs font-bold text-gray-700 disabled:cursor-not-allowed disabled:opacity-40"
               @click="goToPage(currentPage - 1)"
             >
-              ‹
+              이전
             </button>
             <button
-              v-for="page in totalPages"
+              v-for="page in pageNumbers"
               :key="page"
               type="button"
-              class="flex h-7 min-w-[28px] items-center justify-center border text-[12px] font-medium transition"
-              :class="page === currentPage ? 'border-[#004D3C] bg-[#004D3C] text-white' : 'border-gray-300 bg-white text-gray-500 hover:bg-gray-100'"
+              class="h-8 min-w-8 border px-2 text-xs font-bold"
+              :class="page === currentPage ? 'border-[#004D3C] bg-[#004D3C] text-white' : 'border-gray-300 text-gray-700'"
               @click="goToPage(page)"
             >
               {{ page }}
@@ -737,10 +757,10 @@ onBeforeUnmount(() => {
             <button
               type="button"
               :disabled="currentPage === totalPages"
-              class="flex h-7 w-7 items-center justify-center border border-gray-300 bg-white text-[12px] text-gray-500 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
+              class="h-8 border border-gray-300 px-3 text-xs font-bold text-gray-700 disabled:cursor-not-allowed disabled:opacity-40"
               @click="goToPage(currentPage + 1)"
             >
-              ›
+              다음
             </button>
           </div>
         </div>

--- a/src/views/hq/circular-stock/HqCircularStockInventoryView.vue
+++ b/src/views/hq/circular-stock/HqCircularStockInventoryView.vue
@@ -3,10 +3,8 @@ import { computed, onMounted, ref } from 'vue'
 import AppLayout from '@/components/common/AppLayout.vue'
 import CircularStockInventoryBrowseSection from '@/components/hq/circular-stock/CircularStockInventoryBrowseSection.vue'
 import { roleMenus } from '@/config/roleMenus.js'
-import { useAuthStore } from '@/stores/auth.js'
 import { useCircularStockStore } from '@/stores/hq/circularStock/circularStock.js'
 
-const auth = useAuthStore()
 const circularStockStore = useCircularStockStore()
 const hqMenus = roleMenus.hq
 const circularStockMenus = roleMenus.hq.find(menu => menu.label === '순환 재고 관리')?.children ?? []
@@ -51,11 +49,6 @@ function handleQueryChange(query) {
     materialName: query.materialName,
     minRatio: query.minRatio,
   })
-}
-
-function handleLogout() {
-  auth.logout()
-  router.push('/dev-login')
 }
 
 onMounted(() => {

--- a/src/views/hq/circular-stock/HqCircularStockInventoryView.vue
+++ b/src/views/hq/circular-stock/HqCircularStockInventoryView.vue
@@ -18,16 +18,41 @@ const activeSideMenu = ref('순환 재고 조회')
 const isLoading = ref(false)
 const loadError = ref('')
 
-const loadCircularInventory = async () => {
+const loadCircularInventory = async (overrides = {}) => {
   isLoading.value = true
   loadError.value = ''
   try {
-    await circularStockStore.loadCircularInventoryRows()
+    await circularStockStore.loadCircularInventoryRows(overrides)
   } catch (e) {
     loadError.value = e.message || '순환 재고 조회에 실패했습니다.'
   } finally {
     isLoading.value = false
   }
+}
+
+function handlePageChange(page) {
+  loadCircularInventory({ page })
+  window.scrollTo({ top: 0, behavior: 'smooth' })
+}
+
+function handleSizeChange(size) {
+  loadCircularInventory({ page: 0, size })
+  window.scrollTo({ top: 0, behavior: 'smooth' })
+}
+
+function handleSortChange({ sort }) {
+  loadCircularInventory({ page: 0, sort })
+}
+
+function handleQueryChange(query) {
+  loadCircularInventory({
+    page: 0,
+    keyword: query.keyword,
+    warehouseCodes: query.warehouseCodes,
+    materialGroup: query.materialGroup,
+    materialName: query.materialName,
+    minRatio: query.minRatio,
+  })
 }
 
 function handleLogout() {
@@ -64,7 +89,16 @@ onMounted(() => {
         title="순환 재고 리스트"
         :description="isLoading ? '순환 재고를 불러오는 중입니다.' : '소재와 SKU 기준으로 순환 재고를 탐색하고 판매 대상 SKU를 확인합니다.'"
         :show-circular-sale-price-column="true"
+        :server-mode="true"
+        :page="circularStockStore.inventoryPage"
+        :size="circularStockStore.inventorySize"
+        :total-pages="circularStockStore.inventoryTotalPages"
+        :total-elements="circularStockStore.inventoryTotalElements"
         :inventory-rows="circularStockStore.inventoryRows"
+        @page-change="handlePageChange"
+        @size-change="handleSizeChange"
+        @sort-change="handleSortChange"
+        @query-change="handleQueryChange"
       />
     </div>
   </AppLayout>

--- a/src/views/hq/circular-stock/HqCircularStockSalesRegisterView.vue
+++ b/src/views/hq/circular-stock/HqCircularStockSalesRegisterView.vue
@@ -243,7 +243,7 @@ async function loadCircularInventoryRows() {
   isInventoryLoading.value = true
   inventoryLoadError.value = ''
   try {
-    await circularStockStore.loadCircularInventoryRows()
+    await circularStockStore.loadCircularInventoryRows({ page: 0, size: 100, sort: 'skuCode,asc' })
   } catch (e) {
     inventoryLoadError.value = e.message || '순환 재고 불러오기에 실패했습니다.'
   } finally {


### PR DESCRIPTION
## 📌 요약
- 순환 재고 조회/후보 조회 화면을 서버 기준 페이징으로 전환하고, 필터/정렬/검색 동작을 API 쿼리 기반으로 통합했습니다.
- 로그아웃 경로를 `useLogout` 단일 방식으로 정리하고, 후보 조회 화면의 중복 API 호출 가능성을 줄였습니다.

<br><br>

## 🎯 작업 내용
- `GET /api/hq/inventories/circular`, `GET /api/hq/inventories/circular-candidates` 호출을 params 기반으로 사용하도록 프론트 연동 변경
- 순환 재고 조회/후보 조회 화면에서 로컬 페이징 로직 제거 후 서버 응답(`content`, `totalPages`, `totalElements`) 기준 렌더링
- 하단 페이지네이션 UI를 통일(이전/다음 + 번호 최대 5개 + 페이지 크기 20/50/100), 후보 조회 화면 문구/스타일 정리
- 후보 조회 화면 조회 트리거를 `requestCandidates` 단일 경로로 정리하고, 필터 초기화 시 watch 연쇄 호출 방지 가드 추가
- `HqCircularStockInventoryView`의 뷰 내부 로그아웃 잔여 코드 제거(로그아웃은 `AppLayout` + `useLogout` 단일 사용)

<br><br>

## ✔️ 참고 사항
- 빌드 검증 완료: `npm run build` 성공
- 페이지 이동 시 선택 상태 유지, refresh/전환 완료 시 선택 초기화 정책은 기존 유지

<br><br>

## ✔️ 관련 이슈

- Close #433 

<br><br>
