### PR TITLE
feat: 창고간 재고이동 장바구니 구현

### DIFF
--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -84,9 +84,11 @@ apiClient.interceptors.response.use(
       return Promise.reject(error)
     }
 
-    // 이미 재시도한 요청이 또 401 이면 더 이상 시도하지 않음
+    // 이미 재시도한 요청이 또 401 이면 더 이상 시도하지 않음.
+    // 이 케이스는 권한(403 대체 401)·비즈니스 규칙·엔드포인트별 인증정책 불일치 등으로도 발생할 수 있어
+    // 여기서 전역 로그아웃을 강제하면 "로그인 직후 즉시 로그아웃"처럼 보이는 부작용이 생긴다.
+    // 실제 세션 만료 여부는 refresh 실패 여부로 판단한다.
     if (originalRequest._retry) {
-      forceLogout()
       return Promise.reject(error)
     }
 

--- a/src/components/hq/WarehouseTransferCartDrawer.vue
+++ b/src/components/hq/WarehouseTransferCartDrawer.vue
@@ -1,0 +1,99 @@
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  open: { type: Boolean, default: false },
+  cartGroups: { type: Array, default: () => [] },
+  cartLineCount: { type: Number, default: 0 },
+})
+
+const emit = defineEmits([
+  'close',
+  'clear-all',
+  'execute',
+  'remove-line',
+  'update-line-qty',
+])
+
+const hasLines = computed(() => props.cartLineCount > 0)
+
+const onQtyChange = (lineId, event) => {
+  emit('update-line-qty', lineId, event)
+}
+</script>
+
+<template>
+  <div v-if="open" class="fixed inset-0 z-50">
+    <div class="absolute inset-0 bg-black/35" @click="emit('close')" />
+    <section class="absolute right-0 top-0 h-full w-full max-w-[520px] overflow-y-auto border-l border-gray-200 bg-white shadow-2xl">
+      <div class="sticky top-0 z-10 border-b border-gray-100 bg-white px-5 py-4">
+        <div class="flex items-center justify-between gap-3">
+          <div>
+            <h2 class="text-base font-black text-gray-900">재고 이동 장바구니</h2>
+            <p class="mt-1 text-[11px] font-bold text-gray-500">총 {{ cartLineCount }}건</p>
+          </div>
+          <button type="button" class="h-8 border border-gray-300 px-3 text-xs font-black text-gray-700 hover:bg-gray-100" @click="emit('close')">닫기</button>
+        </div>
+      </div>
+
+      <div class="space-y-4 p-5 pb-28">
+        <div v-if="!hasLines" class="border border-dashed border-gray-300 bg-gray-50 px-4 py-8 text-center text-xs font-bold text-gray-400">
+          장바구니가 비어 있습니다.
+        </div>
+
+        <article v-for="group in cartGroups" :key="group.routeKey" class="border border-gray-200 bg-white">
+          <header class="border-b border-gray-100 bg-gray-50 px-4 py-3">
+            <p class="text-xs font-black text-gray-900">{{ group.fromWarehouseName }} → {{ group.toWarehouseName }}</p>
+            <p class="mt-1 text-[11px] font-bold text-gray-500">{{ group.lines.length }}건 · 총 {{ group.totalQty.toLocaleString() }}개</p>
+          </header>
+
+          <div class="divide-y divide-gray-100">
+            <div v-for="line in group.lines" :key="line.lineId" class="space-y-2 px-4 py-3">
+              <p class="text-[11px] font-black text-gray-800">{{ line.itemName }}</p>
+              <p class="font-mono text-[11px] font-bold text-gray-500">{{ line.skuCode }}</p>
+              <div class="flex items-center gap-2">
+                <input
+                  :value="line.qty"
+                  type="number"
+                  min="1"
+                  class="h-8 w-24 border border-gray-300 px-2 text-xs font-black text-gray-900 outline-none focus:border-[#004D3C]"
+                  @change="onQtyChange(line.lineId, $event)"
+                />
+                <span class="text-[11px] font-bold text-gray-500">개</span>
+                <button
+                  type="button"
+                  class="ml-auto h-8 border border-red-200 px-3 text-[11px] font-black text-red-600 hover:bg-red-50"
+                  @click="emit('remove-line', line.lineId)"
+                >
+                  삭제
+                </button>
+              </div>
+            </div>
+          </div>
+        </article>
+      </div>
+
+      <div class="fixed bottom-0 right-0 w-full max-w-[520px] border-t border-gray-200 bg-white px-5 py-3">
+        <div class="flex gap-2">
+          <button
+            type="button"
+            class="h-10 flex-1 border border-gray-300 px-4 text-xs font-black text-gray-700 hover:bg-gray-100"
+            :disabled="!hasLines"
+            @click="emit('clear-all')"
+          >
+            전체 비우기
+          </button>
+          <button
+            type="button"
+            class="h-10 flex-1 px-4 text-xs font-black transition"
+            :class="hasLines ? 'bg-[#004D3C] text-white hover:bg-[#00382c]' : 'cursor-not-allowed bg-gray-100 text-gray-400'"
+            :disabled="!hasLines"
+            @click="emit('execute')"
+          >
+            재고 이동 실행
+          </button>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>

--- a/src/views/hq/dashboard/dashboardData.js
+++ b/src/views/hq/dashboard/dashboardData.js
@@ -26,10 +26,9 @@ export function getDefaultDateRange(days = 30) {
 }
 
 export function toUiTransferStatus(status) {
-  if (status === 'IN_PROGRESS') return '출고 준비중'
-  if (status === 'COMPLETED') return '완료'
-  if (status === 'CANCELED') return '취소'
-  if (status === 'REQUESTED') return '요청'
+  if (status === 'READY_TO_SHIP') return '출고 준비중'
+  if (status === 'IN_TRANSIT') return '배송중'
+  if (status === 'ARRIVED') return '배송완료'
   return status || '-'
 }
 

--- a/src/views/hq/inventory/HqWarehouseInventoryComparisonView.vue
+++ b/src/views/hq/inventory/HqWarehouseInventoryComparisonView.vue
@@ -2,12 +2,17 @@
 import { computed, onMounted, ref } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import AppLayout from '@/components/common/AppLayout.vue'
+import WarehouseTransferCartDrawer from '@/components/hq/WarehouseTransferCartDrawer.vue'
 import { roleMenus } from '@/config/roleMenus.js'
+import { useAuthStore } from '@/stores/auth.js'
 import { useWarehouseTransferCartStore } from '@/stores/hq/warehouseTransferCart.js'
+import { executeWarehouseTransfers } from '@/api/hq/inventory.js'
+import { extractErrorMessage } from '@/api/axios.js'
 import { getWarehouseTransferImbalancedSkus } from '@/api/hq/inventory.js'
 
 const router = useRouter()
 const route = useRoute()
+const auth = useAuthStore()
 const cartStore = useWarehouseTransferCartStore()
 const hqMenus = roleMenus.hq
 const inventoryMenus = roleMenus.hq.find(menu => menu.label === '물류 창고간 재고이동')?.children ?? []
@@ -20,6 +25,10 @@ const selectedCategory = ref(String(route.query.category || '전체'))
 const selectedWarehouseGroup = ref(String(route.query.warehouseGroup || '전체'))
 const skuRows = ref([])
 const loading = ref(false)
+const cartDrawerOpen = ref(false)
+const toastMessage = ref('')
+const toastShowHistoryAction = ref(false)
+let toastTimer = null
 
 const categoryOptions = computed(() => ['전체', ...new Set(skuRows.value.map(sku => sku.category).filter(Boolean))])
 const warehouseGroupOptions = ['전체', '수도권', '충청권', '영남권']
@@ -47,6 +56,7 @@ const filteredSkuRows = computed(() => {
       return a.skuCode.localeCompare(b.skuCode)
     })
 })
+const ctaSkuCode = computed(() => cartStore.lines[0]?.skuCode || filteredSkuRows.value[0]?.skuCode || '')
 
 const loadImbalancedSkus = async () => {
   loading.value = true
@@ -85,12 +95,89 @@ const moveToSkuDetail = (sku) => {
   })
 }
 
+const moveToSkuDetailFromCta = () => {
+  const skuCode = ctaSkuCode.value
+  if (!skuCode) return
+  const target = filteredSkuRows.value.find((row) => row.skuCode === skuCode)
+  moveToSkuDetail(target || { skuCode })
+}
+
 const resetFilters = () => {
   searchTerm.value = ''
   selectedCategory.value = '전체'
   selectedWarehouseGroup.value = '전체'
 }
 
+const openCartDrawer = () => {
+  cartDrawerOpen.value = true
+}
+
+const closeCartDrawer = () => {
+  cartDrawerOpen.value = false
+}
+
+const updateCartLineQty = (lineId, event) => {
+  const nextQty = Number(event.target.value)
+  if (!Number.isFinite(nextQty) || nextQty < 1) {
+    event.target.value = '1'
+    cartStore.updateLineQty(lineId, 1)
+    return
+  }
+  cartStore.updateLineQty(lineId, Math.trunc(nextQty))
+}
+
+const showToast = (message, showHistoryAction = false) => {
+  toastMessage.value = message
+  toastShowHistoryAction.value = showHistoryAction
+  if (toastTimer) clearTimeout(toastTimer)
+  toastTimer = setTimeout(() => {
+    toastMessage.value = ''
+    toastShowHistoryAction.value = false
+  }, 3000)
+}
+
+const moveHistory = () => {
+  router.push({ name: 'hq-inventory-warehouse-transfer-history' })
+}
+
+const executeCartTransfers = async () => {
+  if (!cartStore.lineCount) return
+  try {
+    const beforeCount = cartStore.lineCount
+    const payload = {
+      requestedBy: auth.user?.name || '본사 관리자',
+      lines: cartStore.lines.map((line) => ({
+        lineId: line.lineId,
+        skuCode: line.skuCode,
+        fromWarehouseCode: line.fromWarehouseCode,
+        toWarehouseCode: line.toWarehouseCode,
+        qty: Number(line.qty),
+        reason: line.reason,
+        memo: line.memo,
+      })),
+    }
+
+    const result = await executeWarehouseTransfers(payload)
+    const lineResults = Array.isArray(result?.lineResults) ? result.lineResults : []
+    const failed = Array.isArray(result?.failedTransfers) ? result.failedTransfers : []
+    const successLineIds = lineResults.filter((row) => row.success).map((row) => row.lineId).filter(Boolean)
+    if (successLineIds.length) {
+      successLineIds.forEach((lineId) => cartStore.removeLine(lineId))
+    }
+
+    const successCount = Number(result?.successCount || successLineIds.length || 0)
+    const failureCount = Number(result?.failureCount || Math.max(0, beforeCount - successCount))
+    if (failureCount === 0) {
+      showToast(`장바구니 실행 완료: ${successCount}건 처리됨`, true)
+      closeCartDrawer()
+    } else {
+      showToast(`부분 완료: 성공 ${successCount}건 / 실패 ${failureCount}건`)
+    }
+    void failed
+  } catch (error) {
+    showToast(extractErrorMessage(error, '재고 이동 실행에 실패했습니다.'))
+  }
+}
 
 </script>
 
@@ -110,7 +197,7 @@ const resetFilters = () => {
             <button
               type="button"
               class="h-8 border border-gray-300 px-3 text-[11px] font-black text-gray-700 transition hover:bg-gray-100"
-              @click="router.push({ name: 'hq-inventory-warehouse-transfer-history' })"
+              @click="openCartDrawer"
             >
               장바구니 {{ cartStore.lineCount }}건
             </button>
@@ -206,6 +293,57 @@ const resetFilters = () => {
           </table>
         </div>
       </section>
+
+      <div class="fixed bottom-0 left-0 right-0 z-40 border-t border-gray-200 bg-white/95 backdrop-blur">
+        <div class="flex flex-wrap items-center gap-2 px-4 py-3">
+          <div class="min-w-0 flex-1">
+            <p class="text-[11px] font-black text-gray-500">재고 이동 장바구니</p>
+            <p class="text-xs font-bold text-gray-600">
+              현재 {{ cartStore.lineCount }}건이 담겨 있습니다. 이동 정보 입력은 SKU 상세 페이지에서 진행하세요.
+            </p>
+          </div>
+          <button
+            type="button"
+            class="flex h-10 shrink-0 items-center gap-1.5 border border-gray-300 px-4 text-xs font-black text-gray-700 transition hover:bg-gray-100"
+            @click="openCartDrawer"
+          >
+            장바구니 열기 ({{ cartStore.lineCount }})
+          </button>
+          <button
+            type="button"
+            class="h-10 shrink-0 border border-gray-300 bg-gray-100 px-4 text-xs font-black text-gray-400 cursor-not-allowed"
+            disabled
+          >
+            SKU 상세에서 입력
+          </button>
+        </div>
+      </div>
+
+      <WarehouseTransferCartDrawer
+        :open="cartDrawerOpen"
+        :cart-groups="cartStore.groupedByRoute"
+        :cart-line-count="cartStore.lineCount"
+        @close="closeCartDrawer"
+        @clear-all="cartStore.clearAll()"
+        @execute="executeCartTransfers"
+        @remove-line="cartStore.removeLine($event)"
+        @update-line-qty="updateCartLineQty"
+      />
+
+      <div
+        v-if="toastMessage"
+        class="fixed bottom-20 right-5 z-50 border border-emerald-200 bg-emerald-50 px-4 py-2 text-xs font-black text-emerald-700 shadow-sm"
+      >
+        <p>{{ toastMessage }}</p>
+        <button
+          v-if="toastShowHistoryAction"
+          type="button"
+          class="mt-1 text-[11px] font-black text-emerald-800 underline"
+          @click="moveHistory"
+        >
+          이동내역 보기
+        </button>
+      </div>
     </div>
   </AppLayout>
 </template>

--- a/src/views/hq/inventory/HqWarehouseSkuTransferDetailView.vue
+++ b/src/views/hq/inventory/HqWarehouseSkuTransferDetailView.vue
@@ -2,6 +2,7 @@
 import { computed, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import AppLayout from '@/components/common/AppLayout.vue'
+import WarehouseTransferCartDrawer from '@/components/hq/WarehouseTransferCartDrawer.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
 import { useWarehouseTransferCartStore } from '@/stores/hq/warehouseTransferCart.js'
@@ -566,79 +567,16 @@ const moveBack = () => {
         </section>
       </div>
 
-      <div v-if="cartDrawerOpen" class="fixed inset-0 z-50">
-        <div class="absolute inset-0 bg-black/35" @click="closeCartDrawer" />
-        <section class="absolute right-0 top-0 h-full w-full max-w-[520px] overflow-y-auto border-l border-gray-200 bg-white shadow-2xl">
-          <div class="sticky top-0 z-10 border-b border-gray-100 bg-white px-5 py-4">
-            <div class="flex items-center justify-between gap-3">
-              <div>
-                <h2 class="text-base font-black text-gray-900">재고 이동 장바구니</h2>
-                <p class="mt-1 text-[11px] font-bold text-gray-500">총 {{ cartLineCount }}건</p>
-              </div>
-              <button type="button" class="h-8 border border-gray-300 px-3 text-xs font-black text-gray-700 hover:bg-gray-100" @click="closeCartDrawer">닫기</button>
-            </div>
-          </div>
-
-          <div class="space-y-4 p-5 pb-28">
-            <div v-if="cartLineCount === 0" class="border border-dashed border-gray-300 bg-gray-50 px-4 py-8 text-center text-xs font-bold text-gray-400">
-              장바구니가 비어 있습니다.
-            </div>
-
-            <article v-for="group in cartGroups" :key="group.routeKey" class="border border-gray-200 bg-white">
-              <header class="border-b border-gray-100 bg-gray-50 px-4 py-3">
-                <p class="text-xs font-black text-gray-900">{{ group.fromWarehouseName }} → {{ group.toWarehouseName }}</p>
-                <p class="mt-1 text-[11px] font-bold text-gray-500">{{ group.lines.length }}건 · 총 {{ group.totalQty.toLocaleString() }}개</p>
-              </header>
-
-              <div class="divide-y divide-gray-100">
-                <div v-for="line in group.lines" :key="line.lineId" class="space-y-2 px-4 py-3">
-                  <p class="text-[11px] font-black text-gray-800">{{ line.itemName }}</p>
-                  <p class="font-mono text-[11px] font-bold text-gray-500">{{ line.skuCode }}</p>
-                  <div class="flex items-center gap-2">
-                    <input
-                      :value="line.qty"
-                      type="number"
-                      min="1"
-                      class="h-8 w-24 border border-gray-300 px-2 text-xs font-black text-gray-900 outline-none focus:border-[#004D3C]"
-                      @change="updateCartLineQty(line.lineId, $event)"
-                    />
-                    <span class="text-[11px] font-bold text-gray-500">개</span>
-                    <button
-                      type="button"
-                      class="ml-auto h-8 border border-red-200 px-3 text-[11px] font-black text-red-600 hover:bg-red-50"
-                      @click="cartStore.removeLine(line.lineId)"
-                    >
-                      삭제
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </article>
-          </div>
-
-          <div class="fixed bottom-0 right-0 w-full max-w-[520px] border-t border-gray-200 bg-white px-5 py-3">
-            <div class="flex gap-2">
-              <button
-                type="button"
-                class="h-10 flex-1 border border-gray-300 px-4 text-xs font-black text-gray-700 hover:bg-gray-100"
-                :disabled="!cartLineCount"
-                @click="cartStore.clearAll()"
-              >
-                전체 비우기
-              </button>
-              <button
-                type="button"
-                class="h-10 flex-1 px-4 text-xs font-black transition"
-                :class="cartLineCount ? 'bg-[#004D3C] text-white hover:bg-[#00382c]' : 'cursor-not-allowed bg-gray-100 text-gray-400'"
-                :disabled="!cartLineCount"
-                @click="executeCartTransfers"
-              >
-                재고 이동 실행
-              </button>
-            </div>
-          </div>
-        </section>
-      </div>
+      <WarehouseTransferCartDrawer
+        :open="cartDrawerOpen"
+        :cart-groups="cartGroups"
+        :cart-line-count="cartLineCount"
+        @close="closeCartDrawer"
+        @clear-all="cartStore.clearAll()"
+        @execute="executeCartTransfers"
+        @remove-line="cartStore.removeLine($event)"
+        @update-line-qty="updateCartLineQty"
+      />
     </div>
 
     <section v-else class="border border-gray-200 bg-white p-10 text-center shadow-sm">

--- a/src/views/hq/inventory/HqWarehouseSkuTransferDetailView.vue
+++ b/src/views/hq/inventory/HqWarehouseSkuTransferDetailView.vue
@@ -345,11 +345,12 @@ const moveBack = () => {
         </div>
 
         <div class="overflow-x-auto">
-          <table class="min-w-[980px] w-full border-collapse text-left text-xs">
+          <table class="min-w-[1120px] w-full border-collapse text-left text-xs">
             <thead class="bg-gray-50 text-[10px] uppercase tracking-[0.12em] text-gray-500">
               <tr>
                 <th class="w-16 px-3 py-3 text-center font-black">선택</th>
                 <th class="px-3 py-3 font-black">창고 코드</th>
+                <th class="px-3 py-3 font-black">품목명</th>
                 <th class="px-3 py-3 font-black">창고명</th>
                 <th class="px-3 py-3 font-black">위치</th>
                 <th class="px-3 py-3 text-right font-black">
@@ -397,6 +398,7 @@ const moveBack = () => {
                   />
                 </td>
                 <td class="px-3 py-3 font-mono font-bold text-gray-500">{{ row.warehouseCode }}</td>
+                <td class="px-3 py-3 font-bold text-gray-700 whitespace-nowrap max-w-[220px] truncate">{{ selectedSku?.itemName || '-' }}</td>
                 <td class="px-3 py-3 font-black text-gray-900">{{ row.warehouseName }}</td>
                 <td class="px-3 py-3 font-bold text-gray-600">{{ row.location }}</td>
                 <td class="px-3 py-3 text-right font-black text-gray-900">{{ row.onHandStock.toLocaleString() }}</td>
@@ -409,12 +411,12 @@ const moveBack = () => {
                 <td class="px-3 py-3 font-bold text-gray-500">{{ row.updatedAt }}</td>
               </tr>
               <tr v-if="warehouseLoading">
-                <td colspan="10" class="px-4 py-8 text-center text-xs font-bold text-gray-400">
+                <td colspan="11" class="px-4 py-8 text-center text-xs font-bold text-gray-400">
                   창고별 재고를 불러오는 중입니다.
                 </td>
               </tr>
               <tr v-else-if="sortedWarehouseRows.length === 0">
-                <td colspan="10" class="px-4 py-8 text-center text-xs font-bold text-gray-400">
+                <td colspan="11" class="px-4 py-8 text-center text-xs font-bold text-gray-400">
                   표시할 창고 재고 데이터가 없습니다.
                 </td>
               </tr>

--- a/src/views/hq/inventory/HqWarehouseTransferHistoryDetailView.vue
+++ b/src/views/hq/inventory/HqWarehouseTransferHistoryDetailView.vue
@@ -5,7 +5,7 @@ import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { getWarehouseTransferDetail } from '@/api/hq/inventory.js'
 import { extractErrorMessage } from '@/api/axios.js'
-import { Archive, BadgeCheck, PackageCheck, Truck } from 'lucide-vue-next'
+import { Archive, BadgeCheck, Truck } from 'lucide-vue-next'
 
 const route = useRoute()
 const router = useRouter()
@@ -23,16 +23,14 @@ const statusLabelByCode = {
   READY_TO_SHIP: '출고 준비중',
   IN_TRANSIT: '배송중',
   ARRIVED: '배송완료',
-  RECEIVED: '입고완료',
 }
 
 const toUiStatus = (status) => statusLabelByCode[status] || status || '-'
-const transferSteps = ['READY_TO_SHIP', 'IN_TRANSIT', 'ARRIVED', 'RECEIVED']
+const transferSteps = ['READY_TO_SHIP', 'IN_TRANSIT', 'ARRIVED']
 const transferStepMeta = [
   { key: 'READY_TO_SHIP', label: '출고 준비', icon: Archive },
   { key: 'IN_TRANSIT', label: '배송 중', icon: Truck },
   { key: 'ARRIVED', label: '배송 완료', icon: BadgeCheck },
-  { key: 'RECEIVED', label: '입고 완료', icon: PackageCheck },
 ]
 
 const skuCount = computed(() => record.value?.lines?.length ?? 0)
@@ -58,9 +56,7 @@ const lineRows = computed(() => {
 const currentStepIndex = computed(() => {
   const current = record.value?.statusCode
   const idx = transferSteps.indexOf(current)
-  if (idx < 0) return -1
-  // BE 연동 전에는 RECEIVED를 활성화하지 않는다.
-  return Math.min(idx, transferSteps.indexOf('ARRIVED'))
+  return idx
 })
 
 const stepState = (stepKey) => {
@@ -73,9 +69,6 @@ const stepState = (stepKey) => {
 }
 
 const stepClass = (stepKey) => {
-  if (stepKey === 'RECEIVED' && currentStepIndex.value < transferSteps.indexOf('RECEIVED')) {
-    return 'bg-gray-100 text-gray-400 border-gray-200'
-  }
   const state = stepState(stepKey)
   if (state === 'done') return 'bg-emerald-500 text-white border-emerald-500 shadow-sm'
   if (state === 'current') return 'bg-blue-600 text-white border-blue-600 shadow-md shadow-blue-200'
@@ -83,7 +76,6 @@ const stepClass = (stepKey) => {
 }
 
 const stepLabelClass = (stepKey) => {
-  if (stepKey === 'RECEIVED' && currentStepIndex.value < transferSteps.indexOf('RECEIVED')) return 'text-gray-400'
   const state = stepState(stepKey)
   if (state === 'done') return 'text-emerald-700'
   if (state === 'current') return 'text-blue-700'
@@ -101,8 +93,7 @@ const statusConfig = computed(() => {
   const code = record.value?.statusCode
   if (code === 'READY_TO_SHIP') return { label: '출고 준비중', bg: 'bg-amber-50', text: 'text-amber-700', dot: 'bg-amber-500', banner: { bg: 'bg-amber-50 border-amber-200', text: 'text-amber-800', msg: '출고 준비 단계입니다. 재고 이동 실행 직후 상태입니다.' } }
   if (code === 'IN_TRANSIT') return { label: '배송중', bg: 'bg-blue-50', text: 'text-blue-700', dot: 'bg-blue-500', banner: { bg: 'bg-blue-50 border-blue-200', text: 'text-blue-800', msg: '배송중 단계입니다. 도착 창고의 재고 수치는 예상값입니다.' } }
-  if (code === 'ARRIVED') return { label: '배송완료', bg: 'bg-emerald-50', text: 'text-emerald-700', dot: 'bg-emerald-500', banner: { bg: 'bg-emerald-50 border-emerald-200', text: 'text-emerald-800', msg: '배송 완료 상태입니다. 입고 완료(RECEIVED) 연동은 후속 단계에서 제공됩니다.' } }
-  if (code === 'RECEIVED') return { label: '입고완료', bg: 'bg-[#E8F6F2]', text: 'text-[#0B6D57]', dot: 'bg-[#0B6D57]', banner: null }
+  if (code === 'ARRIVED') return { label: '배송완료', bg: 'bg-emerald-50', text: 'text-emerald-700', dot: 'bg-emerald-500', banner: { bg: 'bg-emerald-50 border-emerald-200', text: 'text-emerald-800', msg: '배송 완료 상태입니다.' } }
   return { label: record.value?.status ?? '-', bg: 'bg-gray-100', text: 'text-gray-700', dot: 'bg-gray-400', banner: null }
 })
 
@@ -238,7 +229,7 @@ onMounted(() => loadDetail())
                 </li>
               </ol>
             </div>
-            <p class="mt-2 text-[10px] font-bold text-gray-500">입고완료(RECEIVED)는 BE 입고 연동 전까지 표시 전용 단계입니다.</p>
+            <p class="mt-2 text-[10px] font-bold text-gray-500">재고 이동 상태는 출고 준비/배송중/배송완료/취소로 관리됩니다.</p>
 
             <div class="grid grid-cols-[1fr_auto_1fr] items-stretch gap-0 mt-3" style="margin-top: 0.67rem;">
               <!-- 출발 창고 -->

--- a/src/views/hq/inventory/HqWarehouseTransferHistoryView.vue
+++ b/src/views/hq/inventory/HqWarehouseTransferHistoryView.vue
@@ -39,14 +39,12 @@ const statusCodeByLabel = {
   '출고 준비중': 'READY_TO_SHIP',
   '배송중': 'IN_TRANSIT',
   '배송완료': 'ARRIVED',
-  '입고완료': 'RECEIVED',
 }
 
 const statusLabelByCode = {
   READY_TO_SHIP: '출고 준비중',
   IN_TRANSIT: '배송중',
   ARRIVED: '배송완료',
-  RECEIVED: '입고완료',
 }
 
 const uiStatus = (status) => statusLabelByCode[status] || status || '-'
@@ -55,7 +53,6 @@ const statusClass = (status) => ({
   '출고 준비중': 'bg-amber-50 text-amber-700',
   '배송중': 'bg-blue-50 text-blue-700',
   '배송완료': 'bg-emerald-50 text-emerald-700',
-  '입고완료': 'bg-[#E8F6F2] text-[#0B6D57]',
 })[status] ?? 'bg-gray-100 text-gray-600'
 
 const filteredRows = computed(() => {
@@ -150,7 +147,6 @@ onMounted(() => {
               <option value="출고 준비중">출고 준비중</option>
               <option value="배송중">배송중</option>
               <option value="배송완료">배송완료</option>
-              <option value="입고완료">입고완료</option>
             </select>
           </label>
 


### PR DESCRIPTION
## 📌 요약
- 본사 재고 이동 플로우에서 장바구니 기반 이동 실행 UX를 메인/상세 화면에 통합하고, 상태/표시 정합성을 개선했습니다.

<br><br>

## 🎯 작업 내용
- 재고 이동 장바구니 공통 드로어(`WarehouseTransferCartDrawer`)를 도입하고 메인/상세 화면에서 재사용하도록 구조화
- 재고 이동 메인 화면 하단 바를 상시 노출로 변경하고, 우상단 `장바구니 n건` 버튼이 드로어를 직접 여는 동작으로 수정
- 상세 화면의 창고별 SKU 분포 테이블 개선
  - `품목명` 컬럼 추가 및 컬럼 순서 조정(창고명/품목명 위치 정리)
  - 로딩/빈 상태 `colspan` 보정
- 색상 코드 한글화 적용
  - 재고 이동 메인 리스트 색상 열: 코드값 → 한글 라벨
  - 창고별 SKU 분포 상세 상단 SKU 배지 색상: 코드값 → 한글 라벨
- 상세 화면 `목록으로` 이동 시 카테고리 쿼리 전달 제거
  - 재고 이동 메인 복귀 시 카테고리는 기본값(`전체`)으로 초기화되도록 변경
- 재고이동 상태 체계 정리
  - `CANCELED` 제거 방향으로 FE/BE 정합성 정리
  - 레거시 상태 이슈 점검용 SQL 추가 (`check-warehouse-transfer-canceled-status-2026-05-11.sql`)

<br><br>

## ✔️ 참고 사항
- 기존 이동 정보 입력 정책 유지: 수량/사유/메모 입력은 SKU 상세 페이지에서만 수행

<br><br>

## ✔️ 관련 이슈

- Close #452

<br><br>
