### PR TITLE
fix(purchase-order): 새 발주 페이지 제품명 잘림 + 발주서 collapse 토글

### DIFF
--- a/src/components/hq/purchase-order/PurchaseOrderCart.vue
+++ b/src/components/hq/purchase-order/PurchaseOrderCart.vue
@@ -22,6 +22,7 @@ defineEmits([
   'scroll-to-catalog-sku',
   'open-clear-cart-confirm',
   'open-submit-confirm',
+  'toggle-collapse',
 ])
 </script>
 
@@ -35,13 +36,24 @@ defineEmits([
         <ShoppingCartIcon :size="14" />
         발주 요청서
       </h3>
-      <span class="text-[10px] font-bold opacity-80">
-        <template v-if="isEditMode">{{ cart.length }}건</template>
-        <template v-else-if="groupedByVendor.length > 0">
-          {{ groupedByVendor.length }}곳 · {{ cart.length }}건
-        </template>
-        <template v-else>{{ cart.length }}건</template>
-      </span>
+      <div class="inline-flex items-center gap-2">
+        <span class="text-[10px] font-bold opacity-80">
+          <template v-if="isEditMode">{{ cart.length }}건</template>
+          <template v-else-if="groupedByVendor.length > 0">
+            {{ groupedByVendor.length }}곳 · {{ cart.length }}건
+          </template>
+          <template v-else>{{ cart.length }}건</template>
+        </span>
+        <button
+          type="button"
+          class="ml-1 inline-flex h-5 w-5 items-center justify-center border border-white/30 text-[10px] font-black leading-none hover:bg-white/10"
+          title="발주 요청서 접기"
+          aria-label="발주 요청서 접기"
+          @click="$emit('toggle-collapse')"
+        >
+          ›
+        </button>
+      </div>
     </div>
 
     <!-- 공급처 표시 — edit 모드 단일 vendor / 신규 모드 그룹 카드 N장 -->

--- a/src/components/hq/purchase-order/PurchaseOrderCatalog.vue
+++ b/src/components/hq/purchase-order/PurchaseOrderCatalog.vue
@@ -326,11 +326,11 @@ void emit
                 @change="toggleAllVisible"
               />
             </th>
-            <th class="w-32 px-2 py-2 text-left font-black">공급처</th>
-            <th class="w-28 px-2 py-2 text-left font-black">제품코드</th>
+            <th class="w-28 px-2 py-2 text-left font-black">공급처</th>
+            <th class="w-24 px-2 py-2 text-left font-black">제품코드</th>
             <th class="px-2 py-2 text-left font-black">제품명</th>
-            <th class="w-24 px-2 py-2 text-left font-black">옵션</th>
-            <th class="w-24 px-2 py-2 text-left font-black">SKU</th>
+            <th class="w-20 px-2 py-2 text-left font-black">옵션</th>
+            <th class="w-32 px-2 py-2 text-left font-black">SKU</th>
             <th class="w-20 px-2 py-2 text-right font-black">단가</th>
             <th
               class="w-12 px-2 py-2 text-right font-black"
@@ -365,14 +365,19 @@ void emit
                 @change="toggleSkuSelected(row.skuCode)"
               />
             </td>
-            <td class="truncate px-2 py-2 align-middle">
+            <td class="truncate px-2 py-2 align-middle" :title="row.vendorName">
               <span class="text-[11px] font-black text-gray-700">{{ row.vendorName }}</span>
             </td>
-            <td class="px-2 py-2 align-middle font-mono text-[10px] text-gray-500">
+            <td
+              class="truncate px-2 py-2 align-middle font-mono text-[10px] text-gray-500"
+              :title="row.productCode"
+            >
               {{ row.productCode }}
             </td>
-            <td class="truncate px-2 py-2 align-middle">
-              <span class="text-xs font-black text-gray-800">{{ row.productName }}</span>
+            <td class="px-2 py-2 align-middle" :title="row.productName">
+              <span class="block whitespace-normal break-words text-xs font-black leading-tight text-gray-800">
+                {{ row.productName }}
+              </span>
             </td>
             <td class="px-2 py-2 align-middle">
               <span class="text-[11px] font-bold text-[#004D3C]">{{ row.displayOption }}</span>

--- a/src/views/hq/purchase-order/HqPurchaseOrderCreateView.vue
+++ b/src/views/hq/purchase-order/HqPurchaseOrderCreateView.vue
@@ -6,7 +6,7 @@ import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
 import { usePurchaseOrderStore } from '@/stores/purchaseOrder.js'
 import { usePurchaseOrderCartStore } from '@/stores/hq/purchaseOrderCart.js'
-import { ArrowLeftIcon } from '@/components/hq/purchase-order/icons.js'
+import { ArrowLeftIcon, ShoppingCartIcon } from '@/components/hq/purchase-order/icons.js'
 import PurchaseOrderBulkQtyModal from '@/components/hq/purchase-order/PurchaseOrderBulkQtyModal.vue'
 import PurchaseOrderCart from '@/components/hq/purchase-order/PurchaseOrderCart.vue'
 import PurchaseOrderCatalog from '@/components/hq/purchase-order/PurchaseOrderCatalog.vue'
@@ -64,6 +64,21 @@ const rowQuantities = ref({})
 const collapsed = ref({})
 // 부족만 보기 토글 (마스터 단위 — 그룹 헤더의 가용재고 < 안전재고 × 1.5 인 그룹만)
 const shortageOnly = ref(false)
+
+// 발주 요청서 패널 접힘 상태 — localStorage 로 사용자 선호 기억.
+// 카탈로그 폭 확보를 위한 ERP 스타일 collapse 토글 (접힘 시 우측 가는 trigger bar).
+const CART_COLLAPSED_KEY = 'stockit:po-cart-collapsed'
+const cartCollapsed = ref(localStorage.getItem(CART_COLLAPSED_KEY) === 'true')
+watch(cartCollapsed, (v) => {
+  try {
+    localStorage.setItem(CART_COLLAPSED_KEY, v ? 'true' : 'false')
+  } catch {
+    // quota / private mode — 영속화만 실패, 동작은 그대로
+  }
+})
+function toggleCartCollapsed() {
+  cartCollapsed.value = !cartCollapsed.value
+}
 
 // ─── Power 모드 ─────────────────────────────────────────────────────────────
 // 다중 선택: skuCode set — Floating bar 와 카탈로그가 v-model 로 공유.
@@ -576,6 +591,7 @@ watch(vendorFilter, () => {
         />
 
         <PurchaseOrderCart
+          v-if="!cartCollapsed"
           :cart="cart"
           :current-cart-vendor-name="currentCartVendorName"
           :grouped-by-vendor="groupedByVendor"
@@ -590,7 +606,32 @@ watch(vendorFilter, () => {
           @scroll-to-catalog-sku="scrollToCatalogSku"
           @open-clear-cart-confirm="openClearCartConfirm"
           @open-submit-confirm="openSubmitConfirm"
+          @toggle-collapse="toggleCartCollapsed"
         />
+
+        <!-- 접힘 상태 trigger bar — 클릭 시 카트 펼치기. 카탈로그가 풀 폭 사용 -->
+        <button
+          v-else
+          type="button"
+          class="group flex w-full shrink-0 items-center justify-between gap-2 border border-gray-300 bg-white px-3 py-2 text-[11px] font-black text-[#004D3C] shadow-sm hover:bg-[#E6F2F0] xl:w-12 xl:flex-col xl:justify-start xl:px-2 xl:py-3"
+          title="발주 요청서 펼치기"
+          aria-label="발주 요청서 펼치기"
+          @click="toggleCartCollapsed"
+        >
+          <span class="inline-flex items-center gap-1 xl:flex-col xl:gap-2">
+            <span class="text-base xl:rotate-180">‹</span>
+            <ShoppingCartIcon :size="14" />
+          </span>
+          <span
+            v-if="cart.length > 0"
+            class="inline-flex items-center bg-[#004D3C] px-1.5 py-0.5 text-[10px] font-black text-white xl:[writing-mode:vertical-rl]"
+          >
+            {{ cart.length }}건
+          </span>
+          <span class="hidden text-[10px] font-bold text-gray-500 xl:inline xl:[writing-mode:vertical-rl]">
+            발주 요청서
+          </span>
+        </button>
       </section>
     </div>
 


### PR DESCRIPTION
## 📌 요약
- 새 발주 페이지에서 제품명이 좌우로 잘려 보이는 문제, 우측 발주 요청서 패널이 항상 자리를 차지해 카탈로그 폭이 부족했던 문제 해소

<br><br>

## 🎯 작업 내용
- `PurchaseOrderCatalog.vue` — 제품명 셀 `truncate` 제거 + `whitespace-normal break-words leading-tight`, `title` 안전망 추가
- 공급처(w-32→w-28) / 제품코드(w-28→w-24) / 옵션(w-24→w-20) 폭 축소, SKU(w-24→w-32) 폭 확장 → 제품명 잔여 공간 확보
- `HqPurchaseOrderCreateView.vue` — 발주 요청서 패널 collapse 토글 (`cartCollapsed` ref + `localStorage("stockit:po-cart-collapsed")` persist)
- `PurchaseOrderCart.vue` — 헤더에 접기 버튼(`›`) 추가 + `@toggle-collapse` emit
- 접힘 상태에서 세로 trigger bar (펼치기 화살표 + 🛒 아이콘 + 건수 배지) 렌더, 클릭 시 다시 펼침

<br><br>

## ✔️ 참고 사항
- 이슈 #458 의 페이징·서버 측 필터링 작업은 이번 PR 범위에서 제외 (별 사이클로 분리 — 이슈는 미해결 상태로 유지)

<br><br>

## ✔️ 관련 이슈

- 

<br><br>
