### PR TITLE
refactor(purchase-order): 새 발주 페이지 UI 정리

### DIFF
--- a/src/components/hq/purchase-order/PurchaseOrderCart.vue
+++ b/src/components/hq/purchase-order/PurchaseOrderCart.vue
@@ -22,7 +22,6 @@ defineEmits([
   'scroll-to-catalog-sku',
   'open-clear-cart-confirm',
   'open-submit-confirm',
-  'toggle-collapse',
 ])
 </script>
 
@@ -36,24 +35,13 @@ defineEmits([
         <ShoppingCartIcon :size="14" />
         발주 요청서
       </h3>
-      <div class="inline-flex items-center gap-2">
-        <span class="text-[10px] font-bold opacity-80">
-          <template v-if="isEditMode">{{ cart.length }}건</template>
-          <template v-else-if="groupedByVendor.length > 0">
-            {{ groupedByVendor.length }}곳 · {{ cart.length }}건
-          </template>
-          <template v-else>{{ cart.length }}건</template>
-        </span>
-        <button
-          type="button"
-          class="ml-1 inline-flex h-5 w-5 items-center justify-center border border-white/30 text-[10px] font-black leading-none hover:bg-white/10"
-          title="발주 요청서 접기"
-          aria-label="발주 요청서 접기"
-          @click="$emit('toggle-collapse')"
-        >
-          ›
-        </button>
-      </div>
+      <span class="text-[10px] font-bold opacity-80">
+        <template v-if="isEditMode">{{ cart.length }}건</template>
+        <template v-else-if="groupedByVendor.length > 0">
+          {{ groupedByVendor.length }}곳 · {{ cart.length }}건
+        </template>
+        <template v-else>{{ cart.length }}건</template>
+      </span>
     </div>
 
     <!-- 공급처 표시 — edit 모드 단일 vendor / 신규 모드 그룹 카드 N장 -->

--- a/src/components/hq/purchase-order/PurchaseOrderCatalog.vue
+++ b/src/components/hq/purchase-order/PurchaseOrderCatalog.vue
@@ -3,7 +3,7 @@ import { computed, ref, toRef } from 'vue'
 import { usePurchaseOrderStore } from '@/stores/purchaseOrder.js'
 import { useFacets } from '@/composables/hq/purchaseOrder/useFacets.js'
 import { usePurchaseOrderStockSim } from '@/composables/hq/purchaseOrder/useStockSim.js'
-import { PlusIcon, SearchIcon } from '@/components/hq/purchase-order/icons.js'
+import { SearchIcon } from '@/components/hq/purchase-order/icons.js'
 
 // 새 발주 카탈로그 — ERP 테이블 스타일.
 // 한 행 = 1 SKU. 공급처/제품/옵션이 컬럼으로 평면화 → 그룹 헤더 제거.
@@ -119,14 +119,8 @@ const filteredRows = computed(() => {
       )
       break
     case 'vendorAsc':
-      skus = [...skus].sort(
-        (a, b) =>
-          a.vendorName.localeCompare(b.vendorName, 'ko') ||
-          a.productName.localeCompare(b.productName, 'ko'),
-      )
-      break
     default:
-      // 기본 정렬 — 공급처 → 제품명 → 옵션
+      // 공급처명 가나다 → 제품명 가나다 → 옵션 순. 기본 정렬.
       skus = [...skus].sort(
         (a, b) =>
           a.vendorName.localeCompare(b.vendorName, 'ko') ||
@@ -229,13 +223,13 @@ void emit
       <select
         v-model="sortBy"
         class="border border-gray-300 bg-white px-3 py-1.5 text-xs outline-none focus:border-[#004D3C]"
+        title="정렬 기준"
       >
-        <option value="default">정렬: 공급처 → 제품</option>
-        <option value="vendorAsc">공급처명</option>
-        <option value="nameAsc">제품명</option>
+        <option value="vendorAsc">공급처명 ↑</option>
+        <option value="nameAsc">제품명 ↑</option>
         <option value="priceAsc">단가 ↑</option>
         <option value="priceDesc">단가 ↓</option>
-        <option value="shortage">부족 SKU 우선</option>
+        <option value="shortage">재고 부족 우선</option>
       </select>
       <button
         type="button"
@@ -327,13 +321,10 @@ void emit
               />
             </th>
             <th class="w-28 px-2 py-2 text-left font-black">공급처</th>
-            <th class="w-24 px-2 py-2 text-left font-black">제품코드</th>
-            <th class="px-2 py-2 text-left font-black">제품명</th>
-            <th class="w-20 px-2 py-2 text-left font-black">옵션</th>
-            <th class="w-32 px-2 py-2 text-left font-black">SKU</th>
-            <th class="w-20 px-2 py-2 text-right font-black">단가</th>
+            <th class="px-2 py-2 text-left font-black">제품</th>
+            <th class="w-24 px-2 py-2 text-right font-black">단가</th>
             <th
-              class="w-12 px-2 py-2 text-right font-black"
+              class="w-14 px-2 py-2 text-right font-black"
               title="가용재고 (실재고 + 입고예정 - 출고예정)"
             >
               재고
@@ -344,9 +335,9 @@ void emit
             >
               권장
             </th>
-            <th class="w-14 px-1 py-2 text-center font-black">상태</th>
+            <th class="w-16 px-1 py-2 text-center font-black">상태</th>
             <th class="w-16 px-1 py-2 text-center font-black">수량</th>
-            <th class="w-12 px-2 py-2 text-center font-black"></th>
+            <th class="w-16 px-1 py-2 text-center font-black">담기</th>
           </tr>
         </thead>
         <tbody :class="!selectedWarehouseCode ? 'pointer-events-none opacity-50' : ''">
@@ -368,22 +359,18 @@ void emit
             <td class="truncate px-2 py-2 align-middle" :title="row.vendorName">
               <span class="text-[11px] font-black text-gray-700">{{ row.vendorName }}</span>
             </td>
-            <td
-              class="truncate px-2 py-2 align-middle font-mono text-[10px] text-gray-500"
-              :title="row.productCode"
-            >
-              {{ row.productCode }}
-            </td>
-            <td class="px-2 py-2 align-middle" :title="row.productName">
-              <span class="block whitespace-normal break-words text-xs font-black leading-tight text-gray-800">
-                {{ row.productName }}
-              </span>
-            </td>
-            <td class="px-2 py-2 align-middle">
-              <span class="text-[11px] font-bold text-[#004D3C]">{{ row.displayOption }}</span>
-            </td>
-            <td class="px-2 py-2 align-middle font-mono text-[10px] text-gray-500">
-              {{ row.skuCode }}
+            <td class="px-2 py-2 align-middle" :title="`${row.productName} · ${row.skuCode}`">
+              <div class="flex flex-col gap-0.5">
+                <div class="flex flex-wrap items-baseline gap-x-2">
+                  <span class="whitespace-normal break-words text-xs font-black leading-tight text-gray-800">
+                    {{ row.productName }}
+                  </span>
+                  <span v-if="row.displayOption" class="text-[11px] font-bold text-[#004D3C]">
+                    {{ row.displayOption }}
+                  </span>
+                </div>
+                <span class="font-mono text-[10px] text-gray-400">{{ row.skuCode }}</span>
+              </div>
             </td>
             <td class="px-2 py-2 text-right align-middle font-bold text-[#004D3C]">
               ₩{{ row.unitPrice.toLocaleString() }}
@@ -405,8 +392,8 @@ void emit
                 <button
                   v-if="rowSuggested(row.skuCode) > 0"
                   type="button"
-                  class="border border-red-300 bg-red-50 px-2 py-0.5 text-[10px] font-black text-red-700 hover:bg-red-100"
-                  :title="`권장 발주 ${rowSuggested(row.skuCode)}개를 수량 입력란에 채웁니다`"
+                  class="text-xs font-black text-[#004D3C] hover:underline"
+                  :title="`클릭 시 수량 입력란에 ${rowSuggested(row.skuCode)} 채움`"
                   @click="applySuggestedToSku(row)"
                 >
                   {{ rowSuggested(row.skuCode) }}
@@ -442,41 +429,40 @@ void emit
                 @keydown.enter.exact="$emit('add-sku-to-cart', row)"
               />
             </td>
-            <td class="px-2 py-2 text-center align-middle">
-              <div class="inline-flex items-center gap-1">
-                <button
-                  type="button"
-                  class="inline-flex items-center justify-center border border-[#004D3C] bg-white p-1 text-[#004D3C] hover:bg-[#E6F2F0] disabled:cursor-not-allowed disabled:opacity-40"
-                  :disabled="!(Number(rowQuantities[row.skuCode]) > 0)"
-                  title="장바구니 담기 (Enter)"
-                  @click="$emit('add-sku-to-cart', row)"
-                >
-                  <PlusIcon :size="12" />
-                </button>
-                <button
-                  v-if="isInCart(row.skuCode)"
-                  type="button"
-                  class="text-[10px] font-bold text-[#004D3C] hover:underline"
-                  title="장바구니에서 보기"
-                  @click="$emit('scroll-to-cart-sku', row.skuCode)"
-                >
-                  ●
-                </button>
-              </div>
+            <td class="px-1 py-2 text-center align-middle">
+              <button
+                v-if="isInCart(row.skuCode)"
+                type="button"
+                class="inline-flex items-center justify-center border border-[#004D3C] bg-[#E6F2F0] px-2 py-0.5 text-[10px] font-black text-[#004D3C] hover:bg-[#D6EAE6]"
+                title="장바구니에서 보기"
+                @click="$emit('scroll-to-cart-sku', row.skuCode)"
+              >
+                ✓ 담김
+              </button>
+              <button
+                v-else
+                type="button"
+                class="inline-flex items-center justify-center border border-[#004D3C] bg-white px-2 py-0.5 text-[10px] font-black text-[#004D3C] hover:bg-[#E6F2F0] disabled:cursor-not-allowed disabled:opacity-40"
+                :disabled="!(Number(rowQuantities[row.skuCode]) > 0)"
+                title="장바구니 담기 (Enter)"
+                @click="$emit('add-sku-to-cart', row)"
+              >
+                담기
+              </button>
             </td>
           </tr>
           <tr v-if="!catalogLoading && catalogSkuRows.length === 0">
-            <td colspan="12" class="px-3 py-8 text-center text-xs text-gray-400">
+            <td colspan="9" class="px-3 py-8 text-center text-xs text-gray-400">
               노출 가능한 계약 제품이 없습니다.
             </td>
           </tr>
           <tr v-else-if="!catalogLoading && filteredRows.length === 0">
-            <td colspan="12" class="px-3 py-8 text-center text-xs text-gray-400">
+            <td colspan="9" class="px-3 py-8 text-center text-xs text-gray-400">
               검색 결과가 없습니다.
             </td>
           </tr>
           <tr v-if="catalogLoading">
-            <td colspan="12" class="px-3 py-8 text-center text-xs text-gray-400">
+            <td colspan="9" class="px-3 py-8 text-center text-xs text-gray-400">
               카탈로그를 불러오는 중...
             </td>
           </tr>

--- a/src/composables/hq/purchaseOrder/useStockSim.js
+++ b/src/composables/hq/purchaseOrder/useStockSim.js
@@ -18,9 +18,9 @@ export function usePurchaseOrderStockSim(selectedWarehouseCode) {
     return stockStore.getSkuSuggestedQuantity(rowStock(skuCode))
   }
 
-  function stockLevelClass(level) {
-    if (level === 'critical') return 'text-red-600'
-    if (level === 'warning') return 'text-amber-600'
+  // 재고 숫자 색상은 항상 중립 회색 — 부족/주의/품절 상태는 별도 "상태" 컬럼 칩이 담당.
+  // level 인자는 호환을 위해 받지만 사용 안 함.
+  function stockLevelClass(_level) {
     return 'text-gray-700'
   }
 

--- a/src/views/hq/purchase-order/HqPurchaseOrderCreateView.vue
+++ b/src/views/hq/purchase-order/HqPurchaseOrderCreateView.vue
@@ -6,7 +6,7 @@ import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
 import { usePurchaseOrderStore } from '@/stores/purchaseOrder.js'
 import { usePurchaseOrderCartStore } from '@/stores/hq/purchaseOrderCart.js'
-import { ArrowLeftIcon, ShoppingCartIcon } from '@/components/hq/purchase-order/icons.js'
+import { ArrowLeftIcon } from '@/components/hq/purchase-order/icons.js'
 import PurchaseOrderBulkQtyModal from '@/components/hq/purchase-order/PurchaseOrderBulkQtyModal.vue'
 import PurchaseOrderCart from '@/components/hq/purchase-order/PurchaseOrderCart.vue'
 import PurchaseOrderCatalog from '@/components/hq/purchase-order/PurchaseOrderCatalog.vue'
@@ -37,7 +37,7 @@ const activeTopMenu = computed(() => '물류 창고 발주')
 const selectedWarehouseCode = ref('')
 const keyword = ref('')
 const vendorFilter = ref('all')
-const sortBy = ref('default')
+const sortBy = ref('vendorAsc')
 const cart = ref([])
 
 // 재고 시뮬레이션 / facet 필터 / 카탈로그 헬퍼는 PurchaseOrderCatalog child 가 자체 보유.
@@ -64,21 +64,6 @@ const rowQuantities = ref({})
 const collapsed = ref({})
 // 부족만 보기 토글 (마스터 단위 — 그룹 헤더의 가용재고 < 안전재고 × 1.5 인 그룹만)
 const shortageOnly = ref(false)
-
-// 발주 요청서 패널 접힘 상태 — localStorage 로 사용자 선호 기억.
-// 카탈로그 폭 확보를 위한 ERP 스타일 collapse 토글 (접힘 시 우측 가는 trigger bar).
-const CART_COLLAPSED_KEY = 'stockit:po-cart-collapsed'
-const cartCollapsed = ref(localStorage.getItem(CART_COLLAPSED_KEY) === 'true')
-watch(cartCollapsed, (v) => {
-  try {
-    localStorage.setItem(CART_COLLAPSED_KEY, v ? 'true' : 'false')
-  } catch {
-    // quota / private mode — 영속화만 실패, 동작은 그대로
-  }
-})
-function toggleCartCollapsed() {
-  cartCollapsed.value = !cartCollapsed.value
-}
 
 // ─── Power 모드 ─────────────────────────────────────────────────────────────
 // 다중 선택: skuCode set — Floating bar 와 카탈로그가 v-model 로 공유.
@@ -591,7 +576,6 @@ watch(vendorFilter, () => {
         />
 
         <PurchaseOrderCart
-          v-if="!cartCollapsed"
           :cart="cart"
           :current-cart-vendor-name="currentCartVendorName"
           :grouped-by-vendor="groupedByVendor"
@@ -606,32 +590,7 @@ watch(vendorFilter, () => {
           @scroll-to-catalog-sku="scrollToCatalogSku"
           @open-clear-cart-confirm="openClearCartConfirm"
           @open-submit-confirm="openSubmitConfirm"
-          @toggle-collapse="toggleCartCollapsed"
         />
-
-        <!-- 접힘 상태 trigger bar — 클릭 시 카트 펼치기. 카탈로그가 풀 폭 사용 -->
-        <button
-          v-else
-          type="button"
-          class="group flex w-full shrink-0 items-center justify-between gap-2 border border-gray-300 bg-white px-3 py-2 text-[11px] font-black text-[#004D3C] shadow-sm hover:bg-[#E6F2F0] xl:w-12 xl:flex-col xl:justify-start xl:px-2 xl:py-3"
-          title="발주 요청서 펼치기"
-          aria-label="발주 요청서 펼치기"
-          @click="toggleCartCollapsed"
-        >
-          <span class="inline-flex items-center gap-1 xl:flex-col xl:gap-2">
-            <span class="text-base xl:rotate-180">‹</span>
-            <ShoppingCartIcon :size="14" />
-          </span>
-          <span
-            v-if="cart.length > 0"
-            class="inline-flex items-center bg-[#004D3C] px-1.5 py-0.5 text-[10px] font-black text-white xl:[writing-mode:vertical-rl]"
-          >
-            {{ cart.length }}건
-          </span>
-          <span class="hidden text-[10px] font-bold text-gray-500 xl:inline xl:[writing-mode:vertical-rl]">
-            발주 요청서
-          </span>
-        </button>
       </section>
     </div>
 


### PR DESCRIPTION
## 📌 요약
- 본사 발주 신규 등록 페이지(/hq/purchase-orders/new) 의 거슬리는 UI 부분을 정리. 우측 발주서 패널 토글 제거 + 카탈로그 컬럼 축약 + 정렬 옵션 표준화.

<br><br>

## 🎯 작업 내용
- 우측 발주서 패널 토글 제거 → 항상 열림 고정. 본사 발주는 멀티 공급처 자동 분할이 핵심 정보라 매번 토글로 열어 확인하는 인지부담이 컸음. localStorage 영속화·트리거 바 같이 제거.
- 카탈로그 컬럼 축약: 제품코드·옵션·SKU 를 "제품" 셀 하나로 통합 (제품명 + 옵션 인라인 + SKU secondary). 좁아진 좌측 폭에서 한 줄에 들어오게 정리.
- 재고 컬럼 색상 회색 통일 — 부족/주의 표현은 상태 칩이 전담 (재고 색상 + 상태 칩 이중 표현 정리).
- 권장 버튼 빨강 박스 → 평범한 녹색 숫자 (헤더에 "권장" 컬럼명이 이미 있어 라벨 중복 제거, 위험감 톤 해소). 담기 액션 [+] 아이콘 → [담기] 텍스트 버튼, 카트에 이미 있는 SKU 는 [✓ 담김].
- 정렬 select 옵션 표준화: 다단계 표기("공급처 → 제품") 제거, 모든 옵션 "필드 ↑/↓" 일관 형식. default 와 vendorAsc 중복 통합, 기본값 vendorAsc.

<br><br>

## ✔️ 참고 사항
- 

<br><br>

## ✔️ 관련 이슈

- 

<br><br>
