### PR TITLE
refactor: 퀵 기본 로그인 사원 코드 변경

### DIFF
--- a/src/views/user/DevLoginView.vue
+++ b/src/views/user/DevLoginView.vue
@@ -16,9 +16,9 @@ const selectedRole = ref('')   // 'HQ' | 'STORE' | 'WAREHOUSE'
 
 // 권한별 간편 로그인 계정 — BE AdminBootstrapRunner 가 생성하는 계정 (.env ADMIN_BOOTSTRAP_PASSWORD)
 const quickAccounts = {
-  HQ:        { code: 'HQ-A0001', password: 'Stockit!2026', label: '본사 관리자', icon: Building2, desc: '본사 통합 운영' },
-  STORE:     { code: 'ST-A0001', password: 'Stockit!2026', label: '매장 관리자', icon: Store,     desc: '매장 재고/주문' },
-  WAREHOUSE: { code: 'WH-A0001', password: 'Stockit!2026', label: '창고 관리자', icon: Warehouse, desc: '입출고/물류' },
+  HQ:        { code: 'hq0001', password: 'Stockit!2026', label: '본사 관리자', icon: Building2, desc: '본사 통합 운영' },
+  STORE:     { code: 'st0001', password: 'Stockit!2026', label: '매장 관리자', icon: Store,     desc: '매장 재고/주문' },
+  WAREHOUSE: { code: 'wh0001', password: 'Stockit!2026', label: '창고 관리자', icon: Warehouse, desc: '입출고/물류' },
 }
 
 const roleOptions = computed(() => Object.entries(quickAccounts).map(([key, v]) => ({ key, ...v })))
@@ -129,10 +129,6 @@ async function handleSubmit() {
 
       <!-- 오른쪽 로그인 폼 -->
       <div class="flex flex-col justify-center p-8 md:p-10">
-        <p class="mb-5 text-[28px] font-black leading-[1] tracking-[-0.01em] text-[#16A34A] sm:text-[36px] md:text-[44px]">
-          무중단 배포 GREEN v2
-        </p>
-
         <div class="mb-8">
           <div class="mb-4 inline-flex items-center gap-1.5 border border-[#cfe2dc] bg-[#eef7f4] px-2.5 py-1.5 text-[11px] font-black text-[#004D3C]">
             <ShieldCheck :size="14" />


### PR DESCRIPTION
## 📌 요약
- Dev 로그인 화면의 Quick Login 코드 값을 백엔드 부트스트랩 계정 코드와 동일하게 맞췄습니다.
- FE-BE 계정 코드 불일치로 인한 개발 로그인 혼선을 제거했습니다.

<br><br>

## 🎯 작업 내용
- `DevLoginView.vue`의 HQ Quick Login 코드 `HQ-A0001` → `hq0001` 변경
- `DevLoginView.vue`의 STORE Quick Login 코드 `ST-A0001` → `st0001` 변경
- `DevLoginView.vue`의 WAREHOUSE Quick Login 코드 `WH-A0001` → `wh0001` 변경

<br><br>

## ✔️ 참고 사항
- Quick Login의 비밀번호/라벨/권한 선택 동작은 기존과 동일하게 유지했습니다.
- 백엔드 부트스트랩 계정 변경이 함께 반영되어야 실제 로그인 테스트가 정상 동작합니다.

<br><br>

## ✔️ 관련 이슈

- Close #461

<br><br>
