### PR TITLE
refactor(inventory): 전사/창고 재고 조회 페이징 + PaginationNav 도입

### DIFF
--- a/src/api/warehouse/inventory.js
+++ b/src/api/warehouse/inventory.js
@@ -1,7 +1,7 @@
 import api, { unwrap } from '@/api/axios.js'
 
-export async function getWarehouseInventories() {
-  const res = await api.get('/api/warehouse/inventories')
+export async function getWarehouseInventories(params = {}) {
+  const res = await api.get('/api/warehouse/inventories', { params })
   return unwrap(res)
 }
 

--- a/src/components/common/PaginationNav.vue
+++ b/src/components/common/PaginationNav.vue
@@ -1,0 +1,123 @@
+<script setup>
+import { computed } from 'vue'
+import { ChevronsLeft, ChevronLeft, ChevronRight, ChevronsRight } from 'lucide-vue-next'
+
+const props = defineProps({
+  page: { type: Number, required: true },          // 0-based
+  size: { type: Number, required: true },
+  totalPages: { type: Number, required: true },
+  totalElements: { type: Number, required: true },
+  hasPrevious: { type: Boolean, required: true },
+  hasNext: { type: Boolean, required: true },
+  sizeOptions: { type: Array, default: () => [20, 50, 100] },
+})
+
+const emit = defineEmits(['update:page', 'update:size'])
+
+const WINDOW = 5
+
+// 표시할 페이지 번호 윈도우 (1-based, 현재 ±2 기본)
+const pageWindow = computed(() => {
+  const total = Math.max(props.totalPages, 1)
+  const current1 = props.page + 1
+  let start = Math.max(1, current1 - 2)
+  let end = Math.min(total, start + WINDOW - 1)
+  if (end - start + 1 < WINDOW) {
+    start = Math.max(1, end - WINDOW + 1)
+  }
+  const out = []
+  for (let i = start; i <= end; i++) out.push(i)
+  return out
+})
+
+function goFirst() {
+  if (props.page !== 0) emit('update:page', 0)
+}
+function goPrev() {
+  if (props.hasPrevious) emit('update:page', props.page - 1)
+}
+function goNext() {
+  if (props.hasNext) emit('update:page', props.page + 1)
+}
+function goLast() {
+  const last = Math.max(props.totalPages - 1, 0)
+  if (props.page !== last) emit('update:page', last)
+}
+function goPage(p1) {
+  emit('update:page', p1 - 1)
+}
+function onSizeChange(e) {
+  const next = Number(e.target.value)
+  if (Number.isFinite(next) && next > 0) emit('update:size', next)
+}
+</script>
+
+<template>
+  <div class="flex flex-wrap items-center justify-between gap-3 border-t border-gray-200 bg-white px-4 py-3">
+    <p class="text-[11px] font-bold text-gray-500">총 {{ totalElements.toLocaleString() }}건</p>
+
+    <div class="flex items-center gap-1">
+      <button
+        type="button"
+        class="flex h-7 w-7 items-center justify-center border border-gray-200 text-gray-500 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40"
+        :disabled="page === 0"
+        aria-label="첫 페이지"
+        @click="goFirst"
+      >
+        <ChevronsLeft :size="14" />
+      </button>
+      <button
+        type="button"
+        class="flex h-7 w-7 items-center justify-center border border-gray-200 text-gray-500 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40"
+        :disabled="!hasPrevious"
+        aria-label="이전 페이지"
+        @click="goPrev"
+      >
+        <ChevronLeft :size="14" />
+      </button>
+
+      <button
+        v-for="p in pageWindow"
+        :key="p"
+        type="button"
+        class="flex h-7 min-w-7 items-center justify-center px-2 text-[11px] font-black"
+        :class="p - 1 === page
+          ? 'bg-[#004D3C] text-white'
+          : 'border border-gray-200 text-gray-700 hover:bg-[#EBF5F5]'"
+        @click="goPage(p)"
+      >
+        {{ p }}
+      </button>
+
+      <button
+        type="button"
+        class="flex h-7 w-7 items-center justify-center border border-gray-200 text-gray-500 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40"
+        :disabled="!hasNext"
+        aria-label="다음 페이지"
+        @click="goNext"
+      >
+        <ChevronRight :size="14" />
+      </button>
+      <button
+        type="button"
+        class="flex h-7 w-7 items-center justify-center border border-gray-200 text-gray-500 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40"
+        :disabled="page >= totalPages - 1 || totalPages <= 0"
+        aria-label="마지막 페이지"
+        @click="goLast"
+      >
+        <ChevronsRight :size="14" />
+      </button>
+    </div>
+
+    <label class="flex items-center gap-2 text-[11px] font-bold text-gray-500">
+      페이지당
+      <select
+        :value="size"
+        class="h-7 border border-gray-300 bg-white px-2 text-[11px] font-bold text-gray-900 outline-none focus:border-[#004D3C]"
+        @change="onSizeChange"
+      >
+        <option v-for="opt in sizeOptions" :key="opt" :value="opt">{{ opt }}</option>
+      </select>
+    </label>
+  </div>
+</template>

--- a/src/views/hq/inventory/HqCompanyWideInventoryView.vue
+++ b/src/views/hq/inventory/HqCompanyWideInventoryView.vue
@@ -2,6 +2,7 @@
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import AppLayout from '@/components/common/AppLayout.vue'
+import PaginationNav from '@/components/common/PaginationNav.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { getCompanyWideInventories } from '@/api/hq/inventory.js'
 
@@ -33,6 +34,14 @@ const categoryMap = {
 const locationTypeOptions = ['매장', '창고']
 const locationOptionsRaw = ref([])
 const inventoryData = ref([])
+
+// 페이징 상태
+const currentPage = ref(0)
+const pageSize = ref(20)
+const totalElements = ref(0)
+const totalPages = ref(0)
+const hasNext = ref(false)
+const hasPrevious = ref(false)
 
 const childCategoryOptions = computed(() =>
   selectedParentCategory.value ? categoryMap[selectedParentCategory.value] : [],
@@ -138,6 +147,8 @@ async function fetchCompanyWideInventory() {
       parentCategory: selectedParentCategory.value || undefined,
       childCategory: selectedChildCategory.value || undefined,
       keyword: searchTerm.value || undefined,
+      page: currentPage.value,
+      size: pageSize.value,
     }
     if (selectedLocations.value.length > 0) payload.locationIds = locationIds
 
@@ -163,11 +174,29 @@ async function fetchCompanyWideInventory() {
       status: item.status,
       updatedAt: item.updatedAt ? new Date(item.updatedAt).toLocaleString('ko-KR', { hour12: false }) : '-',
     }))
+
+    totalElements.value = Number(res?.totalElements ?? 0)
+    totalPages.value = Number(res?.totalPages ?? 0)
+    hasNext.value = Boolean(res?.hasNext)
+    hasPrevious.value = Boolean(res?.hasPrevious)
   } catch (e) {
     loadError.value = e.message || '전사 재고 조회에 실패했습니다.'
     inventoryData.value = []
+    totalElements.value = 0
+    totalPages.value = 0
+    hasNext.value = false
+    hasPrevious.value = false
   } finally {
     isLoading.value = false
+  }
+}
+
+// 필터 변경 시 page=0 으로 리셋 후 fetch (page 가 이미 0 이면 직접 fetch — page watch 가 안 트리거되므로)
+function resetPageOrFetch() {
+  if (currentPage.value === 0) {
+    fetchCompanyWideInventory()
+  } else {
+    currentPage.value = 0
   }
 }
 
@@ -200,8 +229,17 @@ const handleDocumentClick = (event) => {
   }
 }
 
-watch([locationType, selectedParentCategory, selectedChildCategory, selectedStatus, searchTerm, selectedLocations], () => {
+// selectedStatus 는 BE InventoryStatus enum 과 매핑 안 되는 UI 라벨(정상/부족/품절) 이라 클라 필터로만 적용 — watch 제외
+watch([locationType, selectedParentCategory, selectedChildCategory, searchTerm, selectedLocations], () => {
+  resetPageOrFetch()
+})
+
+watch(currentPage, () => {
   fetchCompanyWideInventory()
+})
+
+watch(pageSize, () => {
+  resetPageOrFetch()
 })
 
 onMounted(() => {
@@ -236,7 +274,7 @@ const statusClass = (status) => ({
             <h1 class="mt-1 text-lg font-black text-gray-900">전사 재고 조회</h1>
           </div>
           <div class="text-right text-[11px] font-bold text-gray-500">
-            <p>조회 결과 {{ filteredInventory.length.toLocaleString() }}건</p>
+            <p>조회 결과 {{ totalElements.toLocaleString() }}건</p>
             <p class="mt-1 text-gray-400">{{ locationSummary }}</p>
           </div>
         </div>
@@ -436,6 +474,16 @@ const statusClass = (status) => ({
             </tbody>
           </table>
         </div>
+        <PaginationNav
+          :page="currentPage"
+          :size="pageSize"
+          :total-pages="totalPages"
+          :total-elements="totalElements"
+          :has-previous="hasPrevious"
+          :has-next="hasNext"
+          @update:page="currentPage = $event"
+          @update:size="pageSize = $event"
+        />
       </section>
     </div>
   </AppLayout>

--- a/src/views/warehouse/WarehouseInventoryView.vue
+++ b/src/views/warehouse/WarehouseInventoryView.vue
@@ -1,7 +1,8 @@
 ﻿<script setup>
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import AppLayout from '@/components/common/AppLayout.vue'
+import PaginationNav from '@/components/common/PaginationNav.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
 import { getWarehouseInventories } from '@/api/warehouse/inventory.js'
@@ -29,20 +30,17 @@ const selectedChildCategory = ref(typeof route.query.child === 'string' ? route.
 const selectedStatus = ref(typeof route.query.status === 'string' ? route.query.status : '')
 const searchTerm = ref(typeof route.query.search === 'string' ? route.query.search : '')
 
+// 페이징 상태
+const currentPage = ref(0)
+const pageSize = ref(20)
+const totalElements = ref(0)
+const totalPages = ref(0)
+const hasNext = ref(false)
+const hasPrevious = ref(false)
+
 const childCategoryOptions = computed(() =>
   selectedParentCategory.value ? categoryMap[selectedParentCategory.value] : [],
 )
-
-const filteredInventory = computed(() => {
-  const keyword = searchTerm.value.trim().toLowerCase()
-  return inventoryData.value.filter((item) => {
-    const matchesParent = !selectedParentCategory.value || item.parentCategory === selectedParentCategory.value
-    const matchesChild = !selectedChildCategory.value || item.childCategory === selectedChildCategory.value
-    const matchesStatus = !selectedStatus.value || item.status === selectedStatus.value
-    const matchesKeyword = !keyword || [item.itemCode, item.itemName].join(' ').toLowerCase().includes(keyword)
-    return matchesParent && matchesChild && matchesStatus && matchesKeyword
-  })
-})
 
 const statusClass = (status) => ({
   정상: 'bg-[#EBF5F5] text-black',
@@ -65,6 +63,8 @@ function resetFilters() {
   selectedChildCategory.value = ''
   selectedStatus.value = ''
   searchTerm.value = ''
+  // watch 가 page=0 리셋 + fetch 트리거 — 단 모든 값이 이미 비어 있으면 watch 안 트리거 → 수동 호출
+  if (currentPage.value === 0) loadInventories()
 }
 
 function moveToSkuDetail(item) {
@@ -91,22 +91,58 @@ async function loadInventories() {
   isLoading.value = true
   loadError.value = ''
   try {
-    const rows = await getWarehouseInventories()
-    inventoryData.value = Array.isArray(rows)
-      ? rows.map(row => ({
-        ...row,
-        actualStock: Number(row.actualStock ?? 0),
-        availableStock: Number(row.availableStock ?? 0),
-        safetyStock: Number(row.safetyStock ?? 0),
-      }))
-      : []
+    const params = {
+      parentCategory: selectedParentCategory.value || undefined,
+      childCategory: selectedChildCategory.value || undefined,
+      status: selectedStatus.value || undefined,
+      keyword: searchTerm.value || undefined,
+      page: currentPage.value,
+      size: pageSize.value,
+    }
+    const res = await getWarehouseInventories(params)
+    const items = Array.isArray(res?.items) ? res.items : []
+    inventoryData.value = items.map(row => ({
+      ...row,
+      actualStock: Number(row.actualStock ?? 0),
+      availableStock: Number(row.availableStock ?? 0),
+      safetyStock: Number(row.safetyStock ?? 0),
+    }))
+    totalElements.value = Number(res?.totalElements ?? 0)
+    totalPages.value = Number(res?.totalPages ?? 0)
+    hasNext.value = Boolean(res?.hasNext)
+    hasPrevious.value = Boolean(res?.hasPrevious)
   } catch (e) {
     inventoryData.value = []
+    totalElements.value = 0
+    totalPages.value = 0
+    hasNext.value = false
+    hasPrevious.value = false
     loadError.value = extractErrorMessage(e, '창고 재고를 불러오지 못했습니다.')
   } finally {
     isLoading.value = false
   }
 }
+
+// 필터 변경 시 page=0 으로 리셋 후 fetch (page 가 이미 0 이면 직접 fetch — page watch 가 안 트리거되므로)
+function resetPageOrFetch() {
+  if (currentPage.value === 0) {
+    loadInventories()
+  } else {
+    currentPage.value = 0
+  }
+}
+
+watch([selectedParentCategory, selectedChildCategory, selectedStatus, searchTerm], () => {
+  resetPageOrFetch()
+})
+
+watch(currentPage, () => {
+  loadInventories()
+})
+
+watch(pageSize, () => {
+  resetPageOrFetch()
+})
 
 onMounted(() => {
   loadInventories()
@@ -129,7 +165,7 @@ onMounted(() => {
           </div>
           <div class="text-right text-[11px] font-bold text-gray-500">
             <p>{{ auth.user?.locationCode ?? 'WAREHOUSE' }} · {{ auth.user?.locationName ?? '창고' }}</p>
-            <p class="mt-1 text-gray-400">기준일 {{ today }} · 조회 {{ filteredInventory.length }}건</p>
+            <p class="mt-1 text-gray-400">기준일 {{ today }} · 조회 {{ totalElements.toLocaleString() }}건</p>
           </div>
         </div>
         <p v-if="loadError" class="mb-3 text-xs font-bold text-red-600">{{ loadError }}</p>
@@ -216,7 +252,7 @@ onMounted(() => {
               </thead>
               <tbody class="divide-y divide-gray-100">
                 <tr
-                  v-for="item in filteredInventory"
+                  v-for="item in inventoryData"
                   :key="item.itemCode"
                   class="cursor-pointer hover:bg-[#EBF5F5]/60"
                   @click="moveToSkuDetail(item)"
@@ -234,7 +270,7 @@ onMounted(() => {
                   </td>
                   <td class="px-3 py-3 font-bold text-gray-500">{{ item.updatedAt ? new Date(item.updatedAt).toLocaleString('ko-KR', { hour12: false }) : '-' }}</td>
                 </tr>
-                <tr v-if="filteredInventory.length === 0">
+                <tr v-if="inventoryData.length === 0">
                   <td colspan="8" class="px-3 py-14 text-center text-sm font-bold text-gray-400">
                     {{ isLoading ? '창고 재고를 불러오는 중입니다.' : '조건에 맞는 창고 재고가 없습니다.' }}
                   </td>
@@ -242,6 +278,16 @@ onMounted(() => {
               </tbody>
             </table>
           </div>
+          <PaginationNav
+            :page="currentPage"
+            :size="pageSize"
+            :total-pages="totalPages"
+            :total-elements="totalElements"
+            :has-previous="hasPrevious"
+            :has-next="hasNext"
+            @update:page="currentPage = $event"
+            @update:size="pageSize = $event"
+          />
         </div>
       </section>
     </div>


### PR DESCRIPTION
## 📌 요약
- 공통 PaginationNav 신규 + 전사/창고 재고 조회 View 페이징 동기화, 클라 필터를 서버 query param 으로 이동

<br><br>

## 🎯 작업 내용
- `components/common/PaginationNav.vue` 신규 (page/size/totalPages/hasNext/hasPrevious, 페이지 윈도우 ±2 + 페이지당 셀렉트)
- `HqCompanyWideInventoryView` / `WarehouseInventoryView` 페이징 상태 + 필터 변경 시 page=0 리셋, v-for 응답 items 그대로
- `api/warehouse/inventory.js` `getWarehouseInventories(params)` 시그니처 확장

<br><br>

## ✔️ 참고 사항
- 

<br><br>

## ✔️ 관련 이슈

- Close #464

<br><br>
