### PR TITLE
refactor(purchase-order): 발주 상세 안내 문구에서 자동 전환 디테일 제거

### DIFF
--- a/src/components/hq/purchase-order/PurchaseOrderDetailPanel.vue
+++ b/src/components/hq/purchase-order/PurchaseOrderDetailPanel.vue
@@ -164,27 +164,20 @@ const { statusClass, statusLabel, historyDotClass, historyTextClass, formatDate 
           </button>
         </div>
         <p class="pt-1 text-center text-[11px] leading-relaxed text-gray-500">
-          30분 후 시스템이 자동으로 공급처 승인을 처리합니다.<br />
-          그 전에 [수정] 또는 [취소] 가능합니다.
+          [수정] 또는 [취소] 가능합니다.
         </p>
       </template>
 
       <template v-else-if="order.status === 'APPROVED'">
-        <p class="text-center text-xs leading-relaxed text-gray-500">
-          승인 완료 · 30분 후 시스템이 자동으로 배송 준비 처리합니다.
-        </p>
+        <p class="text-center text-xs leading-relaxed text-gray-500">승인 완료</p>
       </template>
 
       <template v-else-if="order.status === 'READY_TO_SHIP'">
-        <p class="text-center text-xs leading-relaxed text-gray-500">
-          배송 준비 중 · 30분 후 시스템이 자동으로 배송 시작 처리합니다.
-        </p>
+        <p class="text-center text-xs leading-relaxed text-gray-500">배송 준비 중</p>
       </template>
 
       <template v-else-if="order.status === 'IN_TRANSIT'">
-        <p class="text-center text-xs leading-relaxed text-gray-500">
-          배송 중 · 30분 후 시스템이 자동으로 배송 완료 처리합니다.
-        </p>
+        <p class="text-center text-xs leading-relaxed text-gray-500">배송 중</p>
       </template>
 
       <template v-else-if="order.status === 'ARRIVED'">


### PR DESCRIPTION
## 📌 요약
- 발주 상세 패널의 상태별 안내문에서 "30분 후 시스템이 자동으로 …" 표현 제거. 사용자 행동(수정/취소) 만 남도록 정리.

<br><br>

## 🎯 작업 내용
- REQUESTED 안내문을 "[수정] 또는 [취소] 가능합니다." 한 줄로
- APPROVED 안내문을 "승인 완료" 로
- READY_TO_SHIP 안내문을 "배송 준비 중" 으로
- IN_TRANSIT 안내문을 "배송 중" 으로
- ARRIVED 는 "30분" 표현 없어 그대로 둠

<br><br>

## ✔️ 참고 사항
- SYS-001 배치 주기(30분) 같은 시스템 내부 디테일은 사용자 멘탈 모델 밖이라 노출하지 않는 게 UX 우선 원칙에 맞음

<br><br>

## ✔️ 관련 이슈

- Close #467

<br><br>
