### PR TITLE
refactor(purchase-order): 카탈로그 페이지네이션 + 서버 필터/검색 도입

### DIFF
--- a/src/api/hq/purchaseOrder.js
+++ b/src/api/hq/purchaseOrder.js
@@ -9,6 +9,8 @@
  *   POST   /api/hq/purchase-orders/{code}/complete                   (SHIPPING → COMPLETED, 창고 WHS-007)
  *   POST   /api/hq/purchase-orders/{code}/cancel                     (CEN-038 PENDING → REJECTED, with cancelReason)
  *   POST   /api/hq/purchase-orders/batch/run                         (SYS-001 강제 트리거, 시연·QA용)
+ *   GET    /api/hq/purchase-orders/catalog?...&page&size&sort        (새 발주 카탈로그 페이지)
+ *   GET    /api/hq/purchase-orders/catalog/facets?vendorCode=&keyword= (색상/사이즈 facet)
  *
  * SYS-001 자동화: PENDING → APPROVED, APPROVED → SHIPPING 두 단계는 5분 주기 배치가
  *   30분 경과한 발주를 자동 전환. 본사는 작성·취소만, 단건 수동 트리거 엔드포인트 없음.
@@ -78,21 +80,39 @@ export const purchaseOrderApi = {
     apiClient.post(`${BASE}/${code}/cancel`, { cancelReason }).then(unwrap),
 
   /**
-   * 새 발주 페이지 카탈로그 — vendor_product → ProductMaster → ProductSku 묶음 응답.
-   * GET /api/hq/purchase-orders/catalog?vendorCode=&warehouseId=
+   * 새 발주 페이지 카탈로그 — BE Page<SkuRowRes> 평탄 row.
+   * GET /api/hq/purchase-orders/catalog?page&size&sort&vendorCode&keyword&color&skuSize&shortageOnly&warehouseId
    *
-   * vendorCode 미지정: 모든 ACTIVE 공급처 펼침. 지정 시 그 공급처만.
-   * warehouseCode 는 본 사이클 BE 가 사용하지 않음 (인벤토리 합류 후 stock 필터링용).
-   * 응답: { masters: [{ vendorCode, vendorName, vendorProductCode, productCode, productName,
-   *                     contractUnitPrice, minSkuUnitPrice, maxSkuUnitPrice,
-   *                     skus: [{ skuCode, color, size, displayOption, unitPrice }] }],
-   *         optionFacets: [{ name, values: [string] }] }
+   * 응답: Page<{ vendorCode, vendorName, vendorProductCode, productCode, productName,
+   *              skuCode, color, size, displayOption, unitPrice, contractUnitPrice, availableQty }>
+   *
+   * @param {{page?, size?, sort?, vendorCode?, keyword?, color?, skuSize?, shortageOnly?, warehouseId?}} params
+   *   - sort: "vendorName,asc" / "productName,asc" / "unitPrice,asc|desc" / "availableQty,asc" / "id,asc"
+   *   - SKU 사이즈 필터 키는 page size 와 충돌 회피 위해 caller/server 모두 `skuSize`.
    */
-  getCatalog: ({ vendorCode = '', warehouseCode = '' } = {}) => {
+  getCatalog: (params = {}) => {
+    const query = {}
+    if (params.page !== undefined && params.page !== null) query.page = params.page
+    if (params.size !== undefined && params.size !== null) query.size = params.size
+    if (params.sort) query.sort = params.sort
+    if (params.vendorCode) query.vendorCode = params.vendorCode
+    if (params.keyword) query.keyword = params.keyword
+    if (params.color) query.color = params.color
+    if (params.skuSize) query.skuSize = params.skuSize
+    if (params.shortageOnly) query.shortageOnly = params.shortageOnly
+    if (params.warehouseId) query.warehouseId = params.warehouseId
+    return apiClient.get(`${BASE}/catalog`, { params: query }).then(unwrap)
+  },
+
+  /**
+   * 새 발주 카탈로그 facet — 같은 필터 조건의 색상/사이즈 distinct 옵션.
+   * GET /api/hq/purchase-orders/catalog/facets?vendorCode=&keyword=
+   * 응답: { colors: [string], sizes: [string] }
+   */
+  getCatalogFacets: ({ vendorCode = '', keyword = '' } = {}) => {
     const query = {}
     if (vendorCode) query.vendorCode = vendorCode
-    // warehouseCode 는 BE 가 warehouseId(Long) 로 받지만 본 사이클은 placeholder — 보내지 않음
-    void warehouseCode
-    return apiClient.get(`${BASE}/catalog`, { params: query }).then(unwrap)
+    if (keyword) query.keyword = keyword
+    return apiClient.get(`${BASE}/catalog/facets`, { params: query }).then(unwrap)
   },
 }

--- a/src/components/hq/purchase-order/PurchaseOrderBulkQtyModal.vue
+++ b/src/components/hq/purchase-order/PurchaseOrderBulkQtyModal.vue
@@ -33,7 +33,7 @@ function onApply() {
       <div class="bg-[#004D3C] px-5 py-3 text-white">
         <h2 class="text-sm font-black">수량 일괄 입력</h2>
       </div>
-      <div class="p-5 text-xs text-gray-700">
+      <div class="p-5 text-sm text-gray-700">
         <p class="mb-3">
           선택한 <strong>{{ selectedCount }}개 SKU</strong> 모두에 동일한 수량을 적용합니다.
         </p>
@@ -49,14 +49,14 @@ function onApply() {
       <div class="flex items-center justify-end gap-2 border-t border-gray-200 bg-gray-50 px-5 py-3">
         <button
           type="button"
-          class="border border-gray-300 bg-white px-4 py-2 text-xs font-black text-gray-700 hover:bg-gray-100"
+          class="border border-gray-300 bg-white px-4 py-2 text-sm font-black text-gray-700 hover:bg-gray-100"
           @click="emit('close')"
         >
           취소
         </button>
         <button
           type="button"
-          class="border border-[#004D3C] bg-[#004D3C] px-4 py-2 text-xs font-black text-white hover:bg-[#1f4b3a]"
+          class="border border-[#004D3C] bg-[#004D3C] px-4 py-2 text-sm font-black text-white hover:bg-[#1f4b3a]"
           @click="onApply"
         >
           적용

--- a/src/components/hq/purchase-order/PurchaseOrderCancelModal.vue
+++ b/src/components/hq/purchase-order/PurchaseOrderCancelModal.vue
@@ -33,15 +33,15 @@ function onConfirm() {
       <div class="bg-red-700 px-5 py-3 text-white">
         <h2 class="text-sm font-black">발주 취소</h2>
       </div>
-      <div class="space-y-3 p-5 text-xs text-gray-700">
-        <p class="text-[10px] font-bold uppercase tracking-wider text-gray-400">발주 정보</p>
+      <div class="space-y-3 p-5 text-sm text-gray-700">
+        <p class="text-[11px] font-bold uppercase tracking-wider text-gray-400">발주 정보</p>
         <p>
           <strong>{{ order.id }}</strong> ·
           {{ order.vendorName }} ·
           <span class="font-bold text-[#004D3C]">₩{{ order.totalPrice.toLocaleString() }}</span>
         </p>
         <label class="block">
-          <span class="text-[10px] font-bold uppercase tracking-wider text-gray-500">
+          <span class="text-[11px] font-bold uppercase tracking-wider text-gray-500">
             취소 사유 (선택)
           </span>
           <textarea
@@ -49,24 +49,24 @@ function onConfirm() {
             rows="3"
             maxlength="500"
             placeholder="예: 공급처 단가 변경, 수량 잘못 입력 등"
-            class="mt-1 w-full resize-none border border-gray-300 px-2 py-1.5 text-xs outline-none focus:border-red-500"
+            class="mt-1 w-full resize-none border border-gray-300 px-2 py-1.5 text-sm outline-none focus:border-red-500"
           />
         </label>
-        <p class="text-[11px] leading-relaxed text-red-600">
+        <p class="text-xs leading-relaxed text-red-600">
           취소 후에는 되돌릴 수 없습니다. 같은 발주가 필요하면 새 발주로 다시 만들어야 합니다.
         </p>
       </div>
       <div class="flex items-center justify-end gap-2 border-t border-gray-200 bg-gray-50 px-5 py-3">
         <button
           type="button"
-          class="border border-gray-300 bg-white px-4 py-2 text-xs font-black text-gray-700 hover:bg-gray-100"
+          class="border border-gray-300 bg-white px-4 py-2 text-sm font-black text-gray-700 hover:bg-gray-100"
           @click="emit('cancel')"
         >
           취소
         </button>
         <button
           type="button"
-          class="border border-red-700 bg-red-700 px-4 py-2 text-xs font-black text-white hover:bg-red-600"
+          class="border border-red-700 bg-red-700 px-4 py-2 text-sm font-black text-white hover:bg-red-600"
           @click="onConfirm"
         >
           취소 확정

--- a/src/components/hq/purchase-order/PurchaseOrderCart.vue
+++ b/src/components/hq/purchase-order/PurchaseOrderCart.vue
@@ -31,11 +31,11 @@ defineEmits([
   >
     <!-- 헤더 -->
     <div class="flex items-center justify-between bg-[#004D3C] px-4 py-3 text-white">
-      <h3 class="inline-flex items-center gap-2 text-[11px] font-black uppercase tracking-wider">
+      <h3 class="inline-flex items-center gap-2 text-xs font-black uppercase tracking-wider">
         <ShoppingCartIcon :size="14" />
         발주 요청서
       </h3>
-      <span class="text-[10px] font-bold opacity-80">
+      <span class="text-[11px] font-bold opacity-80">
         <template v-if="isEditMode">{{ cart.length }}건</template>
         <template v-else-if="groupedByVendor.length > 0">
           {{ groupedByVendor.length }}곳 · {{ cart.length }}건
@@ -47,7 +47,7 @@ defineEmits([
     <!-- 공급처 표시 — edit 모드 단일 vendor / 신규 모드 그룹 카드 N장 -->
     <div
       v-if="isEditMode && currentCartVendorName"
-      class="border-b border-gray-200 bg-[#E6F2F0] px-4 py-2 text-[10px] font-black uppercase tracking-wider text-[#004D3C]"
+      class="border-b border-gray-200 bg-[#E6F2F0] px-4 py-2 text-[11px] font-black uppercase tracking-wider text-[#004D3C]"
     >
       {{ currentCartVendorName }}
     </div>
@@ -62,7 +62,7 @@ defineEmits([
         <li
           v-for="g in groupedByVendor"
           :key="g.vendorId"
-          class="flex items-center justify-between gap-2 text-[10px] text-[#004D3C]"
+          class="flex items-center justify-between gap-2 text-[11px] text-[#004D3C]"
         >
           <span class="truncate font-black">{{ g.vendorName }}</span>
           <span class="shrink-0 font-bold">
@@ -74,7 +74,7 @@ defineEmits([
 
     <!-- 본문 -->
     <div class="flex-1 overflow-y-auto p-3">
-      <div v-if="cart.length === 0" class="py-10 text-center text-xs text-gray-400">
+      <div v-if="cart.length === 0" class="py-10 text-center text-sm text-gray-400">
         왼쪽 카탈로그에서 품목을 담아주세요
       </div>
       <ul v-else class="space-y-2">
@@ -91,18 +91,18 @@ defineEmits([
         >
           <div class="flex items-start justify-between gap-2">
             <div class="min-w-0 flex-1">
-              <p class="text-xs font-black text-gray-800">{{ item.productName }}</p>
-              <p v-if="item.displayOption" class="text-[10px] font-bold text-[#004D3C]">
+              <p class="text-sm font-black text-gray-800">{{ item.productName }}</p>
+              <p v-if="item.displayOption" class="text-[11px] font-bold text-[#004D3C]">
                 {{ item.displayOption }}
               </p>
-              <p class="text-[10px] text-gray-400">
+              <p class="text-[11px] text-gray-400">
                 {{ item.skuCode || item.productCode }} · ₩{{ item.unitPrice.toLocaleString() }}
               </p>
             </div>
             <button
               v-if="item.skuCode"
               type="button"
-              class="text-[10px] font-bold text-gray-500 hover:text-[#004D3C] underline"
+              class="text-[11px] font-bold text-gray-500 hover:text-[#004D3C] underline"
               title="좌측 카탈로그에서 보기"
               @click="$emit('scroll-to-catalog-sku', item.skuCode)"
             >
@@ -121,7 +121,7 @@ defineEmits([
             <div class="flex items-center gap-1">
               <button
                 type="button"
-                class="flex h-6 w-6 items-center justify-center border border-gray-300 bg-white text-xs hover:bg-gray-50"
+                class="flex h-6 w-6 items-center justify-center border border-gray-300 bg-white text-sm hover:bg-gray-50"
                 @click="$emit('decrease-qty', idx)"
               >
                 −
@@ -130,18 +130,18 @@ defineEmits([
                 :value="item.quantity"
                 type="number"
                 min="1"
-                class="w-12 border border-gray-300 py-0.5 text-center text-xs outline-none focus:border-[#004D3C]"
+                class="w-12 border border-gray-300 py-0.5 text-center text-sm outline-none focus:border-[#004D3C]"
                 @change="$emit('update-qty', idx, $event.target.value)"
               />
               <button
                 type="button"
-                class="flex h-6 w-6 items-center justify-center border border-gray-300 bg-white text-xs hover:bg-gray-50"
+                class="flex h-6 w-6 items-center justify-center border border-gray-300 bg-white text-sm hover:bg-gray-50"
                 @click="$emit('increase-qty', idx)"
               >
                 +
               </button>
             </div>
-            <span class="text-xs font-bold text-gray-700">
+            <span class="text-sm font-bold text-gray-700">
               ₩{{ (item.unitPrice * item.quantity).toLocaleString() }}
             </span>
           </div>
@@ -152,13 +152,13 @@ defineEmits([
     <!-- 푸터 -->
     <div class="space-y-2 border-t border-gray-200 bg-gray-50 p-3">
       <div class="flex items-center justify-between">
-        <span class="text-[11px] font-bold uppercase text-gray-500">총액</span>
+        <span class="text-xs font-bold uppercase text-gray-500">총액</span>
         <span class="text-sm font-black text-[#004D3C]"> ₩{{ cartTotal.toLocaleString() }} </span>
       </div>
       <div class="grid grid-cols-2 gap-2">
         <button
           type="button"
-          class="border border-gray-400 bg-white px-2 py-2 text-[11px] font-black text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+          class="border border-gray-400 bg-white px-2 py-2 text-xs font-black text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
           :disabled="cart.length === 0"
           @click="$emit('open-clear-cart-confirm')"
         >
@@ -166,7 +166,7 @@ defineEmits([
         </button>
         <button
           type="button"
-          class="border border-[#004D3C] bg-[#004D3C] px-2 py-2 text-[11px] font-black text-white hover:bg-[#1f4b3a] disabled:cursor-not-allowed disabled:opacity-50"
+          class="border border-[#004D3C] bg-[#004D3C] px-2 py-2 text-xs font-black text-white hover:bg-[#1f4b3a] disabled:cursor-not-allowed disabled:opacity-50"
           :disabled="!canSubmit"
           @click="$emit('open-submit-confirm')"
         >

--- a/src/components/hq/purchase-order/PurchaseOrderCatalog.vue
+++ b/src/components/hq/purchase-order/PurchaseOrderCatalog.vue
@@ -1,13 +1,14 @@
 <script setup>
-import { computed, ref, toRef } from 'vue'
+import { computed, ref, toRef, watch } from 'vue'
 import { usePurchaseOrderStore } from '@/stores/purchaseOrder.js'
-import { useFacets } from '@/composables/hq/purchaseOrder/useFacets.js'
 import { usePurchaseOrderStockSim } from '@/composables/hq/purchaseOrder/useStockSim.js'
 import { SearchIcon } from '@/components/hq/purchase-order/icons.js'
+import PaginationNav from '@/components/common/PaginationNav.vue'
 
-// 새 발주 카탈로그 — ERP 테이블 스타일.
-// 한 행 = 1 SKU. 공급처/제품/옵션이 컬럼으로 평면화 → 그룹 헤더 제거.
-// 멀티 공급처 카트 흐름 (BE batch API) 과 일관 — 사용자가 자유롭게 여러 공급처 SKU 를 담는다.
+// 새 발주 카탈로그 — ERP 평탄 테이블 (Page<SkuRowRes> 평탄 row 위에 master 헤더 inline grouping).
+// 검색·공급처·색상·사이즈·부족만·정렬 모두 서버 처리 (store.applyCatalogFilters).
+// 본 컴포넌트는 v-model 시그니처(keyword/vendorFilter/sortBy/shortageOnly/selectedSkus/rowQuantities/collapsed)
+// 를 호환 유지하되, 카탈로그 필터는 watch 로 store action 트리거.
 
 const props = defineProps({
   selectedWarehouseCode: { type: String, required: true },
@@ -20,15 +21,13 @@ const vendorFilter = defineModel('vendorFilter', { type: String, required: true 
 const sortBy = defineModel('sortBy', { type: String, required: true })
 const shortageOnly = defineModel('shortageOnly', { type: Boolean, required: true })
 const selectedSkus = defineModel('selectedSkus', { type: Set, required: true })
-// collapsed 는 평면 테이블에선 사용 안 함 — 부모 v-model 호환 위해 정의만 유지
+// collapsed 는 평면 테이블에서 사용 안 함 — 부모 v-model 호환 위해 정의만 유지
 defineModel('collapsed', { type: Object, required: true })
 const rowQuantities = defineModel('rowQuantities', { type: Object, required: true })
 
 const emit = defineEmits(['add-sku-to-cart', 'add-group-to-cart', 'scroll-to-cart-sku'])
 
 const poStore = usePurchaseOrderStore()
-const { activeFacetFilters, toggleFacet, isFacetActive, clearFacets, skuMatchesFacets } =
-  useFacets()
 const {
   stockStore,
   rowStock,
@@ -36,107 +35,95 @@ const {
   rowSuggested,
   stockLevelClass,
   statusChipForSku,
-  shortageRank,
 } = usePurchaseOrderStockSim(toRef(props, 'selectedWarehouseCode'))
 
 const searchInputRef = ref(null)
 
-const catalogSkuRows = computed(() => poStore.catalogSkuRows)
-const catalogFacets = computed(() => poStore.catalogFacets)
+// FE sortBy → BE Pageable.sort 키 매핑 (화이트리스트)
+const SORT_MAP = {
+  vendorAsc: 'vendorName,asc',
+  nameAsc: 'productName,asc',
+  priceAsc: 'unitPrice,asc',
+  priceDesc: 'unitPrice,desc',
+  shortage: 'availableQty,asc',
+}
+
+// vendorFilter 'all' → '' (store 는 빈 문자열 = 전체)
+function normalizeVendor(v) {
+  return v && v !== 'all' ? v : ''
+}
+
+// selectedWarehouseCode → warehouseId Long (store.warehouses 에서 매핑)
+const selectedWarehouseId = computed(() => {
+  const code = props.selectedWarehouseCode
+  if (!code) return null
+  const wh = poStore.warehouses.find((w) => w.code === code)
+  return wh?.id ?? null
+})
+
+// ── watch 모음 — 변경 시 server fetch 트리거 ───────────────────────────
+// keyword 는 300ms 디바운스. 그 외는 즉시 (드롭다운/칩/토글이라 매 변경 빈번 X).
+let keywordTimer = null
+watch(keyword, (v) => {
+  if (keywordTimer) clearTimeout(keywordTimer)
+  keywordTimer = setTimeout(() => {
+    poStore.applyCatalogFilters({ keyword: v ?? '' })
+  }, 300)
+})
+
+watch(vendorFilter, (v) => {
+  poStore.applyCatalogFilters({ vendor: normalizeVendor(v) })
+})
+
+watch(sortBy, (v) => {
+  poStore.applyCatalogFilters({ sort: SORT_MAP[v] ?? 'id,asc' })
+})
+
+watch(shortageOnly, (v) => {
+  poStore.applyCatalogFilters({ shortageOnly: !!v })
+})
+
+watch(selectedWarehouseId, (v) => {
+  poStore.applyCatalogFilters({ warehouseId: v })
+})
+
+// ── 색상/사이즈 facet — single select (현재 같은 값 다시 클릭하면 해제) ──
+function selectColor(c) {
+  const next = poStore.catalogColor === c ? '' : c
+  poStore.applyCatalogFilters({ color: next })
+}
+function selectSize(s) {
+  const next = poStore.catalogSkuSize === s ? '' : s
+  poStore.applyCatalogFilters({ skuSize: next })
+}
+function clearFacets() {
+  poStore.applyCatalogFilters({ color: '', skuSize: '' })
+}
+
+// ── 표시용 computed ───────────────────────────────────────────────────
+const catalogRows = computed(() => poStore.catalogRows)
+const catalogColors = computed(() => poStore.catalogColors)
+const catalogSizes = computed(() => poStore.catalogSizes)
 const catalogLoading = computed(() => poStore.catalogLoading)
 
+// 페이지 안 vendor distinct — 한 페이지 안 vendor 만 보이는 한계는 별 phase 개선 예정
 const vendorOptions = computed(() => {
   const seen = new Map()
-  for (const r of catalogSkuRows.value) {
-    if (r.type === 'header' && !seen.has(r.vendorCode)) {
+  for (const r of catalogRows.value) {
+    if (!seen.has(r.vendorCode)) {
       seen.set(r.vendorCode, { id: r.vendorCode, code: r.vendorCode, name: r.vendorName })
     }
   }
   return [...seen.values()].sort((a, b) => a.name.localeCompare(b.name, 'ko'))
 })
 
-// 평면 SKU 행 — 검색/공급처필터/facet/부족/정렬 적용한 SKU 행만 반환.
-const filteredRows = computed(() => {
-  const kw = keyword.value.trim().toLowerCase()
-  let skus = catalogSkuRows.value.filter((r) => r.type === 'sku')
-  if (skus.length === 0) return []
+const skuRows = computed(() => catalogRows.value)
 
-  // 공급처 필터 (server-side fetch 와 별개로 client 도 안전망)
-  if (vendorFilter.value && vendorFilter.value !== 'all') {
-    skus = skus.filter((r) => r.vendorCode === vendorFilter.value)
-  }
-
-  // 키워드
-  if (kw) {
-    skus = skus.filter((r) =>
-      [
-        r.vendorName,
-        r.vendorCode,
-        r.productName,
-        r.productCode,
-        r.skuCode,
-        r.color,
-        r.size,
-        r.displayOption,
-      ].some((s) => (s ?? '').toLowerCase().includes(kw)),
-    )
-  }
-
-  // Facet (색상·사이즈)
-  skus = skus.filter(skuMatchesFacets)
-
-  // 부족만
-  if (shortageOnly.value && props.selectedWarehouseCode) {
-    skus = skus.filter((r) => {
-      const level = rowStockLevel(r.skuCode)
-      return level === 'critical' || level === 'warning'
-    })
-  }
-
-  // 정렬
-  switch (sortBy.value) {
-    case 'shortage':
-      skus = [...skus].sort((a, b) => {
-        const rankDiff = shortageRank(a.skuCode) - shortageRank(b.skuCode)
-        if (rankDiff !== 0) return rankDiff
-        return (
-          a.productName.localeCompare(b.productName, 'ko') ||
-          (a.displayOption ?? '').localeCompare(b.displayOption ?? '', 'ko')
-        )
-      })
-      break
-    case 'priceAsc':
-      skus = [...skus].sort((a, b) => a.unitPrice - b.unitPrice)
-      break
-    case 'priceDesc':
-      skus = [...skus].sort((a, b) => b.unitPrice - a.unitPrice)
-      break
-    case 'nameAsc':
-      skus = [...skus].sort(
-        (a, b) =>
-          a.productName.localeCompare(b.productName, 'ko') ||
-          (a.displayOption || '').localeCompare(b.displayOption || '', 'ko'),
-      )
-      break
-    case 'vendorAsc':
-    default:
-      // 공급처명 가나다 → 제품명 가나다 → 옵션 순. 기본 정렬.
-      skus = [...skus].sort(
-        (a, b) =>
-          a.vendorName.localeCompare(b.vendorName, 'ko') ||
-          a.productName.localeCompare(b.productName, 'ko') ||
-          (a.displayOption || '').localeCompare(b.displayOption || '', 'ko'),
-      )
-  }
-
-  return skus
-})
-
-const matchedSkuCount = computed(() => filteredRows.value.length)
+const matchedSkuCount = computed(() => poStore.catalogTotalElements)
 
 const shortageCount = computed(() => {
   if (!props.selectedWarehouseCode) return 0
-  const skuCodes = catalogSkuRows.value.filter((r) => r.type === 'sku').map((r) => r.skuCode)
+  const skuCodes = catalogRows.value.map((r) => r.skuCode)
   return stockStore.getSkuShortageCount(props.selectedWarehouseCode, skuCodes)
 })
 
@@ -153,23 +140,21 @@ function toggleSkuSelected(skuCode) {
 
 function toggleAllVisible() {
   const set = new Set(selectedSkus.value)
-  const allOn = filteredRows.value.every((r) => set.has(r.skuCode))
+  const allOn = skuRows.value.every((r) => set.has(r.skuCode))
   if (allOn) {
-    for (const r of filteredRows.value) set.delete(r.skuCode)
+    for (const r of skuRows.value) set.delete(r.skuCode)
   } else {
-    for (const r of filteredRows.value) set.add(r.skuCode)
+    for (const r of skuRows.value) set.add(r.skuCode)
   }
   selectedSkus.value = set
 }
 
 const isAllSelected = computed(
   () =>
-    filteredRows.value.length > 0 &&
-    filteredRows.value.every((r) => selectedSkus.value.has(r.skuCode)),
+    skuRows.value.length > 0 && skuRows.value.every((r) => selectedSkus.value.has(r.skuCode)),
 )
 const isSomeSelected = computed(
-  () =>
-    filteredRows.value.some((r) => selectedSkus.value.has(r.skuCode)) && !isAllSelected.value,
+  () => skuRows.value.some((r) => selectedSkus.value.has(r.skuCode)) && !isAllSelected.value,
 )
 
 function applySuggestedToSku(row) {
@@ -189,8 +174,7 @@ function scrollToSku(skuCode) {
 
 defineExpose({ focusSearch, scrollToSku })
 
-// 평면 테이블에선 그룹 단위 액션 의미 없음 — add-group-to-cart 는 emit 안 함.
-// 부모의 addGroupToCart 핸들러는 unused (호환 보존, 향후 제거 후보).
+// add-group-to-cart 는 평면 테이블에선 사용 안 함 — 호환 보존
 void emit
 </script>
 
@@ -209,20 +193,20 @@ void emit
           v-model="keyword"
           type="text"
           placeholder='제품명/SKU/공급처/옵션 검색  ("/" 로 포커스)'
-          class="w-72 border border-gray-300 bg-white py-1.5 pl-8 pr-3 text-xs outline-none focus:border-[#004D3C]"
+          class="w-72 border border-gray-300 bg-white py-1.5 pl-8 pr-3 text-sm outline-none focus:border-[#004D3C]"
         />
       </label>
       <select
         v-model="vendorFilter"
         :disabled="isEditMode"
-        class="border border-gray-300 bg-white px-3 py-1.5 text-xs outline-none focus:border-[#004D3C] disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500"
+        class="border border-gray-300 bg-white px-3 py-1.5 text-sm outline-none focus:border-[#004D3C] disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500"
       >
         <option value="all">전체 공급처</option>
         <option v-for="v in vendorOptions" :key="v.code" :value="v.code">{{ v.name }}</option>
       </select>
       <select
         v-model="sortBy"
-        class="border border-gray-300 bg-white px-3 py-1.5 text-xs outline-none focus:border-[#004D3C]"
+        class="border border-gray-300 bg-white px-3 py-1.5 text-sm outline-none focus:border-[#004D3C]"
         title="정렬 기준"
       >
         <option value="vendorAsc">공급처명 ↑</option>
@@ -233,7 +217,7 @@ void emit
       </select>
       <button
         type="button"
-        class="border px-3 py-1.5 text-[11px] font-black transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+        class="border px-3 py-1.5 text-xs font-black transition-colors disabled:cursor-not-allowed disabled:opacity-50"
         :class="
           shortageOnly
             ? 'border-red-400 bg-red-50 text-red-700'
@@ -241,55 +225,62 @@ void emit
               ? 'border-red-300 bg-white text-red-600 hover:bg-red-50'
               : 'border-gray-300 bg-white text-gray-600 hover:bg-gray-50'
         "
-        :disabled="!selectedWarehouseCode || shortageCount === 0"
+        :disabled="!selectedWarehouseCode"
         :title="
           !selectedWarehouseCode
             ? '먼저 창고를 선택하세요'
-            : shortageCount === 0
-              ? '재고 부족 SKU 없음'
-              : '가용재고가 안전재고 1.5배 미만인 SKU만 표시'
+            : '안전재고 미만 SKU 만 표시 (서버 필터)'
         "
         @click="shortageOnly = !shortageOnly"
       >
-        {{
-          shortageOnly
-            ? `✓ 부족만 (${shortageCount})`
-            : selectedWarehouseCode && shortageCount > 0
-              ? `부족만 보기 (${shortageCount})`
-              : '부족만 보기'
-        }}
+        {{ shortageOnly ? '✓ 부족만' : '부족만 보기' }}
       </button>
-      <span class="ml-auto text-[11px] font-bold text-gray-500">SKU {{ matchedSkuCount }}건</span>
+      <span class="ml-auto text-xs font-bold text-gray-500">SKU {{ matchedSkuCount }}건</span>
     </div>
 
-    <!-- Facet 필터 칩 (색상/사이즈) -->
+    <!-- Facet 필터 칩 (색상/사이즈) — single select -->
     <div
-      v-if="catalogFacets.length > 0"
+      v-if="catalogColors.length > 0 || catalogSizes.length > 0"
       class="flex flex-wrap items-center gap-2 border-b border-gray-200 bg-white px-2 py-2 pr-[15px]"
     >
-      <div v-for="facet in catalogFacets" :key="facet.name" class="flex items-center gap-1">
-        <span class="text-[10px] font-black uppercase tracking-wider text-gray-400">
-          {{ facet.name }}
-        </span>
+      <div v-if="catalogColors.length > 0" class="flex items-center gap-1">
+        <span class="text-[11px] font-black uppercase tracking-wider text-gray-400">색상</span>
         <button
-          v-for="value in facet.values"
-          :key="`${facet.name}-${value}`"
+          v-for="value in catalogColors"
+          :key="`color-${value}`"
           type="button"
-          class="border px-2 py-0.5 text-[10px] font-bold transition-colors"
+          class="border px-2 py-0.5 text-[11px] font-bold transition-colors"
           :class="
-            isFacetActive(facet.name, value)
+            poStore.catalogColor === value
               ? 'border-[#004D3C] bg-[#004D3C] text-white'
               : 'border-gray-300 bg-white text-gray-600 hover:bg-gray-50'
           "
-          @click="toggleFacet(facet.name, value)"
+          @click="selectColor(value)"
+        >
+          {{ value }}
+        </button>
+      </div>
+      <div v-if="catalogSizes.length > 0" class="flex items-center gap-1">
+        <span class="text-[11px] font-black uppercase tracking-wider text-gray-400">사이즈</span>
+        <button
+          v-for="value in catalogSizes"
+          :key="`size-${value}`"
+          type="button"
+          class="border px-2 py-0.5 text-[11px] font-bold transition-colors"
+          :class="
+            poStore.catalogSkuSize === value
+              ? 'border-[#004D3C] bg-[#004D3C] text-white'
+              : 'border-gray-300 bg-white text-gray-600 hover:bg-gray-50'
+          "
+          @click="selectSize(value)"
         >
           {{ value }}
         </button>
       </div>
       <button
-        v-if="Object.keys(activeFacetFilters).length > 0"
+        v-if="poStore.catalogColor || poStore.catalogSkuSize"
         type="button"
-        class="ml-auto text-[10px] font-bold text-gray-500 underline hover:text-gray-700"
+        class="ml-auto text-[11px] font-bold text-gray-500 underline hover:text-gray-700"
         @click="clearFacets"
       >
         필터 초기화
@@ -299,36 +290,31 @@ void emit
     <!-- 창고 미선택 안내 -->
     <div
       v-if="!selectedWarehouseCode"
-      class="border-b border-amber-200 bg-amber-50 px-3 py-2 pr-[15px] text-[11px] font-bold text-amber-700"
+      class="border-b border-amber-200 bg-amber-50 px-3 py-2 pr-[15px] text-xs font-bold text-amber-700"
     >
       입고 창고를 먼저 선택해주세요. 창고가 정해져야 발주서를 만들 수 있습니다.
     </div>
 
-    <!-- 카탈로그 테이블 — ERP 스타일 평면. 헤더 sticky. -->
+    <!-- 카탈로그 테이블 — master 헤더 inline. -->
     <div class="min-h-0 flex-1 overflow-auto">
-      <table class="w-full table-fixed border-collapse text-xs">
-        <thead class="sticky top-0 z-10 bg-gray-100 text-xs text-gray-600 shadow-sm">
+      <table class="w-full table-fixed border-collapse text-sm">
+        <thead class="sticky top-0 z-10 bg-gray-100 text-sm text-gray-600 shadow-sm">
           <tr>
             <th class="w-8 px-1 py-2 text-center font-black">
               <input
                 type="checkbox"
                 :checked="isAllSelected"
                 :indeterminate.prop="isSomeSelected"
-                :disabled="filteredRows.length === 0"
+                :disabled="skuRows.length === 0"
                 class="cursor-pointer disabled:cursor-not-allowed"
-                title="화면에 보이는 SKU 전체 선택"
+                title="현재 페이지 SKU 전체 선택"
                 @change="toggleAllVisible"
               />
             </th>
             <th class="w-28 px-2 py-2 text-left font-black">공급처</th>
             <th class="px-2 py-2 text-left font-black">제품</th>
             <th class="w-24 px-2 py-2 text-right font-black">단가</th>
-            <th
-              class="w-14 px-2 py-2 text-right font-black"
-              title="가용재고 (실재고 + 입고예정 - 출고예정)"
-            >
-              재고
-            </th>
+            <th class="w-14 px-2 py-2 text-right font-black" title="가용재고">재고</th>
             <th
               class="w-14 px-2 py-2 text-right font-black"
               title="안전재고 × 1.5 까지 채우는 권장 발주 수량"
@@ -342,132 +328,139 @@ void emit
         </thead>
         <tbody :class="!selectedWarehouseCode ? 'pointer-events-none opacity-50' : ''">
           <tr
-            v-for="row in filteredRows"
-            :key="`s-${row.skuCode}`"
+            v-for="row in catalogRows"
+            :key="row.skuCode"
             class="border-b border-gray-100 hover:bg-[#F4FAF8]"
             :class="selectedSkus.has(row.skuCode) ? 'bg-emerald-50' : ''"
             :data-sku-code="row.skuCode"
           >
-            <td class="px-1 py-2 text-center align-middle">
-              <input
-                type="checkbox"
-                :checked="selectedSkus.has(row.skuCode)"
-                class="cursor-pointer"
-                @change="toggleSkuSelected(row.skuCode)"
-              />
-            </td>
-            <td class="truncate px-2 py-2 align-middle" :title="row.vendorName">
-              <span class="text-[11px] font-black text-gray-700">{{ row.vendorName }}</span>
-            </td>
-            <td class="px-2 py-2 align-middle" :title="`${row.productName} · ${row.skuCode}`">
-              <div class="flex flex-col gap-0.5">
-                <div class="flex flex-wrap items-baseline gap-x-2">
-                  <span class="whitespace-normal break-words text-xs font-black leading-tight text-gray-800">
-                    {{ row.productName }}
-                  </span>
-                  <span v-if="row.displayOption" class="text-[11px] font-bold text-[#004D3C]">
-                    {{ row.displayOption }}
-                  </span>
+              <td class="px-1 py-2 text-center align-middle">
+                <input
+                  type="checkbox"
+                  :checked="selectedSkus.has(row.skuCode)"
+                  class="cursor-pointer"
+                  @change="toggleSkuSelected(row.skuCode)"
+                />
+              </td>
+              <td class="truncate px-2 py-2 align-middle" :title="row.vendorName">
+                <span class="text-xs font-black text-gray-700">{{ row.vendorName }}</span>
+              </td>
+              <td class="px-2 py-2 align-middle" :title="`${row.productName} · ${row.skuCode}`">
+                <div class="flex flex-col gap-0.5">
+                  <div class="flex flex-wrap items-baseline gap-x-2">
+                    <span class="whitespace-normal break-words text-sm font-black leading-tight text-gray-800">
+                      {{ row.productName }}
+                    </span>
+                    <span v-if="row.displayOption" class="text-xs font-bold text-[#004D3C]">
+                      {{ row.displayOption }}
+                    </span>
+                  </div>
+                  <span class="font-mono text-[11px] text-gray-400">{{ row.skuCode }}</span>
                 </div>
-                <span class="font-mono text-[10px] text-gray-400">{{ row.skuCode }}</span>
-              </div>
-            </td>
-            <td class="px-2 py-2 text-right align-middle font-bold text-[#004D3C]">
-              ₩{{ row.unitPrice.toLocaleString() }}
-            </td>
-            <td
-              class="px-2 py-2 text-right align-middle font-bold"
-              :class="stockLevelClass(rowStockLevel(row.skuCode))"
-              :title="
-                rowStock(row.skuCode)
-                  ? `실재고 ${rowStock(row.skuCode).onHand} · 안전 ${rowStock(row.skuCode).safetyStock}`
-                  : ''
-              "
-            >
-              <template v-if="rowStock(row.skuCode)">{{ rowStock(row.skuCode).available }}</template>
-              <span v-else class="text-gray-300">—</span>
-            </td>
-            <td class="px-2 py-2 text-right align-middle">
-              <template v-if="rowStock(row.skuCode)">
-                <button
-                  v-if="rowSuggested(row.skuCode) > 0"
-                  type="button"
-                  class="text-xs font-black text-[#004D3C] hover:underline"
-                  :title="`클릭 시 수량 입력란에 ${rowSuggested(row.skuCode)} 채움`"
-                  @click="applySuggestedToSku(row)"
-                >
-                  {{ rowSuggested(row.skuCode) }}
-                </button>
-                <span v-else class="text-gray-300">—</span>
-              </template>
-              <span v-else class="text-gray-300">—</span>
-            </td>
-            <td class="px-1 py-2 text-center align-middle">
-              <template v-if="statusChipForSku(row.skuCode)">
-                <span
-                  class="inline-flex min-w-9 justify-center px-1.5 py-0.5 text-[10px] font-black"
-                  :class="statusChipForSku(row.skuCode).class"
-                >
-                  {{ statusChipForSku(row.skuCode).label }}
-                </span>
-              </template>
-              <span v-else class="text-gray-300">—</span>
-            </td>
-            <td class="px-1 py-2 align-middle">
-              <input
-                type="number"
-                min="0"
-                placeholder="0"
-                class="w-full border border-gray-300 px-1 py-1 text-center text-xs outline-none focus:border-[#004D3C]"
-                :value="rowQuantities[row.skuCode] ?? ''"
-                @input="
-                  rowQuantities = {
-                    ...rowQuantities,
-                    [row.skuCode]: Number($event.target.value) || 0,
-                  }
+              </td>
+              <td class="px-2 py-2 text-right align-middle font-bold text-[#004D3C]">
+                ₩{{ row.unitPrice.toLocaleString() }}
+              </td>
+              <td
+                class="px-2 py-2 text-right align-middle font-bold"
+                :class="stockLevelClass(rowStockLevel(row.skuCode))"
+                :title="
+                  rowStock(row.skuCode)
+                    ? `실재고 ${rowStock(row.skuCode).onHand} · 안전 ${rowStock(row.skuCode).safetyStock}`
+                    : `BE 가용 ${row.availableQty}`
                 "
-                @keydown.enter.exact="$emit('add-sku-to-cart', row)"
-              />
-            </td>
-            <td class="px-1 py-2 text-center align-middle">
-              <button
-                v-if="isInCart(row.skuCode)"
-                type="button"
-                class="inline-flex items-center justify-center border border-[#004D3C] bg-[#E6F2F0] px-2 py-0.5 text-[10px] font-black text-[#004D3C] hover:bg-[#D6EAE6]"
-                title="장바구니에서 보기"
-                @click="$emit('scroll-to-cart-sku', row.skuCode)"
               >
-                ✓ 담김
-              </button>
-              <button
-                v-else
-                type="button"
-                class="inline-flex items-center justify-center border border-[#004D3C] bg-white px-2 py-0.5 text-[10px] font-black text-[#004D3C] hover:bg-[#E6F2F0] disabled:cursor-not-allowed disabled:opacity-40"
-                :disabled="!(Number(rowQuantities[row.skuCode]) > 0)"
-                title="장바구니 담기 (Enter)"
-                @click="$emit('add-sku-to-cart', row)"
-              >
-                담기
-              </button>
-            </td>
+                <template v-if="rowStock(row.skuCode)">{{ rowStock(row.skuCode).available }}</template>
+                <template v-else>{{ row.availableQty }}</template>
+              </td>
+              <td class="px-2 py-2 text-right align-middle">
+                <template v-if="rowStock(row.skuCode)">
+                  <button
+                    v-if="rowSuggested(row.skuCode) > 0"
+                    type="button"
+                    class="text-sm font-black text-[#004D3C] hover:underline"
+                    :title="`클릭 시 수량 입력란에 ${rowSuggested(row.skuCode)} 채움`"
+                    @click="applySuggestedToSku(row)"
+                  >
+                    {{ rowSuggested(row.skuCode) }}
+                  </button>
+                  <span v-else class="text-gray-300">—</span>
+                </template>
+                <span v-else class="text-gray-300">—</span>
+              </td>
+              <td class="px-1 py-2 text-center align-middle">
+                <template v-if="statusChipForSku(row.skuCode)">
+                  <span
+                    class="inline-flex min-w-9 justify-center px-1.5 py-0.5 text-[11px] font-black"
+                    :class="statusChipForSku(row.skuCode).class"
+                  >
+                    {{ statusChipForSku(row.skuCode).label }}
+                  </span>
+                </template>
+                <span v-else class="text-gray-300">—</span>
+              </td>
+              <td class="px-1 py-2 align-middle">
+                <input
+                  type="number"
+                  min="0"
+                  placeholder="0"
+                  class="w-full border border-gray-300 px-1 py-1 text-center text-sm outline-none focus:border-[#004D3C]"
+                  :value="rowQuantities[row.skuCode] ?? ''"
+                  @input="
+                    rowQuantities = {
+                      ...rowQuantities,
+                      [row.skuCode]: Number($event.target.value) || 0,
+                    }
+                  "
+                  @keydown.enter.exact="$emit('add-sku-to-cart', row)"
+                />
+              </td>
+              <td class="px-1 py-2 text-center align-middle">
+                <button
+                  v-if="isInCart(row.skuCode)"
+                  type="button"
+                  class="inline-flex items-center justify-center border border-[#004D3C] bg-[#E6F2F0] px-2 py-0.5 text-[11px] font-black text-[#004D3C] hover:bg-[#D6EAE6]"
+                  title="장바구니에서 보기"
+                  @click="$emit('scroll-to-cart-sku', row.skuCode)"
+                >
+                  ✓ 담김
+                </button>
+                <button
+                  v-else
+                  type="button"
+                  class="inline-flex items-center justify-center border border-[#004D3C] bg-white px-2 py-0.5 text-[11px] font-black text-[#004D3C] hover:bg-[#E6F2F0] disabled:cursor-not-allowed disabled:opacity-40"
+                  :disabled="!(Number(rowQuantities[row.skuCode]) > 0)"
+                  title="장바구니 담기 (Enter)"
+                  @click="$emit('add-sku-to-cart', row)"
+                >
+                  담기
+                </button>
+              </td>
           </tr>
-          <tr v-if="!catalogLoading && catalogSkuRows.length === 0">
-            <td colspan="9" class="px-3 py-8 text-center text-xs text-gray-400">
-              노출 가능한 계약 제품이 없습니다.
-            </td>
-          </tr>
-          <tr v-else-if="!catalogLoading && filteredRows.length === 0">
-            <td colspan="9" class="px-3 py-8 text-center text-xs text-gray-400">
+          <tr v-if="!catalogLoading && skuRows.length === 0">
+            <td colspan="9" class="px-3 py-8 text-center text-sm text-gray-400">
               검색 결과가 없습니다.
             </td>
           </tr>
           <tr v-if="catalogLoading">
-            <td colspan="9" class="px-3 py-8 text-center text-xs text-gray-400">
+            <td colspan="9" class="px-3 py-8 text-center text-sm text-gray-400">
               카탈로그를 불러오는 중...
             </td>
           </tr>
         </tbody>
       </table>
     </div>
+
+    <!-- 페이지네이션 -->
+    <PaginationNav
+      :page="poStore.catalogPage"
+      :size="poStore.catalogSize"
+      :total-pages="poStore.catalogTotalPages"
+      :total-elements="poStore.catalogTotalElements"
+      :has-previous="poStore.catalogHasPrevious"
+      :has-next="poStore.catalogHasNext"
+      @update:page="poStore.setCatalogPage"
+      @update:size="poStore.setCatalogSize"
+    />
   </div>
 </template>

--- a/src/components/hq/purchase-order/PurchaseOrderConfirmModal.vue
+++ b/src/components/hq/purchase-order/PurchaseOrderConfirmModal.vue
@@ -25,12 +25,12 @@ const headerClass = computed(() => {
 
 const confirmBtnClass = computed(() => {
   if (props.variant === 'amber') {
-    return 'border border-amber-600 bg-amber-600 px-4 py-2 text-xs font-black text-white hover:bg-amber-500'
+    return 'border border-amber-600 bg-amber-600 px-4 py-2 text-sm font-black text-white hover:bg-amber-500'
   }
   if (props.variant === 'red') {
-    return 'border border-red-700 bg-red-700 px-4 py-2 text-xs font-black text-white hover:bg-red-600'
+    return 'border border-red-700 bg-red-700 px-4 py-2 text-sm font-black text-white hover:bg-red-600'
   }
-  return 'border border-[#004D3C] bg-[#004D3C] px-4 py-2 text-xs font-black text-white hover:bg-[#1f4b3a]'
+  return 'border border-[#004D3C] bg-[#004D3C] px-4 py-2 text-sm font-black text-white hover:bg-[#1f4b3a]'
 })
 </script>
 
@@ -45,13 +45,13 @@ const confirmBtnClass = computed(() => {
         <AlertTriangleIcon v-if="variant === 'amber'" :size="14" />
         <h2 class="text-sm font-black">{{ title }}</h2>
       </div>
-      <div class="p-5 text-xs text-gray-700">
+      <div class="p-5 text-sm text-gray-700">
         <slot />
       </div>
       <div class="flex items-center justify-end gap-2 border-t border-gray-200 bg-gray-50 px-5 py-3">
         <button
           type="button"
-          class="border border-gray-300 bg-white px-4 py-2 text-xs font-black text-gray-700 hover:bg-gray-100"
+          class="border border-gray-300 bg-white px-4 py-2 text-sm font-black text-gray-700 hover:bg-gray-100"
           @click="$emit('cancel')"
         >
           취소

--- a/src/components/hq/purchase-order/PurchaseOrderDetailPanel.vue
+++ b/src/components/hq/purchase-order/PurchaseOrderDetailPanel.vue
@@ -23,12 +23,12 @@ const { statusClass, statusLabel, historyDotClass, historyTextClass, formatDate 
   >
     <!-- 상세 패널 헤더 -->
     <div class="flex items-center justify-between bg-[#004D3C] px-4 py-3 text-white">
-      <h3 class="inline-flex items-center gap-2 text-[11px] font-black uppercase tracking-wider">
+      <h3 class="inline-flex items-center gap-2 text-xs font-black uppercase tracking-wider">
         <InfoIcon :size="14" />
         발주 상세
       </h3>
       <div class="flex items-center gap-3">
-        <span class="inline-flex px-2 py-1 text-[10px] font-black" :class="statusClass(order.status)">
+        <span class="inline-flex px-2 py-1 text-[11px] font-black" :class="statusClass(order.status)">
           {{ statusLabel(order.status) }}
         </span>
         <button
@@ -48,39 +48,39 @@ const { statusClass, statusLabel, historyDotClass, historyTextClass, formatDate 
       <section class="space-y-3">
         <div class="flex items-start justify-between gap-2">
           <div>
-            <p class="text-[10px] font-bold uppercase text-gray-400">발주번호</p>
+            <p class="text-[11px] font-bold uppercase text-gray-400">발주번호</p>
             <p class="mt-0.5 text-sm font-black text-gray-900">{{ order.id }}</p>
           </div>
         </div>
 
         <div class="grid grid-cols-2 gap-3">
           <div>
-            <p class="text-[10px] font-bold uppercase text-gray-400">공급처</p>
-            <p class="mt-0.5 text-xs font-black text-gray-800">{{ order.vendorName }}</p>
+            <p class="text-[11px] font-bold uppercase text-gray-400">공급처</p>
+            <p class="mt-0.5 text-sm font-black text-gray-800">{{ order.vendorName }}</p>
           </div>
           <div>
-            <p class="text-[10px] font-bold uppercase text-gray-400">입고 창고</p>
-            <p class="mt-0.5 text-xs font-black text-gray-800">{{ order.warehouseName }}</p>
+            <p class="text-[11px] font-bold uppercase text-gray-400">입고 창고</p>
+            <p class="mt-0.5 text-sm font-black text-gray-800">{{ order.warehouseName }}</p>
           </div>
           <div>
-            <p class="inline-flex items-center gap-1 text-[10px] font-bold uppercase text-gray-400">
+            <p class="inline-flex items-center gap-1 text-[11px] font-bold uppercase text-gray-400">
               <UserIcon :size="10" />
               담당자
             </p>
-            <p class="mt-0.5 text-xs font-black text-gray-800">{{ order.memberName }}</p>
+            <p class="mt-0.5 text-sm font-black text-gray-800">{{ order.memberName }}</p>
           </div>
           <div>
-            <p class="text-[10px] font-bold uppercase text-gray-400">생성일시</p>
-            <p class="mt-0.5 text-xs font-bold text-gray-500">{{ formatDate(order.createdAt) }}</p>
+            <p class="text-[11px] font-bold uppercase text-gray-400">생성일시</p>
+            <p class="mt-0.5 text-sm font-bold text-gray-500">{{ formatDate(order.createdAt) }}</p>
           </div>
         </div>
       </section>
 
       <!-- 품목 테이블 -->
       <section>
-        <p class="mb-2 text-[10px] font-black uppercase text-gray-400">발주 품목</p>
-        <table class="w-full text-xs">
-          <thead class="bg-gray-100 text-[10px] uppercase text-gray-500">
+        <p class="mb-2 text-[11px] font-black uppercase text-gray-400">발주 품목</p>
+        <table class="w-full text-sm">
+          <thead class="bg-gray-100 text-[11px] uppercase text-gray-500">
             <tr>
               <th class="px-2 py-2 text-left font-black">제품명</th>
               <th class="w-10 px-2 py-2 text-right font-black">수량</th>
@@ -92,10 +92,10 @@ const { statusClass, statusLabel, historyDotClass, historyTextClass, formatDate 
             <tr v-for="item in order.items" :key="item.skuCode || item.productId">
               <td class="px-2 py-2 align-top">
                 <div class="font-bold text-gray-800">{{ item.productName }}</div>
-                <div v-if="item.displayOption" class="mt-0.5 text-[11px] font-bold text-[#004D3C]">
+                <div v-if="item.displayOption" class="mt-0.5 text-xs font-bold text-[#004D3C]">
                   {{ item.displayOption }}
                 </div>
-                <div v-if="item.skuCode" class="text-[10px] text-gray-400">{{ item.skuCode }}</div>
+                <div v-if="item.skuCode" class="text-[11px] text-gray-400">{{ item.skuCode }}</div>
               </td>
               <td class="px-2 py-2 text-right font-bold text-gray-700 align-top">
                 {{ item.quantity }}
@@ -121,7 +121,7 @@ const { statusClass, statusLabel, historyDotClass, historyTextClass, formatDate 
 
       <!-- 진행 이력 타임라인 -->
       <section v-if="order.statusHistory?.length">
-        <p class="mb-2 text-[10px] font-black uppercase text-gray-400">진행 이력</p>
+        <p class="mb-2 text-[11px] font-black uppercase text-gray-400">진행 이력</p>
         <ol class="ml-2">
           <li
             v-for="(h, idx) in order.statusHistory"
@@ -133,10 +133,10 @@ const { statusClass, statusLabel, historyDotClass, historyTextClass, formatDate 
               v-if="idx < order.statusHistory.length - 1"
               class="absolute bottom-0 left-[4px] top-3.5 w-px bg-gray-300"
             />
-            <p class="text-[11px] font-black" :class="historyTextClass(h.status)">
+            <p class="text-xs font-black" :class="historyTextClass(h.status)">
               {{ statusLabel(h.status) }}
             </p>
-            <p class="text-[10px] text-gray-500">{{ formatDate(h.at) }} · {{ h.byName }}</p>
+            <p class="text-[11px] text-gray-500">{{ formatDate(h.at) }} · {{ h.byName }}</p>
           </li>
         </ol>
       </section>
@@ -148,7 +148,7 @@ const { statusClass, statusLabel, historyDotClass, historyTextClass, formatDate 
         <div class="grid grid-cols-2 gap-2">
           <button
             type="button"
-            class="inline-flex items-center justify-center gap-1 border border-gray-400 bg-white px-2 py-2.5 text-[11px] font-black text-gray-700 hover:bg-gray-50"
+            class="inline-flex items-center justify-center gap-1 border border-gray-400 bg-white px-2 py-2.5 text-xs font-black text-gray-700 hover:bg-gray-50"
             @click="$emit('edit')"
           >
             <EditIcon :size="12" />
@@ -156,42 +156,42 @@ const { statusClass, statusLabel, historyDotClass, historyTextClass, formatDate 
           </button>
           <button
             type="button"
-            class="inline-flex items-center justify-center gap-1 border border-red-500 bg-red-50 px-2 py-2.5 text-[11px] font-black text-red-700 hover:bg-red-100"
+            class="inline-flex items-center justify-center gap-1 border border-red-500 bg-red-50 px-2 py-2.5 text-xs font-black text-red-700 hover:bg-red-100"
             @click="$emit('cancel')"
           >
             <XIcon :size="12" />
             취소
           </button>
         </div>
-        <p class="pt-1 text-center text-[11px] leading-relaxed text-gray-500">
+        <p class="pt-1 text-center text-xs leading-relaxed text-gray-500">
           [수정] 또는 [취소] 가능합니다.
         </p>
       </template>
 
       <template v-else-if="order.status === 'APPROVED'">
-        <p class="text-center text-xs leading-relaxed text-gray-500">승인 완료</p>
+        <p class="text-center text-sm leading-relaxed text-gray-500">승인 완료</p>
       </template>
 
       <template v-else-if="order.status === 'READY_TO_SHIP'">
-        <p class="text-center text-xs leading-relaxed text-gray-500">배송 준비 중</p>
+        <p class="text-center text-sm leading-relaxed text-gray-500">배송 준비 중</p>
       </template>
 
       <template v-else-if="order.status === 'IN_TRANSIT'">
-        <p class="text-center text-xs leading-relaxed text-gray-500">배송 중</p>
+        <p class="text-center text-sm leading-relaxed text-gray-500">배송 중</p>
       </template>
 
       <template v-else-if="order.status === 'ARRIVED'">
-        <p class="text-center text-xs text-gray-500">배송 완료 · 창고 입고 확정 대기</p>
+        <p class="text-center text-sm text-gray-500">배송 완료 · 창고 입고 확정 대기</p>
       </template>
 
       <template v-else>
         <p
           v-if="order.status === 'CANCELLED' && order.cancelReason"
-          class="border border-red-200 bg-red-50 px-3 py-2.5 text-[11px] font-bold leading-relaxed text-red-700"
+          class="border border-red-200 bg-red-50 px-3 py-2.5 text-xs font-bold leading-relaxed text-red-700"
         >
           취소 사유: {{ order.cancelReason }}
         </p>
-        <p class="pt-2 text-center text-xs text-gray-400">
+        <p class="pt-2 text-center text-sm text-gray-400">
           {{ order.status === 'COMPLETED' ? '종료된 발주입니다.' : '취소된 발주입니다.' }}
         </p>
       </template>
@@ -201,7 +201,7 @@ const { statusClass, statusLabel, historyDotClass, historyTextClass, formatDate 
     <div class="border-t border-gray-200">
       <button
         type="button"
-        class="w-full px-4 py-2.5 text-center text-[11px] font-bold text-gray-500 hover:bg-gray-50"
+        class="w-full px-4 py-2.5 text-center text-xs font-bold text-gray-500 hover:bg-gray-50"
         @click="$emit('close')"
       >
         닫기 (ESC)

--- a/src/components/hq/purchase-order/PurchaseOrderFloatingBar.vue
+++ b/src/components/hq/purchase-order/PurchaseOrderFloatingBar.vue
@@ -17,17 +17,17 @@ defineEmits(['openBulkQty', 'clearSelection'])
       class="fixed bottom-6 left-1/2 z-40 -translate-x-1/2 transform"
     >
       <div class="flex items-center gap-3 border border-[#004D3C] bg-[#004D3C] px-4 py-2.5 text-white shadow-xl">
-        <span class="text-xs font-black">{{ selectedCount }}개 SKU 선택됨</span>
+        <span class="text-sm font-black">{{ selectedCount }}개 SKU 선택됨</span>
         <button
           type="button"
-          class="border border-white bg-white px-3 py-1 text-[11px] font-black text-[#004D3C] hover:bg-gray-100"
+          class="border border-white bg-white px-3 py-1 text-xs font-black text-[#004D3C] hover:bg-gray-100"
           @click="$emit('openBulkQty')"
         >
           수량 일괄 입력
         </button>
         <button
           type="button"
-          class="text-[11px] font-bold text-white/80 hover:text-white underline"
+          class="text-xs font-bold text-white/80 hover:text-white underline"
           @click="$emit('clearSelection')"
         >
           선택 해제

--- a/src/components/hq/purchase-order/PurchaseOrderSubmitConfirmModal.vue
+++ b/src/components/hq/purchase-order/PurchaseOrderSubmitConfirmModal.vue
@@ -28,8 +28,8 @@ const vendorCount = computed(() => props.groupedByVendor.length)
       <div class="bg-[#004D3C] px-5 py-3 text-white">
         <h2 class="text-sm font-black">{{ isEditMode ? '발주 수정 확인' : '발주 요청 확인' }}</h2>
       </div>
-      <div class="space-y-3 p-5 text-xs text-gray-700">
-        <p class="text-[10px] font-bold uppercase tracking-wider text-gray-400">발주서 요약</p>
+      <div class="space-y-3 p-5 text-sm text-gray-700">
+        <p class="text-[11px] font-bold uppercase tracking-wider text-gray-400">발주서 요약</p>
         <dl class="space-y-1.5">
           <div class="flex justify-between gap-2">
             <dt class="text-gray-500">입고 창고</dt>
@@ -57,7 +57,7 @@ const vendorCount = computed(() => props.groupedByVendor.length)
 
         <!-- 신규 모드 — vendor 그룹 카드 N장 (공급처별로 발주 1건씩 자동 생성) -->
         <div v-if="!isEditMode && vendorCount > 0" class="space-y-2 pt-1">
-          <p class="text-[10px] font-bold uppercase tracking-wider text-gray-400">
+          <p class="text-[11px] font-bold uppercase tracking-wider text-gray-400">
             공급처별 발주 ({{ vendorCount }}건 생성)
           </p>
           <ul class="space-y-1.5">
@@ -67,17 +67,17 @@ const vendorCount = computed(() => props.groupedByVendor.length)
               class="flex items-center justify-between border border-gray-200 bg-gray-50 px-3 py-2"
             >
               <div class="min-w-0 flex-1">
-                <p class="truncate text-[11px] font-black text-gray-800">{{ g.vendorName }}</p>
-                <p class="text-[10px] text-gray-500">{{ g.itemCount }}건</p>
+                <p class="truncate text-xs font-black text-gray-800">{{ g.vendorName }}</p>
+                <p class="text-[11px] text-gray-500">{{ g.itemCount }}건</p>
               </div>
-              <span class="text-[11px] font-bold text-[#004D3C]">
+              <span class="text-xs font-bold text-[#004D3C]">
                 ₩{{ g.subtotal.toLocaleString() }}
               </span>
             </li>
           </ul>
         </div>
 
-        <p class="pt-2 text-[11px] leading-relaxed text-gray-500">
+        <p class="pt-2 text-xs leading-relaxed text-gray-500">
           <template v-if="isEditMode">
             이 내용으로 발주를 수정합니다. 공급처 승인 전까지만 가능합니다.
           </template>
@@ -92,14 +92,14 @@ const vendorCount = computed(() => props.groupedByVendor.length)
       >
         <button
           type="button"
-          class="border border-gray-300 bg-white px-4 py-2 text-xs font-black text-gray-700 hover:bg-gray-100"
+          class="border border-gray-300 bg-white px-4 py-2 text-sm font-black text-gray-700 hover:bg-gray-100"
           @click="$emit('cancel')"
         >
           취소
         </button>
         <button
           type="button"
-          class="border border-[#004D3C] bg-[#004D3C] px-4 py-2 text-xs font-black text-white hover:bg-[#1f4b3a]"
+          class="border border-[#004D3C] bg-[#004D3C] px-4 py-2 text-sm font-black text-white hover:bg-[#1f4b3a]"
           @click="$emit('confirm')"
         >
           {{ isEditMode ? '수정 저장' : '발주 요청' }}

--- a/src/stores/purchaseOrder.js
+++ b/src/stores/purchaseOrder.js
@@ -7,8 +7,7 @@ import {
   VENDOR_PROCESSING_STATUSES,
   toBeCreateReq,
   toBeUpdateReq,
-  toFeCatalogFacet,
-  toFeCatalogMaster,
+  toFeCatalogRow,
   toFeOrder,
 } from '@/stores/purchaseOrder/mappers.js'
 
@@ -128,79 +127,107 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
     warehouseList.value.map((w) => ({ id: w.id, name: w.name, code: w.code })),
   )
 
-  // ─── 카탈로그 (새 발주 페이지) ──────────────────────────────────────────
-  // BE GET /api/hq/purchase-orders/catalog 응답을 매핑해 보관.
-  // catalogSkuRows getter 가 view 가 v-for 한 번에 돌릴 평탄 row 배열 반환.
-  const catalogMasters = ref([])
-  const catalogFacets = ref([])
+  // ─── 카탈로그 (새 발주 페이지) — Page<SkuRowRes> 평탄 row + 페이징 + 서버 필터/facet
+  const catalogRows = ref([])
+  const catalogPage = ref(0) // 0-based
+  const catalogSize = ref(50)
+  const catalogTotalElements = ref(0)
+  const catalogTotalPages = ref(0)
+  const catalogHasNext = ref(false)
+  const catalogHasPrevious = ref(false)
+  const catalogColors = ref([])
+  const catalogSizes = ref([])
   const catalogLoading = ref(false)
   const catalogError = ref(null)
 
-  // view 가 그룹 헤더 + SKU 행을 한 v-for 로 렌더 가능하도록 평탄 row 배열 반환
-  // row 형식:
-  //   { type: 'header', masterKey, vendorCode, vendorName, vendorProductCode, productCode,
-  //     productName, contractUnitPrice, minSkuUnitPrice, maxSkuUnitPrice, skuCount }
-  //   { type: 'sku',    masterKey, skuCode, color, size, displayOption, unitPrice,
-  //     vendorCode, vendorName, vendorProductCode, productCode, productName }
-  // 정렬 — vendorName 가나다 → productName 가나다 → SKU 는 BE id asc 순서 그대로
-  const catalogSkuRows = computed(() => {
-    const sorted = [...catalogMasters.value].sort((a, b) => {
-      const v = a.vendorName.localeCompare(b.vendorName, 'ko')
-      if (v !== 0) return v
-      return a.productName.localeCompare(b.productName, 'ko')
-    })
-    const rows = []
-    for (const m of sorted) {
-      rows.push({
-        type: 'header',
-        masterKey: m.masterKey,
-        vendorCode: m.vendorCode,
-        vendorName: m.vendorName,
-        vendorProductCode: m.vendorProductCode,
-        productCode: m.productCode,
-        productName: m.productName,
-        contractUnitPrice: m.contractUnitPrice,
-        minSkuUnitPrice: m.minSkuUnitPrice,
-        maxSkuUnitPrice: m.maxSkuUnitPrice,
-        skuCount: m.skus.length,
-      })
-      for (const s of m.skus) {
-        rows.push({
-          type: 'sku',
-          masterKey: m.masterKey,
-          skuCode: s.skuCode,
-          color: s.color,
-          size: s.size,
-          displayOption: s.displayOption,
-          unitPrice: s.unitPrice,
-          vendorCode: m.vendorCode,
-          vendorName: m.vendorName,
-          vendorProductCode: m.vendorProductCode,
-          productCode: m.productCode,
-          productName: m.productName,
-        })
-      }
-    }
-    return rows
-  })
+  // 필터 state — view 가 v-model 또는 직접 binding, action 이 서버 재호출
+  const catalogVendor = ref('')
+  const catalogKeyword = ref('')
+  const catalogColor = ref('')
+  const catalogSkuSize = ref('')
+  const catalogShortageOnly = ref(false)
+  const catalogSort = ref('id,asc')
+  const catalogWarehouseId = ref(null)
 
-  async function fetchCatalog({ vendorCode = '', warehouseCode = '' } = {}) {
+  async function fetchCatalog(overrides = {}) {
     catalogLoading.value = true
     catalogError.value = null
     try {
-      const res = await purchaseOrderApi.getCatalog({ vendorCode, warehouseCode })
-      catalogMasters.value = Array.isArray(res?.masters) ? res.masters.map(toFeCatalogMaster) : []
-      catalogFacets.value = Array.isArray(res?.optionFacets)
-        ? res.optionFacets.map(toFeCatalogFacet)
-        : []
+      const res = await purchaseOrderApi.getCatalog({
+        page: overrides.page ?? catalogPage.value,
+        size: overrides.size ?? catalogSize.value,
+        sort: overrides.sort ?? catalogSort.value,
+        vendorCode: overrides.vendor ?? catalogVendor.value,
+        keyword: overrides.keyword ?? catalogKeyword.value,
+        color: overrides.color ?? catalogColor.value,
+        skuSize: overrides.skuSize ?? catalogSkuSize.value,
+        shortageOnly: (overrides.shortageOnly ?? catalogShortageOnly.value) ? true : undefined,
+        warehouseId: overrides.warehouseId ?? catalogWarehouseId.value,
+      })
+      catalogRows.value = Array.isArray(res?.content) ? res.content.map(toFeCatalogRow) : []
+      catalogPage.value = Number(res?.number ?? 0)
+      catalogSize.value = Number(res?.size ?? 50)
+      catalogTotalElements.value = Number(res?.totalElements ?? 0)
+      catalogTotalPages.value = Number(res?.totalPages ?? 0)
+      catalogHasNext.value = !res?.last
+      catalogHasPrevious.value = !res?.first
     } catch (e) {
       catalogError.value = e?.message ?? '카탈로그를 불러오지 못했습니다.'
-      catalogMasters.value = []
-      catalogFacets.value = []
+      catalogRows.value = []
+      catalogTotalElements.value = 0
+      catalogTotalPages.value = 0
+      catalogHasNext.value = false
+      catalogHasPrevious.value = false
       console.error('[purchaseOrder] fetchCatalog 실패', e)
     } finally {
       catalogLoading.value = false
     }
+  }
+
+  async function fetchCatalogFacets() {
+    try {
+      const res = await purchaseOrderApi.getCatalogFacets({
+        vendorCode: catalogVendor.value,
+        keyword: catalogKeyword.value,
+      })
+      catalogColors.value = Array.isArray(res?.colors) ? res.colors : []
+      catalogSizes.value = Array.isArray(res?.sizes) ? res.sizes : []
+    } catch (e) {
+      console.error('[purchaseOrder] fetchCatalogFacets 실패', e)
+      catalogColors.value = []
+      catalogSizes.value = []
+    }
+  }
+
+  async function setCatalogPage(p) {
+    if (p < 0) return
+    await fetchCatalog({ page: p })
+  }
+
+  async function setCatalogSize(s) {
+    await fetchCatalog({ page: 0, size: s })
+  }
+
+  // 필터 변경 — page=0 으로 리셋. vendor/keyword 바뀌면 facet 도 같이 갱신.
+  async function applyCatalogFilters(patch = {}) {
+    let facetAffected = false
+    if ('vendor' in patch) {
+      catalogVendor.value = patch.vendor ?? ''
+      facetAffected = true
+    }
+    if ('keyword' in patch) {
+      catalogKeyword.value = patch.keyword ?? ''
+      facetAffected = true
+    }
+    if ('color' in patch) catalogColor.value = patch.color ?? ''
+    if ('skuSize' in patch) catalogSkuSize.value = patch.skuSize ?? ''
+    if ('shortageOnly' in patch) catalogShortageOnly.value = !!patch.shortageOnly
+    if ('sort' in patch) catalogSort.value = patch.sort ?? 'id,asc'
+    if ('warehouseId' in patch) catalogWarehouseId.value = patch.warehouseId ?? null
+    await Promise.all([
+      fetchCatalog({ page: 0 }),
+      facetAffected ? fetchCatalogFacets() : Promise.resolve(),
+    ])
   }
 
   async function fetchWarehouses() {
@@ -223,9 +250,12 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
     loading.value = true
     error.value = null
     try {
-      const list = await purchaseOrderApi.list()
+      const res = await purchaseOrderApi.list()
+      // BE 가 Page<ListRes> (po-list-pagination-be) 또는 List 둘 다 대응.
+      // 페이지네이션 UI 도입은 별 phase 책임 — 일단 첫 페이지 데이터만 표시.
+      const list = Array.isArray(res) ? res : (res?.content ?? [])
       // ListRes 는 items/statusHistory 미포함 — 빈 배열로 채워둠
-      purchaseOrders.value = (list ?? []).map((o) => ({
+      purchaseOrders.value = list.map((o) => ({
         ...toFeOrder(o),
         items: [],
         statusHistory: [],
@@ -354,10 +384,25 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
     sortBy,
     loading,
     error,
-    catalogMasters,
-    catalogFacets,
+    // catalog state
+    catalogRows,
+    catalogPage,
+    catalogSize,
+    catalogTotalElements,
+    catalogTotalPages,
+    catalogHasNext,
+    catalogHasPrevious,
+    catalogColors,
+    catalogSizes,
     catalogLoading,
     catalogError,
+    catalogVendor,
+    catalogKeyword,
+    catalogColor,
+    catalogSkuSize,
+    catalogShortageOnly,
+    catalogSort,
+    catalogWarehouseId,
     // getters
     selectedOrder,
     filteredOrders,
@@ -365,7 +410,6 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
     vendorOptions,
     summary,
     warehouses,
-    catalogSkuRows,
     // actions
     selectOrder,
     fetchOrders,
@@ -376,6 +420,11 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
     cancelOrder,
     markCompleted,
     runBatch,
+    // catalog actions
     fetchCatalog,
+    fetchCatalogFacets,
+    setCatalogPage,
+    setCatalogSize,
+    applyCatalogFilters,
   }
 })

--- a/src/stores/purchaseOrder/mappers.js
+++ b/src/stores/purchaseOrder/mappers.js
@@ -1,6 +1,6 @@
 // 본사 발주 store BE ↔ FE 변환 레이어.
 // store 본체(`stores/purchaseOrder.js`) 의 state/getter/action 흐름과 분리해서
-// BE 컨트랙트(PurchaseOrder DetailRes/ListRes/CatalogRes) 매핑 규칙을 한 곳에 모은다.
+// BE 컨트랙트(PurchaseOrder DetailRes/ListRes/SkuRowRes/FacetsRes) 매핑 규칙을 한 곳에 모은다.
 //
 // 매핑:
 //   BE code               → FE id
@@ -74,37 +74,26 @@ export function toFeHistory(beHistory) {
   }
 }
 
-// ─── BE → FE (CatalogRes) ──────────────────────────────────────────────────
-// BE 키 ↔ FE 키 동일 유지 (이름 변환 0). 각 SKU 행에 그룹 컨텍스트 첨부해서
-// view 가 그룹 lookup 없이 자체 표시 가능하게.
+// ─── BE → FE (SkuRowRes 평탄 row) ──────────────────────────────────────────
+// 새 발주 카탈로그가 페이지 단위 SKU 평탄 row 로 옴.
+// master 헤더 grouping 키 (masterKey) 를 부여해 view 가 row 순회하며 직전 productCode 와 비교해 헤더 삽입.
 
-export function toFeCatalogMaster(beMaster) {
+export function toFeCatalogRow(beRow) {
   return {
-    masterKey: beMaster.vendorProductCode,
-    vendorCode: beMaster.vendorCode,
-    vendorName: beMaster.vendorName,
-    vendorProductCode: beMaster.vendorProductCode,
-    productCode: beMaster.productCode,
-    productName: beMaster.productName,
-    contractUnitPrice: beMaster.contractUnitPrice,
-    minSkuUnitPrice: beMaster.minSkuUnitPrice,
-    maxSkuUnitPrice: beMaster.maxSkuUnitPrice,
-    skus: Array.isArray(beMaster.skus)
-      ? beMaster.skus.map((s) => ({
-          skuCode: s.skuCode,
-          color: s.color ?? '',
-          size: s.size ?? '',
-          displayOption: s.displayOption ?? [s.color, s.size].filter(Boolean).join('/'),
-          unitPrice: s.unitPrice,
-        }))
-      : [],
-  }
-}
-
-export function toFeCatalogFacet(beFacet) {
-  return {
-    name: beFacet.name,
-    values: Array.isArray(beFacet.values) ? [...beFacet.values] : [],
+    masterKey: `${beRow.vendorCode}|${beRow.productCode}`,
+    vendorCode: beRow.vendorCode,
+    vendorName: beRow.vendorName,
+    vendorProductCode: beRow.vendorProductCode,
+    productCode: beRow.productCode,
+    productName: beRow.productName,
+    skuCode: beRow.skuCode,
+    color: beRow.color ?? '',
+    size: beRow.size ?? '',
+    displayOption:
+      beRow.displayOption || [beRow.color, beRow.size].filter(Boolean).join('/'),
+    unitPrice: Number(beRow.unitPrice ?? 0),
+    contractUnitPrice: Number(beRow.contractUnitPrice ?? 0),
+    availableQty: Number(beRow.availableQty ?? 0),
   }
 }
 

--- a/src/views/hq/inventory/HqCompanyWideInventoryView.vue
+++ b/src/views/hq/inventory/HqCompanyWideInventoryView.vue
@@ -270,10 +270,10 @@ const statusClass = (status) => ({
       <section class="border border-gray-200 bg-white p-4 shadow-sm">
         <div class="mb-4 flex flex-wrap items-end justify-between gap-3">
           <div>
-            <p class="text-[10px] font-black uppercase tracking-[0.18em] text-gray-400">Inventory</p>
+            <p class="text-[11px] font-black uppercase tracking-[0.18em] text-gray-400">Inventory</p>
             <h1 class="mt-1 text-lg font-black text-gray-900">전사 재고 조회</h1>
           </div>
-          <div class="text-right text-[11px] font-bold text-gray-500">
+          <div class="text-right text-xs font-bold text-gray-500">
             <p>조회 결과 {{ totalElements.toLocaleString() }}건</p>
             <p class="mt-1 text-gray-400">{{ locationSummary }}</p>
           </div>
@@ -281,10 +281,10 @@ const statusClass = (status) => ({
 
         <div class="grid gap-3 xl:grid-cols-[0.8fr_1.3fr_0.9fr_0.9fr_0.8fr_1.3fr]">
           <label class="flex flex-col gap-1.5">
-            <span class="text-[11px] font-bold text-gray-500">거점 유형</span>
+            <span class="text-xs font-bold text-gray-500">거점 유형</span>
             <select
               v-model="locationType"
-              class="h-9 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none focus:border-[#004D3C]"
+              class="h-9 border border-gray-300 bg-white px-3 text-sm font-bold text-gray-900 outline-none focus:border-[#004D3C]"
               @change="handleLocationTypeChange"
             >
               <option>매장</option>
@@ -293,9 +293,9 @@ const statusClass = (status) => ({
           </label>
 
           <div ref="locationDropdownRef" class="relative flex flex-col gap-1.5">
-            <span class="text-[11px] font-bold text-gray-500">{{ locationType }} 선택</span>
+            <span class="text-xs font-bold text-gray-500">{{ locationType }} 선택</span>
             <div
-              class="flex min-h-9 cursor-pointer items-center justify-between gap-2 border border-gray-300 bg-white px-2.5 py-1.5 text-xs font-bold text-gray-900 outline-none transition hover:bg-[#EBF5F5]/50"
+              class="flex min-h-9 cursor-pointer items-center justify-between gap-2 border border-gray-300 bg-white px-2.5 py-1.5 text-sm font-bold text-gray-900 outline-none transition hover:bg-[#EBF5F5]/50"
               :class="isLocationDropdownOpen ? 'border-[#004D3C]' : ''"
               role="button"
               tabindex="0"
@@ -311,7 +311,7 @@ const statusClass = (status) => ({
                   <span
                     v-for="location in locationChipItems"
                     :key="location"
-                    class="inline-flex max-w-full items-center gap-1 bg-[#EBF5F5] px-2 py-1 text-[11px] font-black text-black"
+                    class="inline-flex max-w-full items-center gap-1 bg-[#EBF5F5] px-2 py-1 text-xs font-black text-black"
                   >
                     <span class="truncate">{{ location }}</span>
                     <button
@@ -325,13 +325,13 @@ const statusClass = (status) => ({
                   </span>
                   <span
                     v-if="hiddenLocationCount > 0"
-                    class="inline-flex items-center bg-gray-100 px-2 py-1 text-[11px] font-black text-gray-600"
+                    class="inline-flex items-center bg-gray-100 px-2 py-1 text-xs font-black text-gray-600"
                   >
                     외 {{ hiddenLocationCount }}건
                   </span>
                 </template>
               </div>
-              <span class="shrink-0 text-[10px] text-gray-500" :class="isLocationDropdownOpen ? 'rotate-180' : ''">
+              <span class="shrink-0 text-[11px] text-gray-500" :class="isLocationDropdownOpen ? 'rotate-180' : ''">
                 ▼
               </span>
             </div>
@@ -342,7 +342,7 @@ const statusClass = (status) => ({
               <div class="mb-2 flex items-center justify-between gap-2 border-b border-gray-100 pb-2">
                 <button
                   type="button"
-                  class="flex-1 bg-[#EBF5F5] px-2 py-1.5 text-[11px] font-black text-black hover:bg-[#D6EAEA] disabled:cursor-not-allowed disabled:text-gray-400"
+                  class="flex-1 bg-[#EBF5F5] px-2 py-1.5 text-xs font-black text-black hover:bg-[#D6EAEA] disabled:cursor-not-allowed disabled:text-gray-400"
                   :disabled="isAllLocationSelected"
                   @click.stop="selectAllLocations"
                 >
@@ -350,7 +350,7 @@ const statusClass = (status) => ({
                 </button>
                 <button
                   type="button"
-                  class="flex-1 border border-gray-200 px-2 py-1.5 text-[11px] font-black text-gray-600 hover:bg-gray-50 hover:text-black"
+                  class="flex-1 border border-gray-200 px-2 py-1.5 text-xs font-black text-gray-600 hover:bg-gray-50 hover:text-black"
                   @click.stop="clearLocations"
                 >
                   전체 해제
@@ -360,7 +360,7 @@ const statusClass = (status) => ({
                 <label
                   v-for="location in currentLocationOptions"
                   :key="location"
-                  class="flex cursor-pointer items-center gap-2 px-2 py-2 text-xs font-bold text-black hover:bg-[#EBF5F5]/70"
+                  class="flex cursor-pointer items-center gap-2 px-2 py-2 text-sm font-bold text-black hover:bg-[#EBF5F5]/70"
                   @click.stop
                 >
                   <input
@@ -372,17 +372,17 @@ const statusClass = (status) => ({
                   <span>{{ location }}</span>
                 </label>
               </div>
-              <p class="mt-2 px-1 text-[10px] font-bold text-gray-400">
+              <p class="mt-2 px-1 text-[11px] font-bold text-gray-400">
                 {{ selectedLocations.length === 0 ? `전체 ${locationType} 조회 중` : `${selectedLocations.length}개 ${locationType} 선택됨` }}
               </p>
             </div>
           </div>
 
           <label class="flex flex-col gap-1.5">
-            <span class="text-[11px] font-bold text-gray-500">카테고리 1단계</span>
+            <span class="text-xs font-bold text-gray-500">카테고리 1단계</span>
             <select
               v-model="selectedParentCategory"
-              class="h-9 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none focus:border-[#004D3C]"
+              class="h-9 border border-gray-300 bg-white px-3 text-sm font-bold text-gray-900 outline-none focus:border-[#004D3C]"
               @change="handleParentCategoryChange"
             >
               <option value="">전체</option>
@@ -393,10 +393,10 @@ const statusClass = (status) => ({
           </label>
 
           <label class="flex flex-col gap-1.5">
-            <span class="text-[11px] font-bold text-gray-500">카테고리 2단계</span>
+            <span class="text-xs font-bold text-gray-500">카테고리 2단계</span>
             <select
               v-model="selectedChildCategory"
-              class="h-9 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none focus:border-[#004D3C] disabled:bg-gray-50 disabled:text-gray-400"
+              class="h-9 border border-gray-300 bg-white px-3 text-sm font-bold text-gray-900 outline-none focus:border-[#004D3C] disabled:bg-gray-50 disabled:text-gray-400"
               :disabled="!selectedParentCategory"
             >
               <option value="">전체</option>
@@ -407,10 +407,10 @@ const statusClass = (status) => ({
           </label>
 
           <label class="flex flex-col gap-1.5">
-            <span class="text-[11px] font-bold text-gray-500">상태</span>
+            <span class="text-xs font-bold text-gray-500">상태</span>
             <select
               v-model="selectedStatus"
-              class="h-9 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none focus:border-[#004D3C]"
+              class="h-9 border border-gray-300 bg-white px-3 text-sm font-bold text-gray-900 outline-none focus:border-[#004D3C]"
             >
               <option value="">전체</option>
               <option>정상</option>
@@ -420,11 +420,11 @@ const statusClass = (status) => ({
           </label>
 
           <label class="flex flex-col gap-1.5">
-            <span class="text-[11px] font-bold text-gray-500">검색</span>
+            <span class="text-xs font-bold text-gray-500">검색</span>
             <input
               v-model="searchTerm"
               type="search"
-              class="h-9 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none placeholder:text-gray-400 focus:border-[#004D3C]"
+              class="h-9 border border-gray-300 bg-white px-3 text-sm font-bold text-gray-900 outline-none placeholder:text-gray-400 focus:border-[#004D3C]"
               placeholder="품목 코드, 품목명, 위치명"
             />
           </label>
@@ -433,8 +433,8 @@ const statusClass = (status) => ({
 
       <section class="min-w-0 border border-gray-200 bg-white shadow-sm">
         <div class="overflow-x-auto">
-          <table class="min-w-[1060px] w-full border-collapse text-left text-xs">
-            <thead class="bg-gray-50 text-[10px] uppercase tracking-[0.12em] text-gray-500">
+          <table class="min-w-[1060px] w-full border-collapse text-left text-sm">
+            <thead class="bg-gray-50 text-[11px] uppercase tracking-[0.12em] text-gray-500">
               <tr>
                 <th class="px-3 py-3 font-black">품목 코드</th>
                 <th class="px-3 py-3 font-black">카테고리</th>
@@ -460,7 +460,7 @@ const statusClass = (status) => ({
                 <td class="px-3 py-3 text-right font-black text-gray-900">{{ item.availableStock.toLocaleString() }}</td>
                 <td class="px-3 py-3 text-right font-bold text-gray-500">{{ item.safetyStock.toLocaleString() }}</td>
                 <td class="px-3 py-3 text-center">
-                  <span class="inline-flex min-w-12 justify-center px-2 py-1 text-[11px] font-black" :class="statusClass(item.status)">
+                  <span class="inline-flex min-w-12 justify-center px-2 py-1 text-xs font-black" :class="statusClass(item.status)">
                     {{ item.status }}
                   </span>
                 </td>

--- a/src/views/hq/purchase-order/HqPurchaseOrderCreateView.vue
+++ b/src/views/hq/purchase-order/HqPurchaseOrderCreateView.vue
@@ -127,8 +127,8 @@ function handleBulkApply(qty) {
     return
   }
   const selectedRows = []
-  for (const r of poStore.catalogSkuRows) {
-    if (r.type === 'sku' && selectedSkus.value.has(r.skuCode)) selectedRows.push(r)
+  for (const r of poStore.catalogRows) {
+    if (selectedSkus.value.has(r.skuCode)) selectedRows.push(r)
   }
   if (selectedRows.length === 0) return
   for (const row of selectedRows) {
@@ -468,21 +468,10 @@ function initEditMode() {
   }))
 }
 
-// ─── mounted + vendorFilter watch (카탈로그 fetch) ─────────────────────────
-function effectiveVendorCode() {
-  return vendorFilter.value && vendorFilter.value !== 'all' ? vendorFilter.value : ''
-}
-
-function reloadCatalog() {
-  poStore
-    .fetchCatalog({
-      vendorCode: effectiveVendorCode(),
-      warehouseCode: selectedWarehouseCode.value,
-    })
-    .catch((err) => {
-      console.error('[HqPurchaseOrderCreateView] fetchCatalog 실패', err)
-    })
-}
+// ─── mounted (카탈로그 초기 fetch) ─────────────────────────────────────────
+// 자식 컴포넌트(PurchaseOrderCatalog) 가 keyword/vendorFilter/sortBy/shortageOnly
+// 변경을 watch 해서 store.applyCatalogFilters 를 직접 호출한다.
+// 부모는 초기 페이지/facet fetch + warehouseId 매핑만 담당.
 
 onMounted(() => {
   if (isEditMode.value) {
@@ -490,16 +479,14 @@ onMounted(() => {
   } else {
     loadDraft()
   }
-  reloadCatalog()
   // 인증 hydrate race 로 store 마운트 시점 fetch 가 스킵될 수 있어 보장 fetch.
   if (poStore.warehouses.length === 0) {
     poStore.fetchWarehouses()
   }
-})
-
-// 공급처 필터 변경 시 server-side 재 fetch (한 공급처 결과만 받기)
-watch(vendorFilter, () => {
-  reloadCatalog()
+  poStore.fetchCatalogFacets().catch(() => {})
+  poStore.fetchCatalog().catch((err) => {
+    console.error('[HqPurchaseOrderCreateView] fetchCatalog 실패', err)
+  })
 })
 
 // 아이콘은 @/components/hq/purchase-order/icons.js 에서 import.
@@ -518,7 +505,7 @@ watch(vendorFilter, () => {
       >
         <button
           type="button"
-          class="inline-flex items-center gap-1 text-xs font-bold text-gray-600 hover:text-[#004D3C]"
+          class="inline-flex items-center gap-1 text-sm font-bold text-gray-600 hover:text-[#004D3C]"
           @click="router.push({ name: 'hq-purchase-orders' })"
         >
           <ArrowLeftIcon :size="14" />
@@ -526,13 +513,13 @@ watch(vendorFilter, () => {
         </button>
 
         <div class="ml-2 flex items-center gap-2">
-          <label class="text-[11px] font-black uppercase tracking-wider text-gray-500">
+          <label class="text-xs font-black uppercase tracking-wider text-gray-500">
             입고 창고
           </label>
           <select
             ref="warehouseSelectRef"
             :value="selectedWarehouseCode"
-            class="min-w-[160px] border border-gray-300 bg-white px-3 py-1.5 text-xs outline-none focus:border-[#004D3C]"
+            class="min-w-[160px] border border-gray-300 bg-white px-3 py-1.5 text-sm outline-none focus:border-[#004D3C]"
             @change="handleWarehouseChange($event.target.value)"
           >
             <option value="">창고 선택</option>
@@ -544,13 +531,13 @@ watch(vendorFilter, () => {
 
         <span
           v-if="isEditMode"
-          class="ml-auto inline-flex items-center gap-1 bg-amber-50 px-2 py-1 text-[10px] font-bold text-amber-700"
+          class="ml-auto inline-flex items-center gap-1 bg-amber-50 px-2 py-1 text-[11px] font-bold text-amber-700"
         >
           수정 중: {{ editingOrderId }} · {{ currentCartVendorName }}
         </span>
         <span
           v-else-if="cart.length > 0"
-          class="ml-auto inline-flex items-center gap-1 bg-[#E6F2F0] px-2 py-1 text-[10px] font-bold text-[#004D3C]"
+          class="ml-auto inline-flex items-center gap-1 bg-[#E6F2F0] px-2 py-1 text-[11px] font-bold text-[#004D3C]"
         >
           임시 저장된 품목 {{ cart.length }}건
         </span>
@@ -656,7 +643,7 @@ watch(vendorFilter, () => {
     >
       <div
         v-if="toast.show"
-        class="fixed right-4 top-4 z-[60] border border-[#004D3C] bg-white px-4 py-3 text-xs font-bold text-gray-800 shadow-lg"
+        class="fixed right-4 top-4 z-[60] border border-[#004D3C] bg-white px-4 py-3 text-sm font-bold text-gray-800 shadow-lg"
       >
         {{ toast.message }}
       </div>

--- a/src/views/hq/purchase-order/HqPurchaseOrderView.vue
+++ b/src/views/hq/purchase-order/HqPurchaseOrderView.vue
@@ -158,15 +158,15 @@ onUnmounted(() => window.removeEventListener('keydown', handleKeydown))
           <TruckIcon :size="22" />
         </div>
         <div class="min-w-0 flex-1">
-          <p class="text-[10px] font-bold uppercase tracking-wider text-gray-500">총 발주</p>
+          <p class="text-[11px] font-bold uppercase tracking-wider text-gray-500">총 발주</p>
           <p class="mt-0.5 truncate text-2xl font-black text-[#004D3C]">
             ₩{{ poStore.summary.totalPrice.toLocaleString() }}
           </p>
         </div>
         <div class="text-right">
-          <p class="text-[10px] font-bold uppercase tracking-wider text-gray-500">건수</p>
+          <p class="text-[11px] font-bold uppercase tracking-wider text-gray-500">건수</p>
           <p class="mt-0.5 text-xl font-black text-gray-700">
-            {{ poStore.summary.totalCount }}<span class="ml-0.5 text-xs font-bold">건</span>
+            {{ poStore.summary.totalCount }}<span class="ml-0.5 text-sm font-bold">건</span>
           </p>
         </div>
       </section>
@@ -179,7 +179,7 @@ onUnmounted(() => window.removeEventListener('keydown', handleKeydown))
             v-for="tab in STATUS_TABS"
             :key="tab.key"
             type="button"
-            class="inline-flex items-center gap-1.5 border px-3 py-1.5 text-xs font-black transition-colors"
+            class="inline-flex items-center gap-1.5 border px-3 py-1.5 text-sm font-black transition-colors"
             :class="
               poStore.activeStatusTab === tab.key
                 ? 'border-[#004D3C] bg-[#004D3C] text-white'
@@ -189,7 +189,7 @@ onUnmounted(() => window.removeEventListener('keydown', handleKeydown))
           >
             <span>{{ tab.label }}</span>
             <span
-              class="min-w-[18px] px-1 py-0.5 text-center text-[10px]"
+              class="min-w-[18px] px-1 py-0.5 text-center text-[11px]"
               :class="
                 poStore.activeStatusTab === tab.key
                   ? 'bg-white/20 text-white'
@@ -222,7 +222,7 @@ onUnmounted(() => window.removeEventListener('keydown', handleKeydown))
           <div
             class="flex flex-wrap items-center justify-between gap-2 border-b border-gray-200 bg-white px-3 py-2"
           >
-            <span class="text-xs font-bold text-gray-600">
+            <span class="text-sm font-bold text-gray-600">
               총 {{ poStore.filteredOrders.length }}건
             </span>
             <div class="flex flex-wrap items-center gap-2">
@@ -235,12 +235,12 @@ onUnmounted(() => window.removeEventListener('keydown', handleKeydown))
                   v-model="poStore.searchKeyword"
                   type="text"
                   placeholder="발주번호/공급처/품목명 검색"
-                  class="w-52 border border-gray-300 bg-white py-1.5 pl-8 pr-3 text-xs outline-none focus:border-[#004D3C]"
+                  class="w-52 border border-gray-300 bg-white py-1.5 pl-8 pr-3 text-sm outline-none focus:border-[#004D3C]"
                 />
               </label>
               <button
                 type="button"
-                class="inline-flex items-center gap-1.5 border border-gray-300 bg-white px-3 py-1.5 text-xs font-black text-gray-700 transition-colors hover:bg-gray-50 disabled:opacity-50"
+                class="inline-flex items-center gap-1.5 border border-gray-300 bg-white px-3 py-1.5 text-sm font-black text-gray-700 transition-colors hover:bg-gray-50 disabled:opacity-50"
                 :disabled="isRunningBatch"
                 title="SYS-001 배치를 즉시 한 번 돌립니다 (시연·QA용)"
                 @click="runBatchTrigger"
@@ -250,7 +250,7 @@ onUnmounted(() => window.removeEventListener('keydown', handleKeydown))
               </button>
               <button
                 type="button"
-                class="inline-flex items-center gap-1.5 border border-[#004D3C] bg-[#004D3C] px-3 py-1.5 text-xs font-black text-white transition-colors hover:bg-[#1f4b3a]"
+                class="inline-flex items-center gap-1.5 border border-[#004D3C] bg-[#004D3C] px-3 py-1.5 text-sm font-black text-white transition-colors hover:bg-[#1f4b3a]"
                 @click="goCreatePage"
               >
                 <PlusIcon :size="14" />
@@ -265,7 +265,7 @@ onUnmounted(() => window.removeEventListener('keydown', handleKeydown))
           >
             <select
               v-model="poStore.vendorFilter"
-              class="border border-gray-300 bg-white px-2 py-1.5 text-xs outline-none focus:border-[#004D3C]"
+              class="border border-gray-300 bg-white px-2 py-1.5 text-sm outline-none focus:border-[#004D3C]"
             >
               <option value="">전체 공급처</option>
               <option v-for="v in poStore.vendorOptions" :key="v.id" :value="v.id">
@@ -276,18 +276,18 @@ onUnmounted(() => window.removeEventListener('keydown', handleKeydown))
             <input
               v-model="poStore.dateFrom"
               type="date"
-              class="border border-gray-300 bg-white px-2 py-1.5 text-xs outline-none focus:border-[#004D3C]"
+              class="border border-gray-300 bg-white px-2 py-1.5 text-sm outline-none focus:border-[#004D3C]"
             />
-            <span class="text-xs text-gray-400">~</span>
+            <span class="text-sm text-gray-400">~</span>
             <input
               v-model="poStore.dateTo"
               type="date"
-              class="border border-gray-300 bg-white px-2 py-1.5 text-xs outline-none focus:border-[#004D3C]"
+              class="border border-gray-300 bg-white px-2 py-1.5 text-sm outline-none focus:border-[#004D3C]"
             />
 
             <select
               v-model="poStore.sortBy"
-              class="ml-auto border border-gray-300 bg-white px-2 py-1.5 text-xs outline-none focus:border-[#004D3C]"
+              class="ml-auto border border-gray-300 bg-white px-2 py-1.5 text-sm outline-none focus:border-[#004D3C]"
             >
               <option value="latest">최신순</option>
               <option value="oldest">오래된순</option>
@@ -297,16 +297,16 @@ onUnmounted(() => window.removeEventListener('keydown', handleKeydown))
           </div>
 
           <div class="overflow-auto">
-            <table class="w-full min-w-[760px] table-fixed border-collapse text-xs">
-              <thead class="bg-gray-100 text-[10px] uppercase tracking-wider text-gray-500">
+            <table class="w-full min-w-[1180px] table-fixed border-collapse text-sm">
+              <thead class="bg-gray-100 text-[11px] uppercase tracking-wider text-gray-500">
                 <tr>
-                  <th class="w-32 px-3 py-2 text-left font-black">발주번호</th>
-                  <th class="px-3 py-2 text-left font-black">공급처</th>
-                  <th class="w-28 px-3 py-2 text-left font-black">입고 창고</th>
-                  <th class="w-44 px-3 py-2 text-left font-black">품목</th>
-                  <th class="w-28 px-3 py-2 text-right font-black">총금액</th>
-                  <th class="w-20 px-3 py-2 text-center font-black">상태</th>
-                  <th class="w-28 px-3 py-2 text-center font-black">생성일</th>
+                  <th class="whitespace-nowrap w-48 px-3 py-2 text-left font-black">발주번호</th>
+                  <th class="whitespace-nowrap px-3 py-2 text-left font-black">공급처</th>
+                  <th class="whitespace-nowrap w-56 px-3 py-2 text-left font-black">입고 창고</th>
+                  <th class="whitespace-nowrap w-56 px-3 py-2 text-left font-black">품목</th>
+                  <th class="whitespace-nowrap w-28 px-3 py-2 text-right font-black">총금액</th>
+                  <th class="whitespace-nowrap w-24 px-3 py-2 text-center font-black">상태</th>
+                  <th class="whitespace-nowrap w-32 px-3 py-2 text-center font-black">생성일</th>
                 </tr>
               </thead>
               <tbody class="divide-y divide-gray-100">
@@ -317,10 +317,10 @@ onUnmounted(() => window.removeEventListener('keydown', handleKeydown))
                   :class="{ 'bg-[#E6F2F0]': poStore.selectedOrderId === order.id }"
                   @click="selectOrder(order.id)"
                 >
-                  <td class="px-3 py-3 font-bold text-gray-400">{{ order.id }}</td>
-                  <td class="px-3 py-3 font-black text-gray-800">{{ order.vendorName }}</td>
-                  <td class="px-3 py-3 font-bold text-gray-600">{{ order.warehouseName }}</td>
-                  <td class="px-3 py-3 font-bold text-gray-700">
+                  <td class="truncate px-3 py-3 font-bold text-gray-400" :title="order.id">{{ order.id }}</td>
+                  <td class="truncate px-3 py-3 font-black text-gray-800" :title="order.vendorName">{{ order.vendorName }}</td>
+                  <td class="truncate px-3 py-3 font-bold text-gray-600" :title="order.warehouseName">{{ order.warehouseName }}</td>
+                  <td class="truncate px-3 py-3 font-bold text-gray-700">
                     <span class="block truncate" :title="(order.productNames ?? []).join(', ')">
                       <template v-if="order.productNames && order.productNames.length > 0">
                         {{ order.productNames[0]
@@ -331,23 +331,23 @@ onUnmounted(() => window.removeEventListener('keydown', handleKeydown))
                       <template v-else>—</template>
                     </span>
                   </td>
-                  <td class="px-3 py-3 text-right font-black text-gray-800">
+                  <td class="truncate px-3 py-3 text-right font-black text-gray-800">
                     ₩{{ order.totalPrice.toLocaleString() }}
                   </td>
-                  <td class="px-3 py-3 text-center">
+                  <td class="truncate px-3 py-3 text-center">
                     <span
-                      class="inline-flex px-2 py-1 text-[10px] font-black"
+                      class="inline-flex px-2 py-1 text-[11px] font-black"
                       :class="statusClass(order.status)"
                     >
                       {{ statusLabel(order.status) }}
                     </span>
                   </td>
-                  <td class="px-3 py-3 text-center text-[11px] text-gray-500">
+                  <td class="truncate px-3 py-3 text-center text-xs text-gray-500">
                     {{ formatDate(order.createdAt) }}
                   </td>
                 </tr>
                 <tr v-if="poStore.filteredOrders.length === 0">
-                  <td colspan="7" class="px-3 py-8 text-center text-xs text-gray-400">
+                  <td colspan="7" class="px-3 py-8 text-center text-sm text-gray-400">
                     조회된 발주 내역이 없습니다.
                   </td>
                 </tr>
@@ -382,7 +382,7 @@ onUnmounted(() => window.removeEventListener('keydown', handleKeydown))
     >
       <div
         v-if="toast.show"
-        class="fixed right-4 top-4 z-[60] border border-[#004D3C] bg-white px-4 py-3 text-xs font-bold text-gray-800 shadow-lg"
+        class="fixed right-4 top-4 z-[60] border border-[#004D3C] bg-white px-4 py-3 text-sm font-bold text-gray-800 shadow-lg"
       >
         {{ toast.message }}
       </div>

--- a/src/views/warehouse/WarehouseInventoryView.vue
+++ b/src/views/warehouse/WarehouseInventoryView.vue
@@ -160,32 +160,32 @@ onMounted(() => {
       <section class="border border-gray-200 bg-white p-4 shadow-sm">
         <div class="mb-4 flex flex-wrap items-end justify-between gap-3">
           <div>
-            <p class="text-[10px] font-black uppercase tracking-[0.18em] text-gray-400">Inventory</p>
+            <p class="text-[11px] font-black uppercase tracking-[0.18em] text-gray-400">Inventory</p>
             <h1 class="mt-1 text-lg font-black text-gray-900">창고 재고 조회</h1>
           </div>
-          <div class="text-right text-[11px] font-bold text-gray-500">
+          <div class="text-right text-xs font-bold text-gray-500">
             <p>{{ auth.user?.locationCode ?? 'WAREHOUSE' }} · {{ auth.user?.locationName ?? '창고' }}</p>
             <p class="mt-1 text-gray-400">기준일 {{ today }} · 조회 {{ totalElements.toLocaleString() }}건</p>
           </div>
         </div>
-        <p v-if="loadError" class="mb-3 text-xs font-bold text-red-600">{{ loadError }}</p>
+        <p v-if="loadError" class="mb-3 text-sm font-bold text-red-600">{{ loadError }}</p>
 
         <div class="grid gap-3 xl:grid-cols-[1.2fr_1fr_1fr_1fr_1.2fr]">
           <label class="flex flex-col gap-1.5">
-            <span class="text-[11px] font-bold text-gray-500">검색</span>
+            <span class="text-xs font-bold text-gray-500">검색</span>
             <input
               v-model="searchTerm"
               type="search"
-              class="h-9 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none placeholder:text-gray-400 focus:border-[#004D3C]"
+              class="h-9 border border-gray-300 bg-white px-3 text-sm font-bold text-gray-900 outline-none placeholder:text-gray-400 focus:border-[#004D3C]"
               placeholder="품목 코드, 품목명"
             />
           </label>
 
           <label class="flex flex-col gap-1.5">
-            <span class="text-[11px] font-bold text-gray-500">카테고리 1단계</span>
+            <span class="text-xs font-bold text-gray-500">카테고리 1단계</span>
             <select
               v-model="selectedParentCategory"
-              class="h-9 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none focus:border-[#004D3C]"
+              class="h-9 border border-gray-300 bg-white px-3 text-sm font-bold text-gray-900 outline-none focus:border-[#004D3C]"
               @change="handleParentCategoryChange"
             >
               <option value="">전체</option>
@@ -196,10 +196,10 @@ onMounted(() => {
           </label>
 
           <label class="flex flex-col gap-1.5">
-            <span class="text-[11px] font-bold text-gray-500">카테고리 2단계</span>
+            <span class="text-xs font-bold text-gray-500">카테고리 2단계</span>
             <select
               v-model="selectedChildCategory"
-              class="h-9 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none focus:border-[#004D3C] disabled:bg-gray-50 disabled:text-gray-400"
+              class="h-9 border border-gray-300 bg-white px-3 text-sm font-bold text-gray-900 outline-none focus:border-[#004D3C] disabled:bg-gray-50 disabled:text-gray-400"
               :disabled="!selectedParentCategory"
             >
               <option value="">전체</option>
@@ -210,10 +210,10 @@ onMounted(() => {
           </label>
 
           <label class="flex flex-col gap-1.5">
-            <span class="text-[11px] font-bold text-gray-500">재고 상태</span>
+            <span class="text-xs font-bold text-gray-500">재고 상태</span>
             <select
               v-model="selectedStatus"
-              class="h-9 border border-gray-300 bg-white px-3 text-xs font-bold text-gray-900 outline-none focus:border-[#004D3C]"
+              class="h-9 border border-gray-300 bg-white px-3 text-sm font-bold text-gray-900 outline-none focus:border-[#004D3C]"
             >
               <option value="">전체</option>
               <option value="정상">정상</option>
@@ -225,7 +225,7 @@ onMounted(() => {
           <div class="flex items-end">
             <button
               type="button"
-              class="h-9 w-full border border-gray-300 bg-white px-3 text-xs font-black text-gray-600 hover:bg-gray-50"
+              class="h-9 w-full border border-gray-300 bg-white px-3 text-sm font-black text-gray-600 hover:bg-gray-50"
               @click="resetFilters"
             >
               필터 초기화
@@ -237,8 +237,8 @@ onMounted(() => {
       <section class="min-h-0">
         <div class="min-w-0 border border-gray-200 bg-white shadow-sm">
           <div class="overflow-x-auto">
-            <table class="min-w-[1100px] w-full border-collapse text-left text-xs">
-              <thead class="bg-gray-50 text-[10px] uppercase tracking-[0.12em] text-gray-500">
+            <table class="min-w-[1100px] w-full border-collapse text-left text-sm">
+              <thead class="bg-gray-50 text-[11px] uppercase tracking-[0.12em] text-gray-500">
                 <tr>
                   <th class="px-3 py-3 font-black">품목 코드</th>
                   <th class="px-3 py-3 font-black">카테고리</th>
@@ -264,7 +264,7 @@ onMounted(() => {
                   <td class="px-3 py-3 text-right font-black text-gray-900">{{ item.availableStock.toLocaleString() }}</td>
                   <td class="px-3 py-3 text-right font-bold text-gray-500">{{ item.safetyStock.toLocaleString() }}</td>
                   <td class="px-3 py-3 text-center">
-                    <span class="inline-flex min-w-12 justify-center px-2 py-1 text-[11px] font-black" :class="statusClass(item.status)">
+                    <span class="inline-flex min-w-12 justify-center px-2 py-1 text-xs font-black" :class="statusClass(item.status)">
                       {{ item.status }}
                     </span>
                   </td>


### PR DESCRIPTION
## 📌 요약

- 새 발주 카탈로그를 BE `Page<SkuRowRes>` + `/catalog/facets` 에 맞춰 api/store/view 재구성, 인접 화면 글자 한 단계 상향.

<br><br>

## 🎯 작업 내용

- `api/hq/purchaseOrder.js` `getCatalog(params)` 에 page/size/sort/keyword/color/skuSize/shortageOnly/warehouseId 쿼리 + `getCatalogFacets` 신규
- `stores/purchaseOrder.js` catalog state 재구성 — `catalogRows` + 페이징 6개 + 필터 7개 + actions(`fetchCatalog`/`fetchCatalogFacets`/`setCatalogPage`/`setCatalogSize`/`applyCatalogFilters`)
- `PurchaseOrderCatalog.vue` client computed/useFacets/master 헤더 grouping 제거, `PaginationNav` 바인딩, 색상·사이즈 single-select facet 칩
- `fetchOrders` BE `Page` 응답 호환 (po-list-pagination-be 머지로 인한 break 대응)
- 전사재고/창고재고/새발주/발주내역 글자 한 단계 상향(text-xs→sm 등) + 발주내역 테이블 truncate/컬럼 너비/title attribute

<br><br>

## ✔️ 참고 사항

- 

<br><br>

## ✔️ 관련 이슈

- Close #473
