### PR TITLE
472 refactor 본사 관리자 대시보드 수정

### DIFF
--- a/src/api/hq/esg.js
+++ b/src/api/hq/esg.js
@@ -77,3 +77,51 @@ export const emissionQuotaApi = {
       .put('/api/hq/esg/quota', payload, { params: year ? { year } : {} })
       .then(unwrap),
 }
+
+/**
+ * 순환재고 월별 판매 수익 — ESG 대시보드 "월별 판매 수익" 카드.
+ *
+ * 응답 형태:
+ *   {
+ *     year: 2026,
+ *     monthly: [{ month, revenue, count }, ...12],
+ *     totalRevenue: number,
+ *     totalCount: number,
+ *     monthsWithData: number,
+ *     avgMonthly: number
+ *   }
+ */
+export const circularRevenueApi = {
+  /**
+   * 지정 연도의 12개월 수익/거래 건수 집계 조회.
+   * @param {number} [year] — 미지정 시 BE 가 현재 연도 사용
+   */
+  get: (year) =>
+    apiClient
+      .get('/api/hq/esg/circular-revenue', { params: year ? { year } : {} })
+      .then(unwrap),
+}
+
+/**
+ * 친환경 나무 키우기 점수 — 연간 sale 거래 이벤트.
+ *
+ * 응답 형태:
+ *   {
+ *     year: 2026,
+ *     events: [
+ *       { id, date: 'yyyy-MM-dd', type: 'sale', buyer, material, weightKg,
+ *         isNewBuyer, isLocalPartner }, ...
+ *     ]
+ *   }
+ *
+ * 기부 이벤트는 BE 에 도메인 없으므로 FE 에서 mock 으로 머지.
+ */
+export const scoreEventsApi = {
+  /**
+   * @param {number} [year] — 미지정 시 BE 가 현재 연도 사용
+   */
+  get: (year) =>
+    apiClient
+      .get('/api/hq/esg/score-events', { params: year ? { year } : {} })
+      .then(unwrap),
+}

--- a/src/components/common/EsgTreeWidget.vue
+++ b/src/components/common/EsgTreeWidget.vue
@@ -24,9 +24,12 @@ const stageLabels = [
 ]
 const stageLabel = computed(() => stageLabels[stage.value - 1])
 
-const trunkHeight = computed(() => 8 + stage.value * 5)
-const crownRadius = computed(() => 5 + stage.value * 2.6)
-const crownCenterY = computed(() => 92 - trunkHeight.value - crownRadius.value * 0.35)
+// 성장 공식 — Stage 1 씨앗(매우 작음) → Stage 10 거목(viewBox top 까지 길쭉)
+// viewBox `0 -32 100 132` 기준: 지면 cy=100 (viewBox 최하단, 라벨 글자 바로 위)
+const TRUNK_BOTTOM = 99   // 줄기 바닥 y (지면 cy=100 바로 위)
+const trunkHeight = computed(() => 5 + stage.value * 8.5)      // 1:13.5, 5:47.5, 10:90
+const crownRadius = computed(() => 3 + stage.value * 2.7)      // 1:5.7, 5:16.5, 10:30
+const crownCenterY = computed(() => TRUNK_BOTTOM - trunkHeight.value - crownRadius.value * 0.35)
 const showSideLeaves = computed(() => stage.value >= 4)
 const showFruits = computed(() => stage.value >= 8)
 </script>
@@ -50,12 +53,12 @@ const showFruits = computed(() => stage.value >= 8)
       </div>
 
       <div :class="expanded ? 'flex min-h-0 flex-1 items-end justify-center' : 'flex h-36 items-end justify-center'">
-        <svg viewBox="0 -22 100 122" class="h-full w-auto" aria-hidden="true">
-          <ellipse cx="50" cy="93" rx="30" ry="3.5" class="fill-emerald-200/70" />
+        <svg viewBox="0 -32 100 132" class="h-full w-auto" aria-hidden="true">
+          <ellipse cx="50" cy="100" rx="30" ry="2" class="fill-emerald-200/70" />
 
           <rect
             x="48"
-            :y="92 - trunkHeight"
+            :y="TRUNK_BOTTOM - trunkHeight"
             width="4"
             :height="trunkHeight"
             rx="1.2"

--- a/src/components/common/charts/BarChart.vue
+++ b/src/components/common/charts/BarChart.vue
@@ -29,11 +29,16 @@ defineProps({
   data: { type: Object, required: true },
   options: { type: Object, default: () => ({}) },
   height: { type: Number, default: 240 },
+  // true 일 때 부모 컨테이너 높이를 100% 채움 (height prop 무시)
+  fillHeight: { type: Boolean, default: false },
 })
 </script>
 
 <template>
-  <div :style="{ height: height + 'px' }" class="relative w-full">
+  <div
+    :class="['relative w-full', fillHeight ? 'h-full' : '']"
+    :style="fillHeight ? null : { height: height + 'px' }"
+  >
     <Bar :data="data" :options="options" />
   </div>
 </template>

--- a/src/components/common/charts/LineChart.vue
+++ b/src/components/common/charts/LineChart.vue
@@ -29,11 +29,17 @@ defineProps({
   data: { type: Object, required: true },
   options: { type: Object, default: () => ({}) },
   height: { type: Number, default: 220 },
+  // true 일 때 부모 컨테이너 높이를 100% 채움 (height prop 무시)
+  // 부모가 flex-1 + min-height 인 경우 카드 하단까지 늘어남
+  fillHeight: { type: Boolean, default: false },
 })
 </script>
 
 <template>
-  <div :style="{ height: height + 'px' }" class="relative w-full">
+  <div
+    :class="['relative w-full', fillHeight ? 'h-full' : '']"
+    :style="fillHeight ? null : { height: height + 'px' }"
+  >
     <Line :data="data" :options="options" />
   </div>
 </template>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -52,6 +52,7 @@ import HqCircularStockSalesHistoryView from '@/views/hq/circular-stock/HqCircula
 import HqCircularStockSalesDetailView from '@/views/hq/circular-stock/HqCircularStockSalesDetailView.vue'
 import EsgDashBoardView from '@/views/hq/esg/EsgDashBoardView.vue'
 import EsgTreeScoreView from '@/views/hq/esg/EsgTreeScoreView.vue'
+import EsgCarbonPriceView from '@/views/hq/esg/EsgCarbonPriceView.vue'
 import AccountListView from '@/views/hq/account/AccountListView.vue'
 import AccountApprovalView from '@/views/hq/account/AccountApprovalView.vue'
 import HqAnalyticsOrderStatsView from '@/views/hq/analytics/HqAnalyticsOrderStatsView.vue'
@@ -167,6 +168,7 @@ const router = createRouter({
     { path: '/hq/account/approval', name: 'hq-account-approval', component: AccountApprovalView, meta: { requiresAuth: true, role: 'hq' } },
     { path: '/hq/esg', name: 'hq-esg', component: EsgDashBoardView, meta: { requiresAuth: true, role: 'hq' } },
     { path: '/hq/esg/tree-score', name: 'hq-esg-tree-score', component: EsgTreeScoreView, meta: { requiresAuth: true, role: 'hq' } },
+    { path: '/hq/esg/carbon-price', name: 'hq-esg-carbon-price', component: EsgCarbonPriceView, meta: { requiresAuth: true, role: 'hq' } },
 
     { path: '/store/dashboard', name: 'store-dashboard', component: StoreDashboardView, meta: { requiresAuth: true, role: 'store' } },
     { path: '/store/dashboard2', name: 'store-dashboard2', component: StoreDashboardView2, meta: { requiresAuth: true, role: 'store' } },

--- a/src/stores/esg.js
+++ b/src/stores/esg.js
@@ -1,20 +1,59 @@
 import { ref, computed } from 'vue'
 import { defineStore } from 'pinia'
-// import { getKauPrice } from '@/api/hq/esg.js'  // BE 연동 시 활성화
+import { carbonPriceApi, scoreEventsApi } from '@/api/hq/esg.js'
+import {
+  MOCK_DONATION_EVENTS,
+  computeTotalScore,
+  computeCarbonReductionKg,
+  computeMonthlyCarbonReduction,
+  normalizeSaleEvent,
+} from '@/utils/esgScore.js'
 
 const POINTS_PER_STAGE = 1500
 const MAX_STAGE = 10
 
-const KAU_DEFAULT_PRICE = 9840
+// BE 응답 실패 시 폴백 가격 (BE 의 esg.carbon-api.fallback-price 와 동기화: 9,200)
+const KAU_FALLBACK_PRICE = 9200
 
 export const useEsgStore = defineStore('esg', () => {
-  // scoreCategories 합계와 정합 (탄소 ×0.5 스케일 적용 후): 400+1436+150+150+320 = 2,456
-  const totalPoints = ref(2456)
+  // 초기 0 → fetchTotalPoints() 호출 시 BE sale events + MOCK_DONATION_EVENTS 기반으로 자동 계산
+  const totalPoints = ref(0)
+  const totalPointsLoading = ref(false)
+  const totalPointsError = ref(null)
 
-  const kauPrice = ref(KAU_DEFAULT_PRICE)
+  // 순환재고 총 판매량 (kg) — TreeScore stats.totalKg 와 동일 값
+  // fetchTotalPoints 시 자동 갱신 + TreeScore 페이지 watcher 로도 sync
+  const totalSalesKg = ref(0)
+
+  // 실제 탄소 배출 절감량 (kg CO₂) — SUM(weight × material_factor), CARBON_SCALE 미적용
+  // ESG 대시보드 KPI "탄소 배출 절감" + 탄소중립 "절감한 탄소 배출량" 카드 공유
+  const totalCarbonReductionKg = ref(0)
+  // 월별 탄소 절감량 (kg CO₂) 12개 — 전월 대비 변동률 계산용
+  const carbonReductionMonthly = ref(Array(12).fill(0))
+
+  const kauPrice = ref(KAU_FALLBACK_PRICE)
   const kauPriceUpdatedAt = ref(null)
   const kauPriceLoading = ref(false)
   const kauPriceError = ref(null)
+
+  // 탄소 배출 절감량 (tCO₂) — 보기 쉬운 단위
+  const totalCarbonReductionTon = computed(() => totalCarbonReductionKg.value / 1000)
+
+  // 전월 대비 탄소 절감 변동률 (%) — 데이터 있는 가장 최근 월 vs 그 전월
+  // 양쪽 다 0 이면 0% 반환
+  const carbonReductionDeltaPct = computed(() => {
+    const arr = carbonReductionMonthly.value
+    // 가장 최근 데이터 있는 월 인덱스
+    let lastIdx = -1
+    for (let i = arr.length - 1; i >= 0; i--) {
+      if (arr[i] > 0) { lastIdx = i; break }
+    }
+    if (lastIdx <= 0) return 0
+    const curr = arr[lastIdx]
+    const prev = arr[lastIdx - 1]
+    if (prev === 0) return 0
+    return Number((((curr - prev) / prev) * 100).toFixed(1))
+  })
 
   const stage = computed(() => {
     const s = Math.floor(totalPoints.value / POINTS_PER_STAGE) + 1
@@ -32,15 +71,21 @@ export const useEsgStore = defineStore('esg', () => {
     return stage.value * POINTS_PER_STAGE - totalPoints.value
   })
 
+  /**
+   * KAU25 최신 종가를 BE 에서 조회.
+   *  - 정상: carbonPriceApi.getLatest() 응답으로 kauPrice 갱신
+   *  - 폴백/실패: kauPrice 는 직전값(또는 KAU_FALLBACK_PRICE)을 유지하고 에러만 기록
+   */
   async function fetchKauPrice() {
     kauPriceLoading.value = true
     kauPriceError.value = null
     try {
-      // BE 연동 시 src/api/esg.js의 getKauPrice()로 교체
-      // const { price, updatedAt } = await getKauPrice()
-      // kauPrice.value = price
-      // kauPriceUpdatedAt.value = updatedAt
+      const res = await carbonPriceApi.getLatest()
+      if (res?.pricePerTon != null) {
+        kauPrice.value = Number(res.pricePerTon)
+      }
       kauPriceUpdatedAt.value = new Date().toISOString()
+      return res
     } catch (e) {
       kauPriceError.value = e?.message ?? '시세 조회 실패'
     } finally {
@@ -53,8 +98,54 @@ export const useEsgStore = defineStore('esg', () => {
     kauPriceUpdatedAt.value = updatedAt
   }
 
+  /**
+   * BE sale events + mock donation events 를 합쳐 누적 ESG 점수 계산 후 totalPoints 갱신.
+   *  - ESG 대시보드 헤더 / TreeScore 페이지가 같은 값 공유
+   *  - 점수 룰 변경 시 utils/esgScore.js 만 수정하면 양쪽 자동 반영
+   */
+  async function fetchTotalPoints(year) {
+    totalPointsLoading.value = true
+    totalPointsError.value = null
+    try {
+      const targetYear = year ?? new Date().getFullYear()
+      const res = await scoreEventsApi.get(targetYear)
+      const saleEvents = (res?.events ?? []).map(normalizeSaleEvent)
+      const allEvents = [...saleEvents, ...MOCK_DONATION_EVENTS]
+      totalPoints.value = computeTotalScore(allEvents)
+      totalSalesKg.value = allEvents.reduce((s, e) => s + (Number(e.weightKg) || 0), 0)
+      totalCarbonReductionKg.value = computeCarbonReductionKg(allEvents)
+      carbonReductionMonthly.value = computeMonthlyCarbonReduction(allEvents)
+      return totalPoints.value
+    } catch (e) {
+      totalPointsError.value = e?.message ?? '점수 조회 실패'
+    } finally {
+      totalPointsLoading.value = false
+    }
+  }
+
+  /** 외부에서 계산한 totalPoints 를 강제 주입 (TreeScore 페이지 등에서 실시간 sync 용) */
+  function setTotalPoints(value) {
+    if (typeof value === 'number' && !Number.isNaN(value)) {
+      totalPoints.value = value
+    }
+  }
+
+  /** 외부에서 계산한 총 판매량(kg) 를 주입 (TreeScore stats.totalKg sync 용) */
+  function setTotalSalesKg(value) {
+    if (typeof value === 'number' && !Number.isNaN(value)) {
+      totalSalesKg.value = value
+    }
+  }
+
   return {
     totalPoints,
+    totalPointsLoading,
+    totalPointsError,
+    totalSalesKg,
+    totalCarbonReductionKg,
+    totalCarbonReductionTon,
+    carbonReductionMonthly,
+    carbonReductionDeltaPct,
     stage,
     stageProgress,
     pointsToNext,
@@ -66,5 +157,8 @@ export const useEsgStore = defineStore('esg', () => {
     kauPriceError,
     fetchKauPrice,
     setKauPrice,
+    fetchTotalPoints,
+    setTotalPoints,
+    setTotalSalesKg,
   }
 })

--- a/src/utils/esgScore.js
+++ b/src/utils/esgScore.js
@@ -1,0 +1,132 @@
+/**
+ * esgScore.js — ESG 점수 계산 공용 로직.
+ *
+ * 사용처:
+ *   - EsgTreeScoreView : 친환경 나무 키우기 점수 상세 페이지 (5종 카테고리/이벤트 분해)
+ *   - esgStore         : ESG 대시보드 헤더 누적 ESG 점수 동기화 (fetchTotalPoints)
+ *
+ * 데이터 소스:
+ *   - sale events     : BE 연동 (GET /api/hq/esg/score-events)
+ *   - donation events : BE 도메인 미구현 → MOCK_DONATION_EVENTS 머지
+ *
+ * 룰 마스터 (FE 단일 진실 원본):
+ *   - 향후 BE 이관 시 GET /api/hq/esg/score-rules 로 fetch 가능
+ */
+
+// ─────────── 점수 룰 ───────────
+export const SCORE_RULES = {
+  saleBase: 100,              // 판매 1건 기본 점수
+  donationBase: 80,           // 기부 1건 기본 점수
+  minWeightKg: 10,            // 최소 중량 (이하면 점수 부여 X)
+  newBuyerBonus: 150,         // 신규 거래처 첫 거래 보너스
+  localPartnerBonus: 150,     // 지역 파트너 보너스 (월 3건 cap, FE 미적용)
+}
+
+// 탄소 점수 스케일링 (다른 점수 요소와의 비중 균형)
+export const CARBON_SCALE = 0.5
+
+// ─────────── 소재 계수 (kgCO₂/kg) ───────────
+//   - circular_material_price_policy 시드와 정합
+//   - 향후 BE GET /api/hq/esg/material-factors 로 교체 가능
+export const MATERIAL_FACTORS = {
+  COTTON:     { label: '면',         group: 'NATURAL_SINGLE', factor: 1.8 },
+  WOOL:       { label: '울',         group: 'NATURAL_SINGLE', factor: 2.5 },
+  CASHMERE:   { label: '캐시미어',   group: 'NATURAL_SINGLE', factor: 5.8 },
+  SILK:       { label: '실크',       group: 'NATURAL_SINGLE', factor: 3.2 },
+  LINEN:      { label: '린넨',       group: 'NATURAL_SINGLE', factor: 1.1 },
+  POLYESTER:  { label: '폴리에스터', group: 'SYNTHETIC',      factor: 2.3 },
+  ACRYLIC:    { label: '아크릴',     group: 'SYNTHETIC',      factor: 2.2 },
+  POLYAMIDE:  { label: '나일론',     group: 'SYNTHETIC',      factor: 2.1 },
+  NYLON:      { label: '나일론',     group: 'SYNTHETIC',      factor: 2.1 },
+  ELASTANE:   { label: '스판덱스',   group: 'SYNTHETIC',      factor: 2.5 },
+  BLEND:      { label: '혼방',       group: 'BLEND',          factor: 2.0 },
+}
+
+// ─────────── Mock 기부 이벤트 (BE 도메인 미구현 — 향후 donation_history 테이블로 교체) ───────────
+export const MOCK_DONATION_EVENTS = [
+  { id: 'd-1', date: '2026-04-28', type: 'donation', buyer: '재해구호본부',  material: 'COTTON',    weightKg:  95, isNewBuyer: false, isLocalPartner: false, donationType: 'DISASTER',  method: null },
+  { id: 'd-2', date: '2026-04-22', type: 'donation', buyer: '사회복지시설',  material: 'COTTON',    weightKg:  80, isNewBuyer: false, isLocalPartner: false, donationType: 'VULNERABLE',method: null },
+  { id: 'd-3', date: '2026-04-14', type: 'donation', buyer: '해외구호단체',  material: 'POLYESTER', weightKg:  50, isNewBuyer: false, isLocalPartner: false, donationType: 'OVERSEAS',  method: null },
+  { id: 'd-4', date: '2026-04-05', type: 'donation', buyer: '직업학교',      material: 'BLEND',     weightKg:  30, isNewBuyer: false, isLocalPartner: false, donationType: 'EDU',       method: null },
+  { id: 'd-5', date: '2026-03-12', type: 'donation', buyer: '재해구호본부',  material: 'COTTON',    weightKg:  60, isNewBuyer: false, isLocalPartner: false, donationType: 'DISASTER',  method: null },
+  { id: 'd-6', date: '2026-01-12', type: 'donation', buyer: '직업학교',      material: 'BLEND',     weightKg:  40, isNewBuyer: false, isLocalPartner: false, donationType: 'EDU',       method: null },
+]
+
+/**
+ * BE 응답 sale event 를 FE event 형태로 정규화.
+ *   - Jackson+Lombok 직렬화 quirk 대응 (isNewBuyer → newBuyer)
+ */
+export function normalizeSaleEvent(e) {
+  return {
+    id: e.id,
+    date: e.date,
+    type: 'sale',
+    buyer: e.buyer,
+    material: e.material,
+    weightKg: e.weightKg,
+    isNewBuyer: e.isNewBuyer ?? e.newBuyer ?? false,
+    isLocalPartner: e.isLocalPartner ?? e.localPartner ?? false,
+    donationType: null,
+    method: null,
+  }
+}
+
+/**
+ * 이벤트 1건 → 5종 점수 분해.
+ *   - 무게 10kg 미만은 점수 부여 X (어뷰징 방지)
+ *   - 탄소 점수 = weight × material_factor × CARBON_SCALE
+ */
+export function calcEventScore(e) {
+  const valid = e.weightKg >= SCORE_RULES.minWeightKg
+  const factor = MATERIAL_FACTORS[e.material]?.factor ?? 0
+  if (e.type === 'sale') {
+    if (!valid) return { saleExecution: 0, carbon: 0, newBuyer: 0, localPartner: 0, donationExecution: 0, total: 0, valid: false }
+    const saleExecution = SCORE_RULES.saleBase
+    const carbon = Math.round(e.weightKg * factor * CARBON_SCALE)
+    const newBuyer = e.isNewBuyer ? SCORE_RULES.newBuyerBonus : 0
+    const localPartner = e.isLocalPartner ? SCORE_RULES.localPartnerBonus : 0
+    const total = saleExecution + carbon + newBuyer + localPartner
+    return { saleExecution, carbon, newBuyer, localPartner, donationExecution: 0, total, valid: true }
+  }
+  // donation
+  if (!valid) return { saleExecution: 0, carbon: 0, newBuyer: 0, localPartner: 0, donationExecution: 0, total: 0, valid: false }
+  const donationExecution = SCORE_RULES.donationBase
+  const carbon = Math.round(e.weightKg * factor * CARBON_SCALE)
+  return { saleExecution: 0, carbon, newBuyer: 0, localPartner: 0, donationExecution, total: donationExecution + carbon, valid: true }
+}
+
+/** events 배열 → 누적 ESG 점수 (5종 합산) */
+export function computeTotalScore(events) {
+  let total = 0
+  for (const e of events ?? []) {
+    total += calcEventScore(e).total
+  }
+  return total
+}
+
+/**
+ * 실제 탄소 배출 절감량 (kg CO₂) — 점수용 CARBON_SCALE 미적용.
+ *   - 각 이벤트의 weight × material_factor 합산
+ *   - 의미: 폐기·소각되지 않고 순환재고로 회피한 실제 탄소량
+ */
+export function computeCarbonReductionKg(events) {
+  let total = 0
+  for (const e of events ?? []) {
+    const factor = MATERIAL_FACTORS[e.material]?.factor ?? 0
+    total += Math.round((Number(e.weightKg) || 0) * factor)
+  }
+  return total
+}
+
+/** events 배열 → 1~12월 탄소 절감량 (kg CO₂) 12개 버킷 */
+export function computeMonthlyCarbonReduction(events) {
+  const buckets = Array(12).fill(0)
+  for (const e of events ?? []) {
+    const d = new Date(e.date)
+    if (Number.isNaN(d.getTime())) continue
+    const m = d.getMonth()
+    const factor = MATERIAL_FACTORS[e.material]?.factor ?? 0
+    buckets[m] += Math.round((Number(e.weightKg) || 0) * factor)
+  }
+  return buckets
+}

--- a/src/views/hq/account/AccountListView.vue
+++ b/src/views/hq/account/AccountListView.vue
@@ -4,7 +4,6 @@ import { useRouter } from 'vue-router'
 import {
   Users,
   Search,
-  RotateCcw,
   X,
   AlertCircle,
   CheckCircle2,
@@ -142,12 +141,13 @@ const paginated = computed(() => {
   return filtered.value.slice(start, start + PAGE_SIZE)
 })
 
-function resetFilter() {
+// 컴포넌트 진입(새로고침/페이지 재방문) 시 필터 강제 초기화 — keep-alive 도입 시에도 정상 동작 보장
+onMounted(() => {
   filter.keyword = ''
   filter.role = ''
   filter.status = ''
   currentPage.value = 1
-}
+})
 
 // ── 상세 패널
 const selected = ref(null)
@@ -267,14 +267,6 @@ async function confirmWithdraw() {
         >
           <option v-for="o in statusOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
         </select>
-        <button
-          type="button"
-          class="inline-flex h-9 items-center gap-1.5 border border-gray-300 bg-white px-3 text-[13px] font-medium text-gray-500 transition hover:bg-gray-50"
-          @click="resetFilter"
-        >
-          <RotateCcw :size="13" />
-          초기화
-        </button>
         <span class="text-[12px] font-medium text-gray-400">{{ filtered.length }}건</span>
       </section>
 

--- a/src/views/hq/analytics/HqAnalyticsSalesView.vue
+++ b/src/views/hq/analytics/HqAnalyticsSalesView.vue
@@ -467,7 +467,16 @@ const productDetailBarOptions = {
   indexAxis: 'y',
   plugins: {
     legend: { display: false },
-    tooltip: { callbacks: { label: (ctx) => formatKoreanMoney(ctx.parsed.x) } },
+    tooltip: {
+      callbacks: {
+        label: (ctx) => {
+          const item = top10ProductDetails.value[ctx.dataIndex]
+          const lines = [`매출: ${formatKoreanMoney(ctx.parsed.x)}`]
+          if (item) lines.push(`판매량: ${Number(item.units ?? 0).toLocaleString()}개`)
+          return lines
+        },
+      },
+    },
   },
   scales: {
     x: { grid: { color: '#f3f4f6' }, ticks: { font: { size: 10 }, callback: (v) => formatKoreanMoney(v) } },

--- a/src/views/hq/analytics/HqAnalyticsVendorView.vue
+++ b/src/views/hq/analytics/HqAnalyticsVendorView.vue
@@ -214,6 +214,26 @@ const doughnutOptions = {
   cutout: '60%',
 }
 
+// 소재 매출 비중 도넛 전용 — 판매량(units) 함께 표시
+const materialDoughnutOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: { display: false },
+    tooltip: {
+      callbacks: {
+        label: (ctx) => {
+          const item = circularMaterialStats.value[ctx.dataIndex]
+          const lines = [`${ctx.label}: ${ctx.parsed}%`]
+          if (item) lines.push(`판매량: ${Number(item.units ?? 0).toLocaleString()}건`)
+          return lines
+        },
+      },
+    },
+  },
+  cutout: '60%',
+}
+
 const maxDependency = computed(() =>
   Math.max(...dependencyData.value.slice(0, 5).map((d) => d.pct), 0),
 )
@@ -247,15 +267,13 @@ const materialTypeBadge = (type) => {
   return 'bg-gray-100 text-gray-600'
 }
 
-// ─── 소재 매출 순위 막대 (순환재고 모드용) ────────────────────────────
-const MATERIAL_BAR_COLOR = '#047857'
-
+// ─── 소재 매출 순위 막대 (순환재고 모드용) — 도넛과 동일한 소재별 컬러 매핑 ────
 const materialSalesBarData = computed(() => ({
   labels: circularMaterialStats.value.map((m) => m.name),
   datasets: [{
     label: '매출',
     data: circularMaterialStats.value.map((m) => m.sales),
-    backgroundColor: MATERIAL_BAR_COLOR,
+    backgroundColor: circularMaterialStats.value.map((_, i) => MATERIAL_PALETTE[i % MATERIAL_PALETTE.length]),
     borderRadius: 4,
   }],
 }))
@@ -439,7 +457,7 @@ const materialDoughnutData = computed(() => ({
                 🥧 소재 매출 비중
               </h3>
             </header>
-            <DoughnutChart :data="materialDoughnutData" :options="doughnutOptions" :height="220" />
+            <DoughnutChart :data="materialDoughnutData" :options="materialDoughnutOptions" :height="220" />
             <ul class="mt-3 grid grid-cols-2 gap-x-3 gap-y-1 text-[11px]">
               <li
                 v-for="mat in materialShareList"

--- a/src/views/hq/dashboard/OperationStatusView.vue
+++ b/src/views/hq/dashboard/OperationStatusView.vue
@@ -5,7 +5,6 @@ import {
   AlertTriangle,
   CheckCircle2,
   Clock,
-  Filter,
 } from 'lucide-vue-next'
 import AppLayout from '@/components/common/AppLayout.vue'
 import DoughnutChart from '@/components/common/charts/DoughnutChart.vue'
@@ -88,75 +87,100 @@ const statusByAvailableAndSafety = (available, safety) => {
 const fetchOperationData = async () => {
   isLoading.value = true
   loadError.value = ''
-  try {
-    const { fromDate, toDate } = getDefaultDateRange(30)
-    const [companyWide, purchaseOrders, transfers, stores] = await Promise.all([
-      getCompanyWideInventories(),
-      purchaseOrderApi.list({ from: fromDate, to: toDate }),
-      getWarehouseTransfers({ fromDate, toDate }),
-      getInfrastructures({ type: 'STORE', status: 'ACTIVE' }),
-    ])
 
-    const activeStoreCount = Array.isArray(stores) ? stores.length : 0
+  const { fromDate, toDate } = getDefaultDateRange(30)
+  // 재고이동 진행은 실시간(현재 시점 진행 중) 기준으로 표시 — 기간 필터 우회용 넓은 범위
+  const TRANSFER_FROM = '2020-01-01'
+  const TRANSFER_TO = '2099-12-31'
+  // Promise.allSettled — 부분 실패해도 나머지 KPI는 표시
+  const results = await Promise.allSettled([
+    getCompanyWideInventories(),
+    purchaseOrderApi.list({ from: fromDate, to: toDate }),
+    getWarehouseTransfers({ fromDate: TRANSFER_FROM, toDate: TRANSFER_TO }),
+    getInfrastructures({ type: 'STORE', status: 'ACTIVE' }),
+  ])
+  const [companyWideRes, purchaseOrdersRes, transfersRes, storesRes] = results
 
-    const items = Array.isArray(companyWide?.items) ? companyWide.items : []
-    const shortages = items
-      .map((item) => {
-        const availableStock = toNum(item.availableStock)
-        const safetyStock = toNum(item.safetyStock)
-        return {
-          item: item.itemName,
-          category: [item.parentCategory, item.childCategory].filter(Boolean).join(' > '),
-          location: '전사 집계',
-          status: statusByAvailableAndSafety(availableStock, safetyStock),
-          stock: availableStock,
-          safety: safetyStock,
-          gap: Math.max(0, safetyStock - availableStock),
-        }
-      })
-      .filter((item) => item.status === '부족' || item.status === '품절')
-      .sort((a, b) => b.gap - a.gap)
+  const companyWide = companyWideRes.status === 'fulfilled' ? companyWideRes.value : null
+  // BE 는 Page<> 객체를 반환 — content 배열 추출 (배열 직접 반환 케이스도 호환)
+  const purchaseOrdersRaw = purchaseOrdersRes.status === 'fulfilled' ? purchaseOrdersRes.value : null
+  const purchaseOrders = Array.isArray(purchaseOrdersRaw)
+    ? purchaseOrdersRaw
+    : (Array.isArray(purchaseOrdersRaw?.content) ? purchaseOrdersRaw.content : [])
+  const transfers = transfersRes.status === 'fulfilled'
+    ? (Array.isArray(transfersRes.value) ? transfersRes.value : (transfersRes.value?.content || []))
+    : []
+  const stores = storesRes.status === 'fulfilled'
+    ? (Array.isArray(storesRes.value) ? storesRes.value : (storesRes.value?.content || []))
+    : []
 
-    inventoryRisks.value = shortages.slice(0, 8)
+  const failedLabels = []
+  if (companyWideRes.status === 'rejected') failedLabels.push('전사 재고')
+  if (purchaseOrdersRes.status === 'rejected') failedLabels.push('발주')
+  if (transfersRes.status === 'rejected') failedLabels.push('재고이동')
+  if (storesRes.status === 'rejected') failedLabels.push('매장')
+  loadError.value = failedLabels.length
+    ? `일부 데이터를 불러오지 못했습니다 (${failedLabels.join(', ')}). 네트워크 상태나 BE 상태를 확인해주세요.`
+    : ''
 
-    const statusCountMap = {}
-    for (const order of purchaseOrders || []) {
-      const code = mapPurchaseStatus(order.status)
-      statusCountMap[code] = (statusCountMap[code] || 0) + 1
-    }
-    purchaseStatusBreakdown.value = PURCHASE_STATUS_META.map((s) => ({
-      ...s,
-      count: statusCountMap[s.code] || 0,
-    }))
+  const activeStoreCount = Array.isArray(stores) ? stores.length : 0
 
-    const inTransitTransferCount = (transfers || []).filter(
-      (row) => String(row.status || '').toUpperCase() !== 'ARRIVED',
-    ).length
+  const items = Array.isArray(companyWide?.items) ? companyWide.items : []
+  const shortages = items
+    .map((item) => {
+      const availableStock = toNum(item.availableStock)
+      const safetyStock = toNum(item.safetyStock)
+      return {
+        item: item.itemName,
+        category: [item.parentCategory, item.childCategory].filter(Boolean).join(' > '),
+        location: '전사 집계',
+        status: statusByAvailableAndSafety(availableStock, safetyStock),
+        stock: availableStock,
+        safety: safetyStock,
+        gap: Math.max(0, safetyStock - availableStock),
+      }
+    })
+    .filter((item) => item.status === '부족' || item.status === '품절')
+    .sort((a, b) => b.gap - a.gap)
 
-    kpiOps.value = [
-      {
-        label: '운영 매장 수',
-        value: `${activeStoreCount}`,
-        unit: '곳',
-        caption: '상태 ACTIVE 매장',
-        tone: 'green',
-      },
-      {
-        label: '재고이동 진행',
-        value: `${inTransitTransferCount}`,
-        unit: '건',
-        caption: '출고 준비중 + 배송중',
-        tone: 'blue',
-      },
-    ]
-  } catch (error) {
-    loadError.value = extractErrorMessage(error, '운영 현황 데이터를 불러오지 못했습니다.')
-    kpiOps.value = []
-    inventoryRisks.value = []
-    purchaseStatusBreakdown.value = []
-  } finally {
-    isLoading.value = false
+  inventoryRisks.value = shortages.slice(0, 8)
+
+  const statusCountMap = {}
+  for (const order of purchaseOrders || []) {
+    const code = mapPurchaseStatus(order.status)
+    statusCountMap[code] = (statusCountMap[code] || 0) + 1
   }
+  purchaseStatusBreakdown.value = PURCHASE_STATUS_META.map((s) => ({
+    ...s,
+    count: statusCountMap[s.code] || 0,
+  }))
+
+  const inTransitTransferCount = (transfers || []).filter(
+    (row) => String(row.status || '').toUpperCase() !== 'ARRIVED',
+  ).length
+
+  kpiOps.value = [
+    {
+      label: '운영 매장 수',
+      value: `${activeStoreCount}`,
+      unit: '곳',
+      caption: storesRes.status === 'fulfilled' ? '상태 ACTIVE 매장' : '불러오기 실패',
+      tone: 'green',
+      route: '/hq/infrastructure',
+      hoverCls: 'hover:border-emerald-400',
+    },
+    {
+      label: '재고이동 진행',
+      value: `${inTransitTransferCount}`,
+      unit: '건',
+      caption: transfersRes.status === 'fulfilled' ? '실시간 · 출고 준비중 + 배송중' : '불러오기 실패',
+      tone: 'blue',
+      route: '/hq/inventory/warehouse-comparison',
+      hoverCls: 'hover:border-blue-400',
+    },
+  ]
+
+  isLoading.value = false
 }
 
 // ───────── 상세 분석 (Analytics) 상태 ─────────
@@ -210,7 +234,9 @@ async function fetchAnalyticsData() {
   }
 }
 
-// ───────── 월별 판매 수량 (12회 API 호출 · FE 집계) ─────────
+// ───────── 월별 판매 수량 (단일 API 호출 · FE 월별 집계) ─────────
+// BE의 SalesAnalyticsDto.TrendPoint에 quantity 필드 추가로 1회 호출에서 모든 일자별 수량 수신.
+// FE는 label "MM/dd"에서 월을 추출해 12개 버킷으로 합산.
 const monthlyQuantities = ref(Array(12).fill(0))
 const monthlyQtyLoading = ref(false)
 
@@ -218,21 +244,21 @@ async function fetchMonthlyQuantities() {
   monthlyQtyLoading.value = true
   try {
     const year = selectedYear.value
-    const pad2 = (n) => String(n).padStart(2, '0')
-    const fmt = (y, m, d) => `${y}-${pad2(m)}-${pad2(d)}`
-    const promises = []
-    for (let m = 1; m <= 12; m++) {
-      const from = fmt(year, m, 1)
-      const lastDay = new Date(year, m, 0).getDate()
-      const to = fmt(year, m, lastDay)
-      promises.push(
-        salesAnalyticsApi
-          .get({ period: 'MONTH', from, to })
-          .then((d) => Number(d?.kpi?.totalQuantity ?? d?.kpi?.totalSalesQty ?? 0))
-          .catch(() => 0),
-      )
+    const from = `${year}-01-01`
+    const to = `${year}-12-31`
+    const data = await salesAnalyticsApi.get({ period: 'YEAR', from, to })
+
+    const buckets = Array(12).fill(0)
+    for (const point of (data?.trend?.current ?? [])) {
+      const monthToken = String(point?.label ?? '').split('/')[0]
+      const m = parseInt(monthToken, 10)
+      if (m >= 1 && m <= 12) {
+        buckets[m - 1] += Number(point?.quantity ?? 0)
+      }
     }
-    monthlyQuantities.value = await Promise.all(promises)
+    monthlyQuantities.value = buckets
+  } catch {
+    monthlyQuantities.value = Array(12).fill(0)
   } finally {
     monthlyQtyLoading.value = false
   }
@@ -362,7 +388,16 @@ const materialDoughnutOptions = {
   maintainAspectRatio: false,
   plugins: {
     legend: { display: false },
-    tooltip: { callbacks: { label: (ctx) => `${ctx.label}: ${ctx.parsed}%` } },
+    tooltip: {
+      callbacks: {
+        label: (ctx) => {
+          const item = circularMaterialStats.value[ctx.dataIndex]
+          const lines = [`${ctx.label}: ${ctx.parsed}%`]
+          if (item) lines.push(`판매량: ${Number(item.units ?? 0).toLocaleString()}건`)
+          return lines
+        },
+      },
+    },
   },
   cutout: '60%',
 }
@@ -392,7 +427,7 @@ onMounted(() => {
             </p>
             <h1 class="mt-1 text-xl font-black text-gray-950">본사 대시보드</h1>
             <p class="mt-1 text-xs font-bold text-gray-500">
-              전사 재고·발주·매출 추이·이상치 알림을 한 화면에서 확인합니다.
+              운영 KPI·월별 판매·재고 위험·소재 매출·발주 상태를 한 화면에서 확인합니다.
             </p>
           </div>
           <div class="flex items-center gap-2">
@@ -420,40 +455,14 @@ onMounted(() => {
         운영 현황 데이터를 불러오는 중입니다.
       </p>
 
-      <!-- 필터 바 (매출 추이/통계 카드 대상) -->
-      <section class="flex flex-wrap items-center gap-3 border border-gray-300 bg-white p-3 shadow-sm">
-        <div class="flex items-center gap-1.5 border-r border-gray-200 pr-3 text-[11px] font-bold text-gray-500">
-          <Filter :size="13" />
-          분석 필터
-        </div>
-        <label class="flex items-center gap-2 text-[11px] font-bold text-gray-500">
-          기간
-          <select v-model="periodUnit" class="border border-gray-300 bg-gray-50 px-3 py-1.5 text-xs font-bold text-gray-700 outline-none focus:border-[#004D3C] focus:bg-white">
-            <option v-for="p in periodOptions" :key="p" :value="p">{{ p }}</option>
-          </select>
-        </label>
-        <label class="flex items-center gap-2 text-[11px] font-bold text-gray-500">
-          연도
-          <select v-model.number="selectedYear" class="border border-gray-300 bg-gray-50 px-3 py-1.5 text-xs font-bold text-gray-700 outline-none focus:border-[#004D3C] focus:bg-white">
-            <option v-for="y in yearOptions" :key="y" :value="y">{{ y }}년</option>
-          </select>
-        </label>
-        <label v-if="periodUnit === '월간'" class="flex items-center gap-2 text-[11px] font-bold text-gray-500">
-          월
-          <select v-model.number="selectedMonth" class="border border-gray-300 bg-gray-50 px-3 py-1.5 text-xs font-bold text-gray-700 outline-none focus:border-[#004D3C] focus:bg-white">
-            <option v-for="m in monthOptions" :key="m" :value="m">{{ m }}월</option>
-          </select>
-        </label>
-        <span v-if="statsLoading" class="ml-auto text-[11px] font-bold text-emerald-600">분석 데이터 불러오는 중…</span>
-        <span v-else-if="statsError" class="ml-auto text-[11px] font-bold text-red-600">{{ statsError }}</span>
-      </section>
-
       <!-- 운영 KPI + 통계 카드 -->
       <section class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
         <article
           v-for="stat in kpiOps"
           :key="stat.label"
-          class="border border-gray-200 bg-white px-4 py-3 shadow-sm"
+          class="group border border-gray-200 bg-white px-4 py-3 shadow-sm transition"
+          :class="stat.route ? ['cursor-pointer', stat.hoverCls || 'hover:border-gray-400', 'hover:-translate-y-0.5', 'hover:shadow-md'] : []"
+          @click="stat.route && router.push(stat.route)"
         >
           <p class="text-[11px] font-bold text-gray-500">{{ stat.label }}</p>
           <div class="mt-3 flex items-end justify-between gap-2">
@@ -473,12 +482,18 @@ onMounted(() => {
               }"
             />
           </div>
-          <p class="mt-2 text-[11px] font-bold text-gray-400">{{ stat.caption }}</p>
+          <div class="mt-2 flex items-center justify-between gap-2">
+            <p class="truncate text-[11px] font-bold text-gray-400">{{ stat.caption }}</p>
+            <span
+              v-if="stat.route"
+              class="shrink-0 text-[10px] font-black text-[#004D3C] group-hover:underline"
+            >자세히 보기 →</span>
+          </div>
         </article>
 
         <!-- 상품 판매량 (분석 점프 카드) -->
         <article
-          class="cursor-pointer border border-gray-200 bg-white px-4 py-3 shadow-sm transition hover:-translate-y-0.5 hover:border-emerald-400 hover:shadow-md"
+          class="group cursor-pointer border border-gray-200 bg-white px-4 py-3 shadow-sm transition hover:-translate-y-0.5 hover:border-emerald-400 hover:shadow-md"
           @click="router.push('/hq/analytics/sales')"
         >
           <p class="text-[11px] font-bold text-gray-500">상품 판매량</p>
@@ -489,12 +504,15 @@ onMounted(() => {
             </div>
             <span class="h-2.5 w-2.5 shrink-0 bg-emerald-400" />
           </div>
-          <p class="mt-2 truncate text-[11px] font-bold text-gray-400">{{ formatTrendPct(kpi.totalRevenueTrendPct) }} · 매출 1위 {{ kpi.topProductName || '-' }}</p>
+          <div class="mt-2 flex items-center justify-between gap-2">
+            <p class="truncate text-[11px] font-bold text-gray-400">{{ formatTrendPct(kpi.totalRevenueTrendPct) }} · 매출 1위 {{ kpi.topProductName || '-' }}</p>
+            <span class="shrink-0 text-[10px] font-black text-[#004D3C] group-hover:underline">자세히 보기 →</span>
+          </div>
         </article>
 
         <!-- 순환재고 판매량 (분석 점프 카드) -->
         <article
-          class="cursor-pointer border border-gray-200 bg-white px-4 py-3 shadow-sm transition hover:-translate-y-0.5 hover:border-blue-400 hover:shadow-md"
+          class="group cursor-pointer border border-gray-200 bg-white px-4 py-3 shadow-sm transition hover:-translate-y-0.5 hover:border-blue-400 hover:shadow-md"
           @click="router.push('/hq/analytics/vendors')"
         >
           <p class="text-[11px] font-bold text-gray-500">순환재고 판매량</p>
@@ -505,7 +523,10 @@ onMounted(() => {
             </div>
             <span class="h-2.5 w-2.5 shrink-0 bg-blue-400" />
           </div>
-          <p class="mt-2 truncate text-[11px] font-bold text-gray-400">활성 거래처 {{ Number(kpi.activeVendorCount ?? 0).toLocaleString() }}곳 · TOP {{ (kpi.topVendorName ?? '').trim() || '-' }}</p>
+          <div class="mt-2 flex items-center justify-between gap-2">
+            <p class="truncate text-[11px] font-bold text-gray-400">활성 거래처 {{ Number(kpi.activeVendorCount ?? 0).toLocaleString() }}곳 · TOP {{ (kpi.topVendorName ?? '').trim() || '-' }}</p>
+            <span class="shrink-0 text-[10px] font-black text-[#004D3C] group-hover:underline">자세히 보기 →</span>
+          </div>
         </article>
 
         <article
@@ -529,7 +550,16 @@ onMounted(() => {
                 {{ selectedYear }}년 월별 상품 판매 수량 합계
               </p>
             </div>
-            <span v-if="monthlyQtyLoading" class="text-[11px] font-bold text-emerald-600">집계 중…</span>
+            <div class="flex items-center gap-3">
+              <span v-if="monthlyQtyLoading" class="text-[11px] font-bold text-emerald-600">집계 중…</span>
+              <button
+                type="button"
+                class="text-xs font-black text-[#004D3C] hover:underline"
+                @click="router.push('/hq/analytics/sales')"
+              >
+                판매량 조회
+              </button>
+            </div>
           </div>
           <div class="flex-1 px-4 py-4" style="min-height: 280px;">
             <BarChart :data="monthlySalesChartData" :options="monthlySalesChartOptions" />
@@ -591,11 +621,20 @@ onMounted(() => {
       <!-- 소재 매출 비중 + 발주 상태별 진행 -->
       <section class="grid gap-4 xl:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)]">
         <article class="border border-gray-200 bg-white shadow-sm">
-          <div class="border-b border-gray-100 px-4 py-3">
-            <h2 class="inline-flex items-center gap-2 text-sm font-black text-gray-900">
-              🥧 소재 매출 비중
-            </h2>
-            <p class="mt-1 text-[11px] font-bold text-gray-400">순환재고 소재별 매출 점유율 (현재 필터 기준)</p>
+          <div class="flex items-center justify-between border-b border-gray-100 px-4 py-3">
+            <div>
+              <h2 class="inline-flex items-center gap-2 text-sm font-black text-gray-900">
+                🥧 소재 매출 비중
+              </h2>
+              <p class="mt-1 text-[11px] font-bold text-gray-400">순환재고 소재별 매출 점유율 (현재 필터 기준)</p>
+            </div>
+            <button
+              type="button"
+              class="text-xs font-black text-[#004D3C] hover:underline"
+              @click="router.push('/hq/analytics/vendors')"
+            >
+              순환재고 판매량 조회
+            </button>
           </div>
           <div class="grid gap-4 p-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
             <div class="min-h-[240px]">

--- a/src/views/hq/esg/EsgCarbonPriceView.vue
+++ b/src/views/hq/esg/EsgCarbonPriceView.vue
@@ -1,0 +1,497 @@
+<script setup>
+import { ref, computed, onMounted, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import {
+  TrendingUp, TrendingDown, ArrowUpDown,
+  AlertCircle, RefreshCw, Building2, ArrowLeft,
+} from 'lucide-vue-next'
+import AppLayout from '@/components/common/AppLayout.vue'
+import { roleMenus } from '@/config/roleMenus.js'
+import { useAuthStore } from '@/stores/auth.js'
+import { carbonPriceApi } from '@/api/hq/esg.js'
+import { extractErrorMessage } from '@/api/axios.js'
+
+// Chart.js
+import {
+  Chart as ChartJS,
+  CategoryScale, LinearScale, PointElement, LineElement,
+  Title, Tooltip, Legend, Filler,
+} from 'chart.js'
+import { Line as ChartJsLine } from 'vue-chartjs'
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, Filler)
+const router = useRouter()
+const auth = useAuthStore()
+
+// ─────────── AppLayout props ───────────
+const topMenus = computed(() => roleMenus.hq ?? [])
+const sideMenus = computed(
+  () => (roleMenus.hq ?? []).find((menu) => menu.label === 'ESG 대시보드')?.children ?? [],
+)
+const activeSideMenu = ref('배출권 시장 가치')
+
+// ─────────── 기간 필터 ───────────
+const PERIOD_OPTIONS = [
+  { key: 'SEVEN_DAYS', label: '7일' },
+  { key: 'ONE_MONTH',  label: '1개월' },
+  { key: 'SIX_MONTHS', label: '6개월' },
+]
+const selectedPeriod = ref('SEVEN_DAYS')
+
+// ─────────── 페이징 (일자별 상세 테이블) ───────────
+const PAGE_SIZE = 15
+const currentPage = ref(1)
+
+// 최신 → 과거 순 정렬된 전체 데이터 (테이블용)
+const sortedDesc = computed(() => [...trend.value].reverse())
+
+// 전체 페이지 수
+const totalPages = computed(() =>
+  Math.max(1, Math.ceil(sortedDesc.value.length / PAGE_SIZE)),
+)
+
+// 현재 페이지의 데이터 슬라이스
+const pagedRows = computed(() => {
+  const start = (currentPage.value - 1) * PAGE_SIZE
+  return sortedDesc.value.slice(start, start + PAGE_SIZE)
+})
+
+// 표시할 페이지 번호 목록 (현재 ±2, 양 끝 + 줄임표)
+const pageNumbers = computed(() => {
+  const total = totalPages.value
+  const cur = currentPage.value
+  if (total <= 7) return Array.from({ length: total }, (_, i) => i + 1)
+
+  const pages = new Set([1, 2, total - 1, total, cur - 1, cur, cur + 1])
+  const sorted = [...pages].filter(p => p >= 1 && p <= total).sort((a, b) => a - b)
+
+  // 사이에 끊김 있으면 ... 삽입
+  const result = []
+  let prev = 0
+  for (const p of sorted) {
+    if (prev && p - prev > 1) result.push('...')
+    result.push(p)
+    prev = p
+  }
+  return result
+})
+
+function goToPage(p) {
+  if (p === '...') return
+  if (p < 1 || p > totalPages.value) return
+  currentPage.value = p
+}
+
+// 기간 필터 변경 시 페이지 1로 리셋 (아래 watch 통합)
+
+// ─────────── 데이터 로드 ───────────
+const latest = ref(null)
+const trend  = ref([])
+const loading = ref(false)
+const loadError = ref('')
+
+/** latest 와 trend 둘 다 로드 (초기 진입 / 새로고침 버튼) */
+async function loadAll() {
+  loading.value = true
+  loadError.value = ''
+  try {
+    const [latestRes, trendRes] = await Promise.all([
+      carbonPriceApi.getLatest(),
+      carbonPriceApi.getTrend(selectedPeriod.value),
+    ])
+    latest.value = latestRes
+    trend.value = trendRes ?? []
+  } catch (err) {
+    loadError.value = extractErrorMessage(err, '배출권 시세를 불러오지 못했습니다.')
+  } finally {
+    loading.value = false
+  }
+}
+
+/** 기간 탭 변경 시 trend 만 다시 로드 (latest 는 그대로) */
+async function loadTrendOnly(period) {
+  loading.value = true
+  loadError.value = ''
+  try {
+    const trendRes = await carbonPriceApi.getTrend(period)
+    trend.value = trendRes ?? []
+  } catch (err) {
+    loadError.value = extractErrorMessage(err, '배출권 시세를 불러오지 못했습니다.')
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(selectedPeriod, (next) => {
+  currentPage.value = 1   // 기간 바꾸면 페이지 1로 리셋
+  loadTrendOnly(next)
+})
+
+onMounted(loadAll)
+
+// ─────────── 포맷터 ───────────
+const formatPrice = (n) => (n ?? 0).toLocaleString('ko-KR')
+const formatPct = (s) => {
+  if (s === null || s === undefined || s === '') return '0%'
+  const n = parseFloat(s)
+  if (Number.isNaN(n)) return s
+  const sign = n > 0 ? '+' : ''
+  return `${sign}${n.toFixed(2)}%`
+}
+const formatBasDt = (yyyymmdd) => {
+  if (!yyyymmdd || yyyymmdd.length !== 8) return yyyymmdd ?? '-'
+  return `${yyyymmdd.slice(0,4)}-${yyyymmdd.slice(4,6)}-${yyyymmdd.slice(6,8)}`
+}
+const shortDt = (yyyymmdd) => {
+  if (!yyyymmdd || yyyymmdd.length !== 8) return yyyymmdd ?? ''
+  return `${yyyymmdd.slice(4,6)}/${yyyymmdd.slice(6,8)}`
+}
+
+// ─────────── 기간 메타 ───────────
+const trendStartDate = computed(() => trend.value.length ? formatBasDt(trend.value[0].basDt) : '')
+const trendEndDate   = computed(() => trend.value.length ? formatBasDt(trend.value[trend.value.length - 1].basDt) : '')
+
+// ─────────── KPI 계산 ───────────
+const sevenDay = computed(() => trend.value.slice(-7))
+
+const high7d = computed(() => {
+  if (!sevenDay.value.length) return 0
+  return Math.max(...sevenDay.value.map(d => d.pricePerTon))
+})
+const low7d = computed(() => {
+  if (!sevenDay.value.length) return 0
+  return Math.min(...sevenDay.value.map(d => d.pricePerTon))
+})
+const avg7d = computed(() => {
+  if (!sevenDay.value.length) return 0
+  const sum = sevenDay.value.reduce((acc, d) => acc + d.pricePerTon, 0)
+  return Math.round(sum / sevenDay.value.length)
+})
+
+const fltRtNum = computed(() => parseFloat(latest.value?.fltRt ?? '0') || 0)
+const isUp = computed(() => fltRtNum.value > 0)
+const isDown = computed(() => fltRtNum.value < 0)
+
+// ─────────── Chart.js 설정 ───────────
+const chartData = computed(() => ({
+  labels: trend.value.map(d => shortDt(d.basDt)),
+  datasets: [
+    {
+      label: 'KAU25 종가 (원/톤)',
+      data: trend.value.map(d => d.pricePerTon),
+      borderColor: '#004D3C',
+      backgroundColor: 'rgba(0, 77, 60, 0.08)',
+      pointBackgroundColor: '#004D3C',
+      pointRadius: 4,
+      pointHoverRadius: 6,
+      tension: 0.25,
+      fill: true,
+    },
+  ],
+}))
+
+const chartOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: { display: false },
+    tooltip: {
+      backgroundColor: '#004D3C',
+      titleColor: '#fff',
+      bodyColor: '#fff',
+      padding: 10,
+      callbacks: {
+        label: (ctx) => `${ctx.parsed.y.toLocaleString('ko-KR')}원/톤`,
+      },
+    },
+  },
+  scales: {
+    y: {
+      beginAtZero: false,
+      ticks: { callback: (v) => v.toLocaleString('ko-KR') + '원' },
+      grid: { color: 'rgba(0,0,0,0.05)' },
+    },
+    x: {
+      grid: { display: false },
+      ticks: {
+        autoSkip: false,
+        maxRotation: 0,
+        // 최근 거래일(마지막)과 첫 거래일은 항상 표시, 중간은 균등 압축
+        callback: function (value, index) {
+          const labels = this.chart?.data?.labels ?? []
+          const total = labels.length
+          if (total === 0) return ''
+          if (index === 0 || index === total - 1) return labels[index]
+          const skipN = Math.max(1, Math.ceil(total / 10))
+          return index % skipN === 0 ? labels[index] : ''
+        },
+      },
+    },
+  },
+}
+</script>
+
+<template>
+  <AppLayout
+    active-top-menu="ESG 대시보드"
+    :top-menus="topMenus"
+    :side-menus="sideMenus"
+    v-model:active-side-menu="activeSideMenu"
+  >
+    <div class="flex flex-col gap-4">
+      <!-- 헤더 -->
+      <div class="flex items-end justify-between">
+        <div>
+          <button
+            type="button"
+            class="mb-2 inline-flex items-center gap-1.5 border border-[#004D3C]/30 bg-[#eef7f4] px-3 py-1.5 text-[12px] font-bold text-[#004D3C] transition hover:bg-[#004D3C] hover:text-white"
+            @click="router.push('/hq/esg')"
+          >
+            <ArrowLeft :size="14" />
+            ESG 대시보드로 돌아가기
+          </button>
+          <h1 class="text-[20px] font-bold text-gray-900">
+            탄소 배출권 시장
+          </h1>
+          <p class="mt-0.5 text-[12px] text-gray-500">
+            KRX 한국거래소 배출권 시장(KAU25) 시세 — 공공데이터포털 연동
+          </p>
+        </div>
+        <button
+          type="button"
+          class="inline-flex items-center gap-1.5 border border-gray-300 bg-white px-3 py-1.5 text-[12px] font-medium text-gray-600 transition hover:bg-gray-50"
+          @click="loadAll"
+          :disabled="loading"
+        >
+          <RefreshCw :size="13" :class="{ 'animate-spin': loading }" />
+          새로고침
+        </button>
+      </div>
+
+      <!-- 로딩 / 에러 -->
+      <div v-if="loading && !latest" class="border border-gray-300 bg-white p-12 text-center text-[13px] text-gray-500">
+        시세를 불러오는 중...
+      </div>
+      <div v-else-if="loadError" class="flex items-center gap-2 border border-red-200 bg-red-50 p-4 text-[13px] text-red-600">
+        <AlertCircle :size="16" />
+        {{ loadError }}
+      </div>
+
+      <template v-else-if="latest">
+        <!-- 폴백 알림 -->
+        <div
+          v-if="latest.fallback"
+          class="flex items-start gap-2 border border-amber-200 bg-amber-50 px-4 py-2.5 text-[12px] font-medium text-amber-800"
+        >
+          <AlertCircle :size="14" class="mt-0.5 shrink-0" />
+          외부 시세 API 응답이 일시적으로 지연되어 예비값(fallback)을 표시 중입니다. 새로고침으로 재시도해 보세요.
+        </div>
+
+        <!-- KPI 카드 4개 -->
+        <section class="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
+          <!-- 현재 시세 -->
+          <div class="border border-gray-300 bg-gradient-to-br from-[#004D3C] to-[#0A6E58] p-5 text-white shadow-sm">
+            <div class="flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-widest text-white/70">
+              <Building2 :size="12" />
+              현재 시세
+            </div>
+            <div class="mt-2 flex items-baseline gap-1.5">
+              <span class="text-[26px] font-black leading-none">{{ formatPrice(latest.pricePerTon) }}</span>
+              <span class="text-[12px] text-white/80">원/톤</span>
+            </div>
+            <div class="mt-2 text-[11px] text-white/70">
+              {{ formatBasDt(latest.basDt) }} · {{ latest.symbol }}
+            </div>
+          </div>
+
+          <!-- 전일 대비 -->
+          <div class="border border-gray-300 bg-white p-5 shadow-sm">
+            <div class="inline-flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-widest text-gray-400">
+              <ArrowUpDown :size="12" />
+              전일 대비
+            </div>
+            <div
+              class="mt-2 flex items-baseline gap-1.5"
+              :class="isUp ? 'text-red-600' : isDown ? 'text-blue-600' : 'text-gray-700'"
+            >
+              <component :is="isUp ? TrendingUp : isDown ? TrendingDown : ArrowUpDown" :size="22" />
+              <span class="text-[24px] font-black leading-none">
+                {{ formatPct(latest.fltRt) }}
+              </span>
+            </div>
+            <p class="mt-2 text-[11px] text-gray-500">전일 종가 대비 등락률</p>
+          </div>
+
+          <!-- 7일 최고 -->
+          <div class="border border-gray-300 bg-white p-5 shadow-sm">
+            <div class="inline-flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-widest text-gray-400">
+              <TrendingUp :size="12" class="text-red-500" />
+              7거래일 최고
+            </div>
+            <div class="mt-2 flex items-baseline gap-1.5">
+              <span class="text-[24px] font-black leading-none text-gray-800">{{ formatPrice(high7d) }}</span>
+              <span class="text-[12px] text-gray-400">원/톤</span>
+            </div>
+            <p class="mt-2 text-[11px] text-gray-500">최근 7거래일 종가 중 최고가</p>
+          </div>
+
+          <!-- 7일 최저 -->
+          <div class="border border-gray-300 bg-white p-5 shadow-sm">
+            <div class="inline-flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-widest text-gray-400">
+              <TrendingDown :size="12" class="text-blue-500" />
+              7거래일 최저
+            </div>
+            <div class="mt-2 flex items-baseline gap-1.5">
+              <span class="text-[24px] font-black leading-none text-gray-800">{{ formatPrice(low7d) }}</span>
+              <span class="text-[12px] text-gray-400">원/톤</span>
+            </div>
+            <p class="mt-2 text-[11px] text-gray-500">평균 {{ formatPrice(avg7d) }}원/톤</p>
+          </div>
+        </section>
+
+        <!-- 시계열 차트 -->
+        <section class="border border-gray-300 bg-white shadow-sm">
+          <div class="flex items-center justify-between border-b border-gray-200 px-4 py-3">
+            <div>
+              <h2 class="text-[14px] font-bold text-gray-800">시세 추이 ({{ trend.length }}거래일)</h2>
+              <p class="text-[10px] text-gray-500">KAU25 일별 종가 (원/톤) · 거래량 0 인 날짜는 제외</p>
+              <p v-if="trend.length" class="mt-0.5 text-[10.5px] text-gray-600">
+                기간: <span class="font-mono">{{ trendStartDate }}</span>
+                <span class="mx-1 text-gray-400">~</span>
+                <span class="font-mono font-bold text-[#004D3C]">{{ trendEndDate }}</span>
+                <span class="ml-1 text-gray-400">(최근 거래일)</span>
+              </p>
+            </div>
+            <!-- 기간 필터 탭 -->
+            <div class="flex gap-1">
+              <button
+                v-for="opt in PERIOD_OPTIONS"
+                :key="opt.key"
+                type="button"
+                :class="[
+                  'border px-3 py-1 text-[12px] font-bold transition',
+                  selectedPeriod === opt.key
+                    ? 'border-[#004D3C] bg-[#004D3C] text-white'
+                    : 'border-gray-300 bg-white text-gray-600 hover:bg-gray-50'
+                ]"
+                :disabled="loading"
+                @click="selectedPeriod = opt.key"
+              >
+                {{ opt.label }}
+              </button>
+            </div>
+          </div>
+          <div class="p-4" style="height: 360px;">
+            <ChartJsLine v-if="trend.length" :data="chartData" :options="chartOptions" />
+            <div v-else class="flex h-full items-center justify-center text-[12px] text-gray-400">
+              데이터 없음
+            </div>
+          </div>
+          <!-- 휴장일 안내 footer -->
+          <div class="border-t border-gray-100 bg-gray-50 px-4 py-2.5 text-[11px] leading-relaxed text-gray-500">
+            <span class="mr-1 font-bold text-gray-700">ⓘ</span>
+            한국거래소 배출권 시장은 <strong class="text-gray-700">평일 오전 10:00~12:00</strong>만 운영됩니다.
+            <strong class="text-gray-700">주말·공휴일</strong>은 휴장이라 시세가 형성되지 않아
+            그래프와 표에서 제외됩니다.
+          </div>
+        </section>
+
+        <!-- 일자별 상세 테이블 (15건/페이지 페이징) -->
+        <section class="border border-gray-300 bg-white shadow-sm">
+          <div class="flex items-center justify-between border-b border-gray-200 px-4 py-3">
+            <h2 class="text-[14px] font-bold text-gray-800">
+              일자별 상세
+              <span class="ml-1 font-normal text-gray-500">총 {{ trend.length }}거래일</span>
+            </h2>
+            <span class="text-[11px] font-medium text-gray-500">
+              {{ currentPage }} / {{ totalPages }} 페이지
+            </span>
+          </div>
+          <div class="overflow-x-auto">
+            <table class="w-full text-left text-[12px]">
+              <thead class="border-b border-gray-200 bg-gray-50">
+                <tr>
+                  <th class="px-4 py-2 font-bold text-gray-600">기준일</th>
+                  <th class="px-4 py-2 font-bold text-gray-600">종목</th>
+                  <th class="px-4 py-2 text-right font-bold text-gray-600">종가</th>
+                  <th class="px-4 py-2 text-right font-bold text-gray-600">등락률</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  v-for="(d, idx) in pagedRows"
+                  :key="d.basDt + idx"
+                  class="border-b border-gray-100 last:border-0"
+                >
+                  <td class="px-4 py-2 font-mono text-gray-800">{{ formatBasDt(d.basDt) }}</td>
+                  <td class="px-4 py-2 font-mono text-gray-600">{{ d.symbol }}</td>
+                  <td class="px-4 py-2 text-right font-bold text-gray-900">{{ formatPrice(d.pricePerTon) }}원</td>
+                  <td
+                    class="px-4 py-2 text-right font-medium"
+                    :class="parseFloat(d.fltRt) > 0 ? 'text-red-600' : parseFloat(d.fltRt) < 0 ? 'text-blue-600' : 'text-gray-500'"
+                  >
+                    {{ formatPct(d.fltRt) }}
+                  </td>
+                </tr>
+                <tr v-if="!pagedRows.length">
+                  <td colspan="4" class="px-4 py-6 text-center text-[12px] text-gray-400">데이터 없음</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- 페이지네이션 -->
+          <div
+            v-if="totalPages > 1"
+            class="flex items-center justify-between border-t border-gray-200 bg-gray-50 px-4 py-2.5"
+          >
+            <span class="text-[11px] text-gray-500">
+              {{ (currentPage - 1) * 15 + 1 }}–{{ Math.min(currentPage * 15, trend.length) }}
+              / 총 {{ trend.length }}건
+            </span>
+
+            <div class="flex items-center gap-1">
+              <!-- 이전 -->
+              <button
+                type="button"
+                class="h-7 border border-gray-300 bg-white px-2.5 text-[11px] font-medium text-gray-600 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
+                :disabled="currentPage === 1"
+                @click="goToPage(currentPage - 1)"
+              >
+                이전
+              </button>
+
+              <!-- 페이지 번호 -->
+              <button
+                v-for="(p, idx) in pageNumbers"
+                :key="idx"
+                type="button"
+                :disabled="p === '...'"
+                :class="[
+                  'h-7 min-w-[28px] px-2 text-[11px] font-medium transition',
+                  p === currentPage
+                    ? 'border border-[#004D3C] bg-[#004D3C] text-white'
+                    : p === '...'
+                      ? 'cursor-default text-gray-400'
+                      : 'border border-gray-300 bg-white text-gray-600 hover:bg-gray-100'
+                ]"
+                @click="goToPage(p)"
+              >
+                {{ p }}
+              </button>
+
+              <!-- 다음 -->
+              <button
+                type="button"
+                class="h-7 border border-gray-300 bg-white px-2.5 text-[11px] font-medium text-gray-600 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
+                :disabled="currentPage === totalPages"
+                @click="goToPage(currentPage + 1)"
+              >
+                다음
+              </button>
+            </div>
+          </div>
+        </section>
+      </template>
+    </div>
+  </AppLayout>
+</template>

--- a/src/views/hq/esg/EsgDashBoardView.vue
+++ b/src/views/hq/esg/EsgDashBoardView.vue
@@ -24,7 +24,7 @@ import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
 import { useEsgStore } from '@/stores/esg.js'
 import { useEmissionQuotaStore } from '@/stores/emissionQuota.js'
-import { carbonPriceApi } from '@/api/hq/esg.js'
+import { carbonPriceApi, circularRevenueApi } from '@/api/hq/esg.js'
 import { extractErrorMessage } from '@/api/axios.js'
 const router = useRouter()
 const auth = useAuthStore()
@@ -35,7 +35,15 @@ const activeSideMenu = ref('탄소배출권 관리')
 const esgSideMenus = (hqMenus.find((menu) => menu.label === 'ESG 대시보드')?.children ?? [])
 
 const esgStore = useEsgStore()
-const { totalPoints, kauPrice, kauPriceUpdatedAt, kauPriceLoading } = storeToRefs(esgStore)
+const {
+  totalPoints,
+  totalSalesKg,
+  totalCarbonReductionTon,
+  carbonReductionDeltaPct,
+  kauPrice,
+  kauPriceUpdatedAt,
+  kauPriceLoading,
+} = storeToRefs(esgStore)
 
 // ─────────── 배출권(KAU25) 실시간 시세 — BE 연동 ───────────
 const carbonLatest = ref(null)        // { pricePerTon, symbol, basDt, fltRt, fallback }
@@ -53,6 +61,10 @@ async function loadCarbonPrice() {
     ])
     carbonLatest.value = latestRes
     carbonTrend.value = trendRes ?? []
+    // esgStore.kauPrice 와 동기화 — circularStock 빌더 / 다른 화면이 동일 가격 참조
+    if (latestRes?.pricePerTon != null) {
+      esgStore.setKauPrice(latestRes.pricePerTon)
+    }
   } catch (err) {
     carbonError.value = extractErrorMessage(err, '배출권 시세를 불러오지 못했습니다.')
   } finally {
@@ -135,6 +147,13 @@ const formatBasDtShort = (yyyymmdd) => {
 }
 
 onMounted(loadCarbonPrice)
+
+// 헤더 누적 ESG 점수 — BE sale events + mock donation 으로 자동 계산
+onMounted(() => {
+  esgStore.fetchTotalPoints().catch(err => {
+    console.error('[EsgDashBoardView] fetchTotalPoints failed:', err)
+  })
+})
 
 // 배출 한도 vs 실적 데이터 — emissionQuota 스토어와 연동
 // 대시보드 진입 시 BE 에서 저장된 할당량/월별 실적을 불러와 새로고침/재로그인 후에도 동일하게 유지
@@ -432,14 +451,23 @@ const kauUpdatedLabel = computed(() => {
   )
 })
 
-onMounted(() => {
-  esgStore.fetchKauPrice()
-})
+// 별도 esgStore.fetchKauPrice() 호출은 제거 — loadCarbonPrice 가 BE 호출 후
+// esgStore.setKauPrice 로 동기화하므로 중복 API 호출을 피함
 
-const kpiMetrics = [
-  { label: '탄소 배출 절감', value: '2,847', unit: 'kg CO₂', sub: '전월 대비 +12%', icon: TrendingDown, valueCls: 'text-emerald-700', iconBg: 'bg-emerald-50', iconCls: 'text-emerald-600' },
-  { label: '순환재고 판매량', value: '1,240', unit: 'kg', sub: '불법폐기 0건', icon: ShieldCheck, valueCls: 'text-teal-700', iconBg: 'bg-teal-50', iconCls: 'text-teal-600' },
-]
+// KPI 2카드 — BE 데이터 기반 (esgStore.fetchTotalPoints 에서 계산)
+//   탄소 배출 절감 = SUM(weight × material_factor) / 1000 [tCO₂]
+//   순환재고 판매량 = SUM(weight) [kg]
+//   전월 대비 변동률 = (이번달 - 전월) / 전월 × 100
+const carbonDeltaLabel = computed(() => {
+  const pct = carbonReductionDeltaPct.value
+  if (pct === 0) return '전월 대비 변동 없음'
+  const sign = pct > 0 ? '+' : ''
+  return `전월 대비 ${sign}${pct}%`
+})
+const kpiMetrics = computed(() => [
+  { label: '탄소 배출 절감',   value: (totalCarbonReductionTon.value ?? 0).toFixed(2),    unit: 'tCO₂', sub: carbonDeltaLabel.value, icon: TrendingDown, valueCls: 'text-emerald-700', iconBg: 'bg-emerald-50', iconCls: 'text-emerald-600' },
+  { label: '순환재고 판매량', value: (totalSalesKg.value ?? 0).toLocaleString('ko-KR'), unit: 'kg',   sub: '불법폐기 0건',         icon: ShieldCheck,  valueCls: 'text-teal-700',     iconBg: 'bg-teal-50',     iconCls: 'text-teal-600' },
+])
 
 // ─────────── 거래 가능 탄소 배출권 (자산 포트폴리오 스타일) ───────────
 //   잔여 한도 × KAU25 시세 = 보유 자산 가치
@@ -448,9 +476,15 @@ const carbonAssetValue = computed(() =>
   Math.round(emissionCompliance.value.expectedSurplus * (kauPrice.value || 0)),
 )
 
-// 변동률 (1월 평균 대비) — mock baseline ₩42,000,000
+// 변동률 (7거래일 첫째 날 대비) — carbonTrend 의 첫째 날 종가를 baseline 으로 동적 산정
 const carbonAssetTrend = computed(() => {
-  const baseline = 42_000_000
+  const surplus = emissionCompliance.value.expectedSurplus
+  const trend = carbonTrend.value ?? []
+  if (trend.length === 0) {
+    return { up: false, down: false, label: '시세 미조회', detail: '기준값 없음' }
+  }
+  const firstPrice = Number(trend[0]?.pricePerTon) || 0
+  const baseline = Math.round(surplus * firstPrice)
   const current = carbonAssetValue.value
   if (baseline === 0) return { up: false, down: false, label: '0%', detail: '기준값 없음' }
   const diff = current - baseline
@@ -459,26 +493,36 @@ const carbonAssetTrend = computed(() => {
   const formattedDiff = (diff >= 0 ? '+' : '−') + '₩' + Math.abs(diff).toLocaleString('ko-KR')
   return {
     up: diff > 0, down: diff < 0,
-    label: `${formattedPct} (vs 1월 평균)`,
-    detail: `${formattedDiff} · 잔여 ${emissionCompliance.value.expectedSurplus.toLocaleString()} tCO₂ × ₩${(kauPrice.value || 0).toLocaleString()}`,
+    label: `${formattedPct} (vs 7거래일 첫날)`,
+    detail: `${formattedDiff} · 잔여 ${surplus.toLocaleString()} tCO₂ × ₩${(kauPrice.value || 0).toLocaleString()}`,
   }
 })
 
-// 월별 자산 가치 추이 (mock — 잔여량은 동일, 시세 변동 반영)
-const CARBON_ASSET_MONTHLY_PRICE = [8200, 8400, 8950, 9100, 9620, 9840, 9700, 9550, 9420, 9180, 8950, 8800]
-const carbonAssetMonthlyData = computed(() => ({
-  labels: ['1월','2월','3월','4월','5월','6월','7월','8월','9월','10월','11월','12월'],
-  datasets: [{
-    label: '자산 가치',
-    data: CARBON_ASSET_MONTHLY_PRICE.map(p =>
-      Math.round(emissionCompliance.value.expectedSurplus * p),
-    ),
-    backgroundColor: 'rgba(245, 158, 11, 0.85)',
-    borderColor: '#d97706',
-    borderWidth: 1.5, borderRadius: 3,
-    maxBarThickness: 18, categoryPercentage: 0.7, barPercentage: 0.8,
-  }],
-}))
+// 일별 자산 가치 추이 — 잔여 한도(현재) × 일별 KAU25 종가 (carbonTrend, BE 연동)
+const carbonAssetMonthlyData = computed(() => {
+  const trend = carbonTrend.value ?? []
+  const surplus = emissionCompliance.value.expectedSurplus
+  return {
+    labels: trend.map(d => {
+      const s = d?.basDt ?? ''
+      return s.length === 8 ? `${s.slice(4,6)}/${s.slice(6,8)}` : s
+    }),
+    datasets: [{
+      label: '자산 가치',
+      data: trend.map(d => Math.round(surplus * (Number(d?.pricePerTon) || 0))),
+      borderColor: '#d97706',
+      backgroundColor: 'rgba(245, 158, 11, 0.12)',
+      pointBackgroundColor: '#d97706',
+      pointBorderColor: '#fff',
+      pointBorderWidth: 1.5,
+      pointRadius: 3.5,
+      pointHoverRadius: 5,
+      borderWidth: 2,
+      tension: 0.3,
+      fill: true,
+    }],
+  }
+})
 const carbonAssetMonthlyOptions = {
   responsive: true, maintainAspectRatio: false,
   layout: { padding: { left: 0, right: 4, top: 4, bottom: 4 } },
@@ -511,39 +555,62 @@ const carbonAssetMonthlyOptions = {
   },
 }
 
-// ─────────── 순환 재고 판매 수익 (mock) ───────────
-//   향후 BE 연동: GET /api/hq/circular-stock/sales/revenue?period=YEAR|Q|M
-//   계산: SUM(sale_price) by month/buyer
-const revenuePeriod = ref('YEAR')   // M | Q | YEAR
+// ─────────── 순환 재고 판매 수익 — BE 연동 ───────────
+//   GET /api/hq/esg/circular-revenue?year=YYYY
+//   응답: { year, monthly:[{month,revenue,count}], totalRevenue, totalCount, monthsWithData, avgMonthly }
+const revenuePeriod = ref('YEAR')   // M | Q | YEAR (토글 — totalRevenue 계산 범위만 영향)
+const revenueData = ref(null)        // BE 응답 원본
+const revenueLoading = ref(false)
+const revenueError = ref('')
 
-// 월별 수익 mock (1~12월, 단위 원)
-const REVENUE_MONTHLY = [376_000, 800_000, 630_000, 2_010_000, 0, 0, 0, 0, 0, 0, 0, 0]
-// 월별 거래 건수 mock (1~12월)
-const REVENUE_COUNT_MONTHLY = [1, 2, 2, 4, 0, 0, 0, 0, 0, 0, 0, 0]
+async function loadRevenue() {
+  revenueLoading.value = true
+  revenueError.value = ''
+  try {
+    const year = new Date().getFullYear()
+    revenueData.value = await circularRevenueApi.get(year)
+  } catch (err) {
+    revenueError.value = extractErrorMessage(err, '순환재고 판매 수익을 불러오지 못했습니다.')
+  } finally {
+    revenueLoading.value = false
+  }
+}
+onMounted(loadRevenue)
 
+// 12개월 수익 배열 — BE 응답 기반 (없으면 0으로 패딩)
+const revenueMonthly = computed(() => {
+  const monthly = revenueData.value?.monthly ?? []
+  const arr = Array(12).fill(0)
+  for (const p of monthly) {
+    const m = Number(p?.month) || 0
+    if (m >= 1 && m <= 12) arr[m - 1] = Number(p?.revenue) || 0
+  }
+  return arr
+})
+
+// 토글 (월/분기/연) 에 따른 합계 — BE 의 12개월 데이터를 FE 에서 슬라이싱
 const totalRevenue = computed(() => {
+  const arr = revenueMonthly.value
   const now = new Date()
   const m = now.getMonth()
-  if (revenuePeriod.value === 'M') return REVENUE_MONTHLY[m] ?? 0
+  if (revenuePeriod.value === 'M') return arr[m] ?? 0
   if (revenuePeriod.value === 'Q') {
     const start = Math.max(0, m - 2)
-    return REVENUE_MONTHLY.slice(start, m + 1).reduce((s, v) => s + v, 0)
+    return arr.slice(start, m + 1).reduce((s, v) => s + v, 0)
   }
-  return REVENUE_MONTHLY.reduce((s, v) => s + v, 0)
+  return revenueData.value?.totalRevenue ?? arr.reduce((s, v) => s + v, 0)
 })
 
-const revenueStats = computed(() => {
-  const monthsWithData = REVENUE_MONTHLY.filter(v => v > 0).length || 1
-  const avgMonthly = Math.round(REVENUE_MONTHLY.reduce((s, v) => s + v, 0) / monthsWithData)
-  const count = REVENUE_COUNT_MONTHLY.reduce((s, v) => s + v, 0)
-  return { avgMonthly, count }
-})
+const revenueStats = computed(() => ({
+  avgMonthly: Number(revenueData.value?.avgMonthly) || 0,
+  count: Number(revenueData.value?.totalCount) || 0,
+}))
 
 const revenueChartData = computed(() => ({
   labels: ['1월','2월','3월','4월','5월','6월','7월','8월','9월','10월','11월','12월'],
   datasets: [{
     label: '월별 수익',
-    data: REVENUE_MONTHLY,
+    data: revenueMonthly.value,
     backgroundColor: 'rgba(16, 185, 129, 0.85)',
     borderColor: '#059669',
     borderWidth: 1.5, borderRadius: 3,
@@ -581,12 +648,6 @@ const revenueChartOptions = {
     },
   },
 }
-
-const topBuyers = computed(() => {
-  const sorted = [...REVENUE_BY_BUYER].sort((a, b) => b.amount - a.amount)
-  const total = sorted.reduce((s, b) => s + b.amount, 0) || 1
-  return sorted.map(b => ({ ...b, share: ((b.amount / total) * 100).toFixed(1) }))
-})
 
 const dateLabel = computed(() =>
   new Intl.DateTimeFormat('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' }).format(new Date()),
@@ -649,7 +710,7 @@ const dateLabel = computed(() =>
         </article>
       </section>
 
-      <!-- 배출 한도 vs 실적 + 배출권 시장 가치 환산 -->
+      <!-- 배출 한도 vs 실적 + 거래 가능 탄소 배출권 -->
       <section class="grid gap-3 xl:grid-cols-2">
 
         <!-- 탄소중립 관리 (emissionQuota 스토어 연동) -->
@@ -715,7 +776,8 @@ const dateLabel = computed(() =>
               <div class="border border-emerald-200 bg-emerald-50 px-2 py-2">
                 <p class="text-[10px] text-emerald-700">절감한 탄소 배출량</p>
                 <div class="mt-0.5 flex items-baseline gap-0.5">
-                  <span class="text-[14px] font-bold text-emerald-700">{{ emissionCompliance.ytdAvoided.toLocaleString() }}</span>
+                  <!-- KPI "탄소 배출 절감" 카드와 동일한 값 (esgStore.totalCarbonReductionKg / 1000) -->
+                  <span class="text-[14px] font-bold text-emerald-700">{{ totalCarbonReductionTon.toFixed(2) }}</span>
                   <span class="text-[9px] text-emerald-600">tCO₂</span>
                 </div>
               </div>
@@ -736,12 +798,117 @@ const dateLabel = computed(() =>
           </div>
         </article>
 
-        <!-- 배출권 시장 가치 환산 (BE 실시간 KAU25 연동) -->
+        <!-- 거래 가능 탄소 배출권 (자산 포트폴리오 스타일) -->
+        <article class="flex min-w-0 flex-col border border-gray-300 bg-white shadow-sm">
+          <div class="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 border-b border-gray-200 px-3 py-2.5">
+            <h3 class="inline-flex flex-wrap items-center gap-x-2 gap-y-0.5 text-sm font-medium text-gray-800">
+              <span class="inline-flex items-center gap-2">
+                <Coins :size="15" class="text-amber-600" />
+                거래 가능 탄소 배출권
+                <span class="text-[10px] font-normal text-gray-400">자산 포트폴리오</span>
+              </span>
+              <span class="text-[10.5px] font-normal text-amber-700/80">
+                ⓘ 잔여 한도 × KAU25 시세 · KRX 매도 가능 (평일 10:00~12:00)
+              </span>
+            </h3>
+            <span class="shrink-0 text-[10px] text-gray-400">기준: {{ dateLabel }}</span>
+          </div>
+
+          <!-- 보유 자산 가치 (메인 메트릭) -->
+          <div class="border-b border-amber-100 bg-gradient-to-br from-amber-50 to-yellow-50 px-3 py-3">
+            <p class="text-[10px] font-medium text-amber-700/80">보유 자산 가치</p>
+            <div class="mt-1 flex items-baseline gap-1.5">
+              <span class="text-[24px] font-black text-amber-700">
+                ₩{{ carbonAssetValue.toLocaleString('ko-KR') }}
+              </span>
+              <span
+                class="text-[11px] font-bold"
+                :class="carbonAssetTrend.up ? 'text-red-600' : carbonAssetTrend.down ? 'text-blue-600' : 'text-gray-500'"
+              >
+                {{ carbonAssetTrend.up ? '↗' : carbonAssetTrend.down ? '↘' : '·' }}
+                {{ carbonAssetTrend.label }}
+              </span>
+            </div>
+            <p class="mt-1 text-[10px] text-amber-700/70">
+              {{ carbonAssetTrend.detail }}
+            </p>
+          </div>
+
+          <!-- 월별 가치 추이 (막대 차트) -->
+          <div class="flex min-w-0 flex-1 flex-col px-3 py-2.5">
+            <p class="mb-1.5 text-[10px] font-medium uppercase tracking-widest text-gray-500">최근 7거래일 자산 가치 추이</p>
+            <div class="relative w-full flex-1" style="min-height: 220px;">
+              <LineChart :data="carbonAssetMonthlyData" :options="carbonAssetMonthlyOptions" fill-height />
+            </div>
+          </div>
+        </article>
+      </section>
+
+      <!-- 순환 재고 판매 수익 + 탄소 배출권 시장 -->
+      <section class="grid gap-3 xl:grid-cols-2">
+
+        <!-- 순환 재고 판매 수익 -->
+        <article class="flex min-w-0 flex-col border border-gray-300 bg-white shadow-sm">
+          <div class="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 border-b border-gray-200 px-3 py-2.5">
+            <h3 class="inline-flex flex-wrap items-center gap-x-2 gap-y-0.5 text-sm font-medium text-gray-800">
+              <span class="inline-flex items-center gap-2">
+                <Wallet :size="15" class="text-emerald-600" />
+                순환 재고 판매 수익
+              </span>
+              <span class="text-[10.5px] font-normal text-emerald-700/80">
+                ⓘ 판매 단가 × 무게 합산 · 월말 마감 후 자동 갱신
+              </span>
+            </h3>
+            <div class="inline-flex shrink-0 items-center gap-0.5 border border-gray-300 bg-white p-0.5">
+              <button
+                v-for="p in [{v:'M',l:'월'},{v:'Q',l:'분기'},{v:'YEAR',l:'년'}]"
+                :key="p.v"
+                type="button"
+                class="px-2 py-0.5 text-[10px] font-medium transition"
+                :class="revenuePeriod === p.v ? 'bg-emerald-700 text-white' : 'text-gray-600 hover:bg-gray-50'"
+                @click="revenuePeriod = p.v"
+              >{{ p.l }}</button>
+            </div>
+          </div>
+
+          <!-- 월별 판매 수익 (메인) -->
+          <div class="border-b border-emerald-100 bg-gradient-to-br from-emerald-50 to-white px-3 py-3">
+            <p class="text-[10px] font-medium text-emerald-700/80">
+              월별 판매 수익
+            </p>
+            <div class="mt-1 flex items-baseline gap-1.5">
+              <span class="text-[24px] font-black text-emerald-700">
+                ₩{{ totalRevenue.toLocaleString('ko-KR') }}
+              </span>
+            </div>
+            <p class="mt-1 text-[10px] text-emerald-700/70">
+              거래 {{ revenueStats.count }}건 · 월 평균 ₩{{ revenueStats.avgMonthly.toLocaleString() }}
+              <span class="ml-1 text-gray-500">(데이터 있는 월 기준)</span>
+            </p>
+          </div>
+
+          <!-- 월별 수익 추이 -->
+          <div class="flex min-w-0 flex-1 flex-col px-3 py-2.5">
+            <p class="mb-1.5 text-[10px] font-medium uppercase tracking-widest text-gray-500">월별 수익 추이 (12개월)</p>
+            <div class="relative w-full flex-1" style="min-height: 220px;">
+              <BarChart :data="revenueChartData" :options="revenueChartOptions" fill-height />
+            </div>
+          </div>
+        </article>
+
+        <!-- 탄소 배출권 시장 (BE 실시간 KAU25 연동) -->
         <article class="flex flex-col border border-gray-300 bg-white shadow-sm">
           <div class="flex items-center justify-between gap-2 border-b border-gray-200 px-3 py-2.5">
             <h3 class="inline-flex items-center gap-2 text-sm font-medium text-gray-800">
               <Coins :size="15" class="text-amber-600" />
-              배출권 시장 가치 환산
+              탄소 배출권 시장
+              <button
+                type="button"
+                class="ml-1 inline-flex items-center gap-0.5 text-[10px] font-normal text-amber-700 transition-colors hover:text-amber-800 hover:underline"
+                @click="router.push('/hq/esg/carbon-price')"
+              >
+                자세히 보기 →
+              </button>
             </h3>
             <div class="flex items-center gap-1.5">
               <span v-if="carbonLatest?.basDt" class="text-[9px] text-gray-400">
@@ -811,104 +978,6 @@ const dateLabel = computed(() =>
               한국거래소 배출권 시장은 <strong>평일 오전 10:00~12:00</strong>만 운영됩니다.
               <strong>주말·공휴일</strong>은 휴장이라 시세가 형성되지 않아 그래프와 표에서 제외됩니다.
             </p>
-          </div>
-        </article>
-      </section>
-
-      <!-- 거래 가능 탄소 배출권 + 활동 내역 -->
-      <section class="grid gap-3 xl:grid-cols-2">
-
-        <!-- 거래 가능 탄소 배출권 (자산 포트폴리오 스타일) -->
-        <article class="flex min-w-0 flex-col border border-gray-300 bg-white shadow-sm">
-          <div class="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 border-b border-gray-200 px-3 py-2.5">
-            <h3 class="inline-flex flex-wrap items-center gap-x-2 gap-y-0.5 text-sm font-medium text-gray-800">
-              <span class="inline-flex items-center gap-2">
-                <Coins :size="15" class="text-amber-600" />
-                거래 가능 탄소 배출권
-                <span class="text-[10px] font-normal text-gray-400">자산 포트폴리오</span>
-              </span>
-              <span class="text-[10.5px] font-normal text-amber-700/80">
-                ⓘ 잔여 한도 × KAU25 시세 · KRX 매도 가능 (평일 10:00~12:00)
-              </span>
-            </h3>
-            <span class="shrink-0 text-[10px] text-gray-400">기준: {{ dateLabel }}</span>
-          </div>
-
-          <!-- 보유 자산 가치 (메인 메트릭) -->
-          <div class="border-b border-amber-100 bg-gradient-to-br from-amber-50 to-yellow-50 px-3 py-3">
-            <p class="text-[10px] font-medium text-amber-700/80">보유 자산 가치</p>
-            <div class="mt-1 flex items-baseline gap-1.5">
-              <span class="text-[24px] font-black text-amber-700">
-                ₩{{ carbonAssetValue.toLocaleString('ko-KR') }}
-              </span>
-              <span
-                class="text-[11px] font-bold"
-                :class="carbonAssetTrend.up ? 'text-red-600' : carbonAssetTrend.down ? 'text-blue-600' : 'text-gray-500'"
-              >
-                {{ carbonAssetTrend.up ? '↗' : carbonAssetTrend.down ? '↘' : '·' }}
-                {{ carbonAssetTrend.label }}
-              </span>
-            </div>
-            <p class="mt-1 text-[10px] text-amber-700/70">
-              {{ carbonAssetTrend.detail }}
-            </p>
-          </div>
-
-          <!-- 월별 가치 추이 (막대 차트) -->
-          <div class="flex min-w-0 flex-1 flex-col px-3 py-2.5">
-            <p class="mb-1.5 text-[10px] font-medium uppercase tracking-widest text-gray-500">월별 자산 가치 추이</p>
-            <div class="relative w-full" style="height: 220px;">
-              <BarChart :data="carbonAssetMonthlyData" :options="carbonAssetMonthlyOptions" />
-            </div>
-          </div>
-        </article>
-
-        <!-- 순환 재고 판매 수익 -->
-        <article class="flex min-w-0 flex-col border border-gray-300 bg-white shadow-sm">
-          <div class="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 border-b border-gray-200 px-3 py-2.5">
-            <h3 class="inline-flex flex-wrap items-center gap-x-2 gap-y-0.5 text-sm font-medium text-gray-800">
-              <span class="inline-flex items-center gap-2">
-                <Wallet :size="15" class="text-emerald-600" />
-                순환 재고 판매 수익
-              </span>
-              <span class="text-[10.5px] font-normal text-emerald-700/80">
-                ⓘ 판매 단가 × 무게 합산 · 월말 마감 후 자동 갱신
-              </span>
-            </h3>
-            <div class="inline-flex shrink-0 items-center gap-0.5 border border-gray-300 bg-white p-0.5">
-              <button
-                v-for="p in [{v:'M',l:'월'},{v:'Q',l:'분기'},{v:'YEAR',l:'년'}]"
-                :key="p.v"
-                type="button"
-                class="px-2 py-0.5 text-[10px] font-medium transition"
-                :class="revenuePeriod === p.v ? 'bg-emerald-700 text-white' : 'text-gray-600 hover:bg-gray-50'"
-                @click="revenuePeriod = p.v"
-              >{{ p.l }}</button>
-            </div>
-          </div>
-
-          <!-- 누적 수익 (메인) -->
-          <div class="border-b border-emerald-100 bg-gradient-to-br from-emerald-50 to-white px-3 py-3">
-            <p class="text-[10px] font-medium text-emerald-700/80">
-              {{ revenuePeriod === 'M' ? '이번 달' : revenuePeriod === 'Q' ? '최근 3개월' : '올해 (YTD)' }} 누적 수익
-            </p>
-            <div class="mt-1 flex items-baseline gap-1.5">
-              <span class="text-[24px] font-black text-emerald-700">
-                ₩{{ totalRevenue.toLocaleString('ko-KR') }}
-              </span>
-            </div>
-            <p class="mt-1 text-[10px] text-emerald-700/70">
-              거래 {{ revenueStats.count }}건 · 월 평균 ₩{{ revenueStats.avgMonthly.toLocaleString() }}
-              <span class="ml-1 text-gray-500">(데이터 있는 월 기준)</span>
-            </p>
-          </div>
-
-          <!-- 월별 수익 추이 -->
-          <div class="flex min-w-0 flex-1 flex-col px-3 py-2.5">
-            <p class="mb-1.5 text-[10px] font-medium uppercase tracking-widest text-gray-500">월별 수익 추이 (12개월)</p>
-            <div class="relative w-full" style="height: 220px;">
-              <BarChart :data="revenueChartData" :options="revenueChartOptions" />
-            </div>
           </div>
         </article>
       </section>

--- a/src/views/hq/esg/EsgTreeScoreView.vue
+++ b/src/views/hq/esg/EsgTreeScoreView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import {
   ArrowLeft, RefreshCw, Leaf, Recycle, ShieldCheck, Heart,
@@ -12,6 +12,9 @@ import DoughnutChart from '@/components/common/charts/DoughnutChart.vue'
 import EsgTreeWidget from '@/components/common/EsgTreeWidget.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
+import { useEsgStore } from '@/stores/esg.js'
+import { scoreEventsApi } from '@/api/hq/esg.js'
+import { extractErrorMessage } from '@/api/axios.js'
 const router = useRouter()
 const auth = useAuthStore()
 const topMenus = computed(() => roleMenus.hq ?? [])
@@ -118,29 +121,57 @@ const MATERIAL_GROUP_LABEL = {
   BLEND:          '혼방',
 }
 
-// ─────────── Mock 이벤트 데이터 (BE 연동 시 GET /api/hq/esg/score/events 로 교체) ───────────
-const events = ref([
-  // 4월 판매 4건
-  { id: 1,  date: '2026-04-27', type: 'sale',     buyer: '신규 D사', material: 'POLYESTER', weightKg: 500, isNewBuyer: true,  isLocalPartner: false, donationType: null,        method: 'RECYCLE' },
-  { id: 2,  date: '2026-04-20', type: 'sale',     buyer: '마을협동조합', material: 'BLEND',     weightKg: 300, isNewBuyer: false, isLocalPartner: true,  donationType: null,        method: 'UPCYCLE' },
-  { id: 3,  date: '2026-04-15', type: 'sale',     buyer: 'B사',     material: 'COTTON',    weightKg: 250, isNewBuyer: false, isLocalPartner: false, donationType: null,        method: 'RESALE' },
-  { id: 4,  date: '2026-04-10', type: 'sale',     buyer: 'A사',     material: 'COTTON',    weightKg: 100, isNewBuyer: false, isLocalPartner: false, donationType: null,        method: 'RESALE' },
+// ─────────── 이벤트 데이터 ───────────
+//   sale: BE 연동 (GET /api/hq/esg/score-events)
+//   donation: BE 도메인 미구현 → mock 유지 (향후 BE 추가 시 같은 형태로 머지)
+const MOCK_DONATION_EVENTS = [
   // 4월 기부 4건
-  { id: 5,  date: '2026-04-28', type: 'donation', buyer: '재해구호본부',  material: 'COTTON',    weightKg:  95, isNewBuyer: false, isLocalPartner: false, donationType: 'DISASTER',  method: null },
-  { id: 6,  date: '2026-04-22', type: 'donation', buyer: '사회복지시설',  material: 'COTTON',    weightKg:  80, isNewBuyer: false, isLocalPartner: false, donationType: 'VULNERABLE',method: null },
-  { id: 7,  date: '2026-04-14', type: 'donation', buyer: '해외구호단체',  material: 'POLYESTER', weightKg:  50, isNewBuyer: false, isLocalPartner: false, donationType: 'OVERSEAS',  method: null },
-  { id: 8,  date: '2026-04-05', type: 'donation', buyer: '직업학교',      material: 'BLEND',     weightKg:  30, isNewBuyer: false, isLocalPartner: false, donationType: 'EDU',       method: null },
-  // 3월 mock (월별 추이용)
-  { id: 9,  date: '2026-03-25', type: 'sale',     buyer: 'B사',     material: 'WOOL',      weightKg: 150, isNewBuyer: false, isLocalPartner: false, donationType: null,        method: 'UPCYCLE' },
-  { id: 10, date: '2026-03-18', type: 'sale',     buyer: 'C사',     material: 'NYLON',     weightKg: 200, isNewBuyer: true,  isLocalPartner: false, donationType: null,        method: 'RECYCLE' },
-  { id: 11, date: '2026-03-12', type: 'donation', buyer: '재해구호본부',  material: 'COTTON',    weightKg:  60, isNewBuyer: false, isLocalPartner: false, donationType: 'DISASTER',  method: null },
-  // 2월 mock
-  { id: 12, date: '2026-02-28', type: 'sale',     buyer: 'A사',     material: 'COTTON',    weightKg: 180, isNewBuyer: false, isLocalPartner: false, donationType: null,        method: 'RESALE' },
-  { id: 13, date: '2026-02-15', type: 'sale',     buyer: '마을협동조합', material: 'BLEND',     weightKg: 220, isNewBuyer: false, isLocalPartner: true,  donationType: null,        method: 'UPCYCLE' },
-  // 1월 mock
-  { id: 14, date: '2026-01-22', type: 'sale',     buyer: 'A사',     material: 'COTTON',    weightKg:   8, isNewBuyer: false, isLocalPartner: false, donationType: null,        method: 'RESALE' },  // 최소 미달
-  { id: 15, date: '2026-01-12', type: 'donation', buyer: '직업학교',      material: 'BLEND',     weightKg:  40, isNewBuyer: false, isLocalPartner: false, donationType: 'EDU',       method: null },
-])
+  { id: 'd-1', date: '2026-04-28', type: 'donation', buyer: '재해구호본부',  material: 'COTTON',    weightKg:  95, isNewBuyer: false, isLocalPartner: false, donationType: 'DISASTER',  method: null },
+  { id: 'd-2', date: '2026-04-22', type: 'donation', buyer: '사회복지시설',  material: 'COTTON',    weightKg:  80, isNewBuyer: false, isLocalPartner: false, donationType: 'VULNERABLE',method: null },
+  { id: 'd-3', date: '2026-04-14', type: 'donation', buyer: '해외구호단체',  material: 'POLYESTER', weightKg:  50, isNewBuyer: false, isLocalPartner: false, donationType: 'OVERSEAS',  method: null },
+  { id: 'd-4', date: '2026-04-05', type: 'donation', buyer: '직업학교',      material: 'BLEND',     weightKg:  30, isNewBuyer: false, isLocalPartner: false, donationType: 'EDU',       method: null },
+  // 3월 기부 1건
+  { id: 'd-5', date: '2026-03-12', type: 'donation', buyer: '재해구호본부',  material: 'COTTON',    weightKg:  60, isNewBuyer: false, isLocalPartner: false, donationType: 'DISASTER',  method: null },
+  // 1월 기부 1건
+  { id: 'd-6', date: '2026-01-12', type: 'donation', buyer: '직업학교',      material: 'BLEND',     weightKg:  40, isNewBuyer: false, isLocalPartner: false, donationType: 'EDU',       method: null },
+]
+
+const saleEvents = ref([])
+const loadEventsError = ref('')
+
+/** BE 응답 sale events 를 FE event 형태로 정규화
+ *  - Jackson+Lombok 직렬화 quirk: isNewBuyer → "newBuyer" 로 직렬화됨
+ *  - 양쪽 필드명 모두 수용해서 BE/FE 직렬화 컨벤션 변경에 견고
+ */
+function normalizeSaleEvent(e) {
+  return {
+    id: e.id,
+    date: e.date,
+    type: 'sale',
+    buyer: e.buyer,
+    material: e.material,
+    weightKg: e.weightKg,
+    isNewBuyer: e.isNewBuyer ?? e.newBuyer ?? false,
+    isLocalPartner: e.isLocalPartner ?? e.localPartner ?? false,
+    donationType: null,
+    method: null,
+  }
+}
+
+async function loadEvents(year) {
+  loadEventsError.value = ''
+  try {
+    const targetYear = year ?? new Date().getFullYear()
+    const res = await scoreEventsApi.get(targetYear)
+    saleEvents.value = (res?.events ?? []).map(normalizeSaleEvent)
+  } catch (err) {
+    loadEventsError.value = extractErrorMessage(err, '점수 이벤트를 불러오지 못했습니다.')
+    saleEvents.value = []
+  }
+}
+
+// sale (BE) + donation (mock) 머지 → 기존 events 변수와 동일 인터페이스
+const events = computed(() => [...saleEvents.value, ...MOCK_DONATION_EVENTS])
 
 // ─────────── 점수 계산 함수 (이벤트 1건 → 분해 점수) ───────────
 //   탄소 점수 = 무게(kg) × 소재 계수 × 0.5
@@ -229,6 +260,10 @@ const totalScore = computed(() =>
   Object.values(categoryTotals.value).reduce((a, b) => a + b, 0),
 )
 
+// ESG 대시보드 헤더와 누적 점수 동기화 — totalScore 변할 때마다 esgStore 갱신
+const esgStore = useEsgStore()
+watch(totalScore, (n) => esgStore.setTotalPoints(n), { immediate: true })
+
 const scoreCategories = computed(() => {
   const t = categoryTotals.value
   const total = totalScore.value || 1
@@ -258,6 +293,9 @@ const stats = computed(() => {
     avgScore: validEvents.length > 0 ? Math.round(totalScore.value / validEvents.length) : 0,
   }
 })
+
+// ESG 대시보드 KPI "순환재고 판매량" 카드와 동기화
+watch(() => stats.value.totalKg, (n) => esgStore.setTotalSalesKg(n), { immediate: true })
 
 // ─────────── 월별 추이 차트 ───────────
 const monthLabels = ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월', '9월', '10월', '11월', '12월']
@@ -325,14 +363,48 @@ const categoryDoughnutOptions = {
 const sortedEvents = computed(() =>
   [...logEvents.value].sort((a, b) => new Date(b.date) - new Date(a.date)),
 )
-const pageSize = ref(8)
+const pageSize = ref(20)
 const page = ref(1)
 const totalPages = computed(() => Math.max(1, Math.ceil(sortedEvents.value.length / pageSize.value)))
 const pagedEvents = computed(() => {
   const start = (page.value - 1) * pageSize.value
   return sortedEvents.value.slice(start, start + pageSize.value)
 })
-function changePage(p) { if (p >= 1 && p <= totalPages.value) page.value = p }
+
+/**
+ * 화살표 페이지네이션 — 현재 페이지를 중심으로 최대 5개 번호만 표시.
+ *  - totalPages ≤ 5: 전체 표시
+ *  - cur ≤ 3: [1, 2, 3, 4, 5]
+ *  - cur ≥ total-2: 마지막 5개
+ *  - 그 외: [cur-2, cur-1, cur, cur+1, cur+2]
+ */
+const PAGE_WINDOW = 5
+const pageNumbers = computed(() => {
+  const total = totalPages.value
+  const cur = page.value
+  if (total <= PAGE_WINDOW) {
+    return Array.from({ length: total }, (_, i) => i + 1)
+  }
+  let start
+  if (cur <= 3) {
+    start = 1
+  } else if (cur >= total - 2) {
+    start = total - PAGE_WINDOW + 1
+  } else {
+    start = cur - 2
+  }
+  return Array.from({ length: PAGE_WINDOW }, (_, i) => start + i)
+})
+
+const PAGE_JUMP = 5
+function changePage(p) {
+  const clamped = Math.max(1, Math.min(totalPages.value, p))
+  page.value = clamped
+}
+function goJumpBack()    { changePage(page.value - PAGE_JUMP) }
+function goPrev()        { changePage(page.value - 1) }
+function goNext()        { changePage(page.value + 1) }
+function goJumpForward() { changePage(page.value + PAGE_JUMP) }
 
 
 // ─────────── 포맷터 ───────────
@@ -341,11 +413,15 @@ const formatDate = (s) => s.slice(5).replace('-', '.')
 const typeLabel = (t) => t === 'sale' ? '판매' : '기부'
 const typeCls = (t) => t === 'sale' ? 'bg-emerald-50 text-emerald-700 border-emerald-200' : 'bg-pink-50 text-pink-700 border-pink-200'
 
-// 페이지 로드
+// 페이지 로드 — BE sale events 호출
 const loading = ref(false)
 async function reload() {
   loading.value = true
-  try { await new Promise(r => setTimeout(r, 100)) } finally { loading.value = false }
+  try {
+    await loadEvents()
+  } finally {
+    loading.value = false
+  }
 }
 onMounted(reload)
 </script>
@@ -431,8 +507,10 @@ onMounted(reload)
         </div>
         <div class="border border-gray-300 bg-white p-4 shadow-sm">
           <p class="text-[10px] font-bold uppercase tracking-widest text-gray-400">총 순환재고 판매량</p>
-          <p class="mt-1 text-[22px] font-black text-gray-800">{{ formatNum(stats.totalKg) }}</p>
-          <p class="mt-0.5 text-[10px] text-gray-500">kg / 평균 {{ formatNum(stats.avgScore) }} pt/건</p>
+          <p class="mt-1 flex items-baseline gap-1">
+            <span class="text-[22px] font-black text-gray-800">{{ formatNum(stats.totalKg) }}</span>
+            <span class="text-[11px] font-medium text-gray-500">kg</span>
+          </p>
         </div>
       </section>
 
@@ -628,8 +706,29 @@ onMounted(reload)
             </template>
           </span>
           <div v-if="totalPages > 1" class="inline-flex items-center gap-1">
+            <!-- 5페이지 이전 -->
             <button
-              v-for="p in totalPages"
+              type="button"
+              :disabled="page === 1"
+              class="h-7 min-w-[28px] border border-gray-300 bg-white px-2 text-[11px] font-medium text-gray-600 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-white"
+              title="5페이지 이전"
+              @click="goJumpBack"
+            >
+              «
+            </button>
+            <!-- 이전 -->
+            <button
+              type="button"
+              :disabled="page === 1"
+              class="h-7 min-w-[28px] border border-gray-300 bg-white px-2 text-[11px] font-medium text-gray-600 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-white"
+              title="이전 페이지"
+              @click="goPrev"
+            >
+              ‹
+            </button>
+            <!-- 페이지 번호 (최대 5개) -->
+            <button
+              v-for="p in pageNumbers"
               :key="p"
               type="button"
               class="h-7 min-w-[28px] border border-gray-300 px-2 text-[11px] font-medium transition"
@@ -637,6 +736,26 @@ onMounted(reload)
               @click="changePage(p)"
             >
               {{ p }}
+            </button>
+            <!-- 다음 -->
+            <button
+              type="button"
+              :disabled="page === totalPages"
+              class="h-7 min-w-[28px] border border-gray-300 bg-white px-2 text-[11px] font-medium text-gray-600 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-white"
+              title="다음 페이지"
+              @click="goNext"
+            >
+              ›
+            </button>
+            <!-- 5페이지 이후 -->
+            <button
+              type="button"
+              :disabled="page === totalPages"
+              class="h-7 min-w-[28px] border border-gray-300 bg-white px-2 text-[11px] font-medium text-gray-600 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-white"
+              title="5페이지 이후"
+              @click="goJumpForward"
+            >
+              »
             </button>
           </div>
         </div>

--- a/src/views/store/dashboard/StoreDashboardView.vue
+++ b/src/views/store/dashboard/StoreDashboardView.vue
@@ -22,8 +22,6 @@ const storeOrdersError = ref(false)
 const inventories = ref([])
 const todaySalesAmount = ref(0)
 const todaySalesCount = ref(0)
-// 최근 7일 일평균 판매 수량 (재고 보유일 계산용)
-const dailyAvgSalesQty = ref(0)
 
 // 발주 현황 (입고 현황 패턴 — 2 카드)
 const storeOrderSummary = ref({ pending: 0, todayRequested: 0 })
@@ -55,31 +53,6 @@ const totalItems = computed(() => safeInventories.value.length)
 const lowStockCount = computed(() => safeInventories.value.filter((row) => Number(row.availableStock ?? 0) > 0 && Number(row.availableStock ?? 0) <= Number(row.safetyStock ?? 0)).length)
 const outOfStockCount = computed(() => safeInventories.value.filter((row) => Number(row.availableStock ?? 0) <= 0).length)
 const riskItems = computed(() => safeInventories.value.filter((row) => Number(row.availableStock ?? 0) <= Number(row.safetyStock ?? 0)))
-
-// 재고 보유일 — 가장 시급한 SKU (Min)
-// 각 SKU별 보유일 = availableStock / (일평균 판매수량 / SKU 수)  [균일 속도 가정]
-const urgentSkuInventory = computed(() => {
-  const list = safeInventories.value
-  const avg = dailyAvgSalesQty.value
-  if (!list.length || !avg || avg <= 0) return null
-  const perSkuVelocity = avg / list.length
-  if (perSkuVelocity <= 0) return null
-  let minDays = Infinity
-  let urgent = null
-  for (const row of list) {
-    const stock = Number(row.availableStock ?? 0)
-    const days = stock / perSkuVelocity
-    if (days < minDays) {
-      minDays = days
-      urgent = row
-    }
-  }
-  if (!urgent || !Number.isFinite(minDays)) return null
-  return {
-    days: Math.round(minDays * 10) / 10,
-    itemName: urgent.itemName || urgent.itemCode || '-',
-  }
-})
 
 // 재고 리스크 미니 리스트 — 품절 우선, 그 다음 부족(부족분 큰 순) — TOP 6
 const topRiskItems = computed(() =>
@@ -225,22 +198,18 @@ async function fetchStats() {
       const dd = String(d.getDate()).padStart(2, '0')
       bucket[key] = { date: `${mm}/${dd}`, amount: 0 }
     }
-    let totalQty7d = 0
     for (const sale of list) {
       const soldAt = sale?.soldAt ? new Date(sale.soldAt) : null
       if (soldAt && !Number.isNaN(soldAt.getTime())) {
         const key = dateStr(soldAt)
         if (bucket[key]) bucket[key].amount += Number(sale?.totalAmount ?? 0)
       }
-      totalQty7d += Number(sale?.totalQuantity ?? 0)
     }
     dailySales.value = Object.keys(bucket)
       .sort()
       .map((k) => bucket[k])
-    dailyAvgSalesQty.value = totalQty7d / 7
   } catch {
     dailySales.value = []
-    dailyAvgSalesQty.value = 0
     dailySalesError.value = true
   }
 
@@ -314,18 +283,8 @@ onMounted(fetchStats)
       <section class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
         <article class="border border-gray-300 bg-white p-3 shadow-sm"><p class="text-[10px] font-black uppercase tracking-[0.12em] text-gray-400">금일 매출</p><p class="mt-2 text-2xl font-black text-gray-900">₩{{ todaySalesAmount.toLocaleString() }}</p><p v-if="salesError" class="mt-1 text-[10px] font-bold text-red-500">불러오기 실패</p></article>
         <article class="border border-gray-300 bg-white p-3 shadow-sm"><p class="text-[10px] font-black uppercase tracking-[0.12em] text-gray-400">금일 판매 건수</p><p class="mt-2 text-2xl font-black text-gray-900">{{ todaySalesCount.toLocaleString() }}<span class="ml-1 text-sm font-black text-gray-400">건</span></p></article>
-        <article class="border border-gray-300 bg-white p-3 shadow-sm"><p class="text-[10px] font-black uppercase tracking-[0.12em] text-gray-400">재고 위험 SKU</p><p class="mt-2 text-2xl font-black text-gray-900">{{ riskItems.length.toLocaleString() }}<span class="ml-1 text-sm font-black text-gray-400">개</span></p></article>
-        <article class="border border-gray-300 bg-white p-3 shadow-sm">
-          <p class="text-[10px] font-black uppercase tracking-[0.12em] text-gray-400">재고 보유일 (최단)</p>
-          <p class="mt-2 text-2xl font-black text-gray-900">
-            <template v-if="urgentSkuInventory">{{ urgentSkuInventory.days.toLocaleString() }}<span class="ml-1 text-sm font-black text-gray-400">일</span></template>
-            <template v-else><span class="text-base font-black text-gray-400">—</span></template>
-          </p>
-          <p class="mt-1 truncate text-[10px] font-bold text-gray-500" :title="urgentSkuInventory?.itemName ?? ''">
-            <template v-if="urgentSkuInventory">{{ urgentSkuInventory.itemName }}</template>
-            <template v-else>판매 데이터 부족</template>
-          </p>
-        </article>
+        <article class="border border-gray-300 bg-white p-3 shadow-sm"><p class="text-[10px] font-black uppercase tracking-[0.12em] text-gray-400">품절 SKU 수</p><p class="mt-2 text-2xl font-black text-red-700">{{ outOfStockCount.toLocaleString() }}<span class="ml-1 text-sm font-black text-gray-400">개</span></p><p class="mt-1 text-[10px] font-bold text-gray-400">가용 재고 0 이하</p></article>
+        <article class="border border-gray-300 bg-white p-3 shadow-sm"><p class="text-[10px] font-black uppercase tracking-[0.12em] text-gray-400">부족 SKU 수</p><p class="mt-2 text-2xl font-black text-amber-700">{{ lowStockCount.toLocaleString() }}<span class="ml-1 text-sm font-black text-gray-400">개</span></p><p class="mt-1 text-[10px] font-bold text-gray-400">안전재고 이하 (0 초과)</p></article>
       </section>
 
       <section class="grid gap-3 xl:grid-cols-2">


### PR DESCRIPTION
## 📌 요약
- 본사 대시보드 KPI 4카드 개편 + ESG 도메인(대시보드/TreeScore) BE 연동으로 mock 대다수 제거 + 차트 fill-height 도입

<br><br>

## 🎯 작업 내용
- **hq-dashboard**: KPI 4카드(운영 매장 수 / 재고이동 진행 / 상품 판매량 / 순환재고 판매량) 개편 + 카드별 "자세히 보기" 페이지 이동 + 월별 판매 수량 차트 12콜 → 1콜 최적화 + 재고이동 진행 실시간 전수 조회 + Promise.allSettled 부분 실패 허용
- **hq-esg (대시보드)**: 거래 가능 탄소 배출권 일별 라인차트(잔여한도 × KAU 7거래일) + 월별 판매 수익 BE 연동(`circularRevenueApi`) + KAU25 시세 실시간 연동(9840 하드코딩 제거) + KPI 2카드 / 탄소중립 "절감한 탄소 배출량" 통일된 BE 데이터(kg/tCO₂) + 차트 `fill-height` 적용 카드 하단 공백 해결 + dead code(`marketVolume`, `monthlyChartData`, `reducedKrw` 등) 정리 + `topBuyers` 런타임 에러 제거
- **hq-esg (TreeScore)**: sale 이벤트 BE 연동(`scoreEventsApi`, donation 6건 mock 유지) + 페이지네이션 `« ‹ 5개 › »` 화살표(5페이지 단위 점프) + 통계 4카드 정리(총 판매량 `kg` 단위 표기)
- **hq-esg (공용)**: `src/utils/esgScore.js` 점수 계산 모듈 추출(`SCORE_RULES` / `MATERIAL_FACTORS` / `calcEventScore` / `computeTotalScore` / `computeCarbonReductionKg`) — Dashboard + TreeScore가 같은 룰 공유
- **hq-esg (탄소 배출권 시세)**: `EsgCarbonPriceView` 복구(`ba4892d`에서 삭제됐던 페이지) + `/hq/esg/carbon-price` 라우트 추가(사이드 메뉴 비노출, 대시보드 "자세히 보기" 진입)
- **hq-esg (ESG 나무 위젯)**: viewBox `0 -32 100 132`, 줄기 `5+stage*8.5`, 지면 `cy=100`로 Lv10 거목이 ESG 나무 글자 바로 아래까지 도달
- **hq-account**: 필터 진입 시 자동 초기화(`onMounted` 리셋) + 사용자 혼선 가능한 "초기화" 버튼 제거
- **store-dashboard**: 재고 보유일(최단) 카드 제거 → 품절 SKU 수 / 부족 SKU 수 2카드 분리
- **hq-analytics**: 상품별 매출 차트 tooltip 판매량 추가 + 소재 매출 비중 ↔ 매출 순위 색상 1:1 매핑(`MATERIAL_PALETTE`)
- **공용 차트**: `LineChart` / `BarChart`에 `fill-height` prop 추가 — 부모 컨테이너 stretch 시 차트 100% 채움 (기존 호출처 영향 없음)

<br><br>

## ✔️ 참고 사항
- BE PR(#261) 선행 머지 필수 — `circularRevenueApi`, `scoreEventsApi` 가 BE 신규 엔드포인트 호출
- 제거된 mock: `totalPoints = 2456`, `kpiMetrics` 정적 배열, `REVENUE_MONTHLY`/`REVENUE_COUNT_MONTHLY` 12개월, `CARBON_ASSET_MONTHLY_PRICE` 12개월, `marketVolume`, `monthlyChartData`, `reducedKrw`, baseline `42_000_000`, `ytdAvoided` mock 기반 계산 등
- ESG 대시보드 헤더 누적 점수 + KPI 2카드 + 탄소중립 카드의 절감 탄소가 모두 동일 BE 데이터에서 일관된 값으로 표시 (`stores/esg.js.fetchTotalPoints` 액션 + TreeScore watcher 양방향 sync)
- BE Jackson 직렬화 quirk(`isNewBuyer` → `newBuyer`) 양쪽 모두 수용하도록 `normalizeSaleEvent` 처리
- TreeScore mock으로 남긴 기부 6건은 추후 BE `donation_history` 도메인 추가 시 BE 응답 머지로 자연 교체 가능한 구조

<br><br>

## ✔️ 관련 이슈

- Close #472 

<br><br>
