### PR TITLE
refactor: 순환 재고 판매 최종 판매 등록서 확인 모달 UI 리팩토링

### DIFF
--- a/docs/codex/recycle-sell/02-implementation/순환재고_판매_리팩토링_구현보고서_20260518.md
+++ b/docs/codex/recycle-sell/02-implementation/순환재고_판매_리팩토링_구현보고서_20260518.md
@@ -1,0 +1,151 @@
+﻿# 순환재고 판매 리팩토링 구현 보고서
+
+- 작성일: 2026-05-18
+- 대상 워크스페이스: `C:\Users\saral\Desktop\Stockit`
+- 범위: 순환재고 판매 등록/조회 화면의 무동작 변경 리팩토링(컴포넌트 분리 + 미사용 코드 정리)
+
+## 1) 목표 및 원칙
+
+### 목표
+- 대형 Vue 뷰 파일(2000줄+)의 유지보수성 개선
+- 기능/동작/가드/검증/문구의 의미를 바꾸지 않고 구조만 분리
+
+### 준수 원칙
+- 비즈니스 로직 및 스토어 호출 경로 유지
+- 기존 문구/클래스 의미/disabled 조건/버튼 동작 순서 유지
+- 파괴적 명령 미사용(`git reset --hard` 등 금지)
+- 빌드 통과를 기준으로 단계별 검증 수행
+
+## 2) 단계별 구현 내역
+
+### Step 2: RegisterView Stepper + Step1 + Footer 분리
+- 대상 파일:
+  - `src/views/hq/circular-stock/HqCircularStockSalesRegisterView.vue`
+- 신규 컴포넌트:
+  - `src/components/hq/circular-stock/sales-register/SalesRegisterStepper.vue`
+  - `src/components/hq/circular-stock/sales-register/SalesRegisterStep1SkuTable.vue`
+  - `src/components/hq/circular-stock/sales-register/SalesRegisterStepFooter.vue`
+- 핵심 유지:
+  - 부모에 `moveStep`, `openFinalReviewModal`, step 가드/검증 계산식, store 호출 로직 유지
+- 정리:
+  - 분리 후 부모에서 참조가 끊긴 일부 코드 제거
+
+### Step 3: RegisterView FinalReviewModal 분리
+- 신규 컴포넌트:
+  - `src/components/hq/circular-stock/sales-register/SalesRegisterFinalReviewModal.vue`
+- 변경 방식:
+  - 부모 템플릿의 최종 확인 모달 블록을 컴포넌트 호출로 치환
+  - 이벤트만 위임:
+    - `close`
+    - `return-edit`
+    - `submit`
+- 핵심 유지:
+  - `openFinalReviewModal`, `returnToDrawerEdit`, `submitSale`는 부모에서 그대로 유지
+
+### Step 4: RegisterView Step2(거래처 매칭) 섹션 분리
+- 신규 컴포넌트:
+  - `src/components/hq/circular-stock/sales-register/SalesRegisterStep2BuyerSection.vue`
+- 분리 내용:
+  - `saleStep === 2` 렌더링 블록을 하위 컴포넌트로 이동
+  - 추천 탭/수동 탭/추천 카드/근거 노출/검색 목록 렌더링 분리
+- 핵심 유지:
+  - 추천 fetch/근거 reveal 타이머/선택 가드/핵심 핸들러는 부모 유지
+
+### Step 5: RegisterView Step3(입력/클램프/토글/요약) 섹션 분리
+- 신규 컴포넌트:
+  - `src/components/hq/circular-stock/sales-register/SalesRegisterStep3ConditionsSection.vue`
+- 분리 내용:
+  - Step3 본문 UI(그룹 카드, 입력, 토글, 우측 요약, 메모) 이동
+- 핵심 유지:
+  - 계산/검증/스토어 갱신 로직은 부모 유지
+  - Step footer 경고/카운트/등록 가능 조건은 부모 계산 유지
+
+### Step 6: SkuSelectView 분리
+- 대상 파일:
+  - `src/views/hq/circular-stock/HqCircularStockSalesSkuSelectView.vue`
+- 신규 컴포넌트:
+  - `src/components/hq/circular-stock/sales-select/SalesSkuSelectBottomBar.vue`
+  - `src/components/hq/circular-stock/sales-select/SalesSkuSelectSelectedSkuModal.vue`
+  - `src/components/hq/circular-stock/sales-select/SalesSkuSelectResetConfirmModal.vue`
+- 핵심 유지:
+  - 재고 조회/필터/정렬/페이지/가드/스토어 호출/라우팅 로직은 부모 유지
+
+## 3) 미사용 코드 정리 결과
+
+### RegisterView 정리 항목
+- 제거한 미사용/중복 코드(주요):
+  - `matchingMaterialBadges`, `matchingContextSummary` (내부 ESG 임시 계산 포함)
+  - `toggleStep3Detail`, `isStep3DetailOpen`, `step3HasOverLimit`, `expandedStep3Rows`
+  - `isItemAdded`, `isRowSelectionDisabled`, `openDrawer`, `toggleDrawer`, `addItemToDraft`
+  - `isPriceEditMode`, `openPriceEditMode`, `closePriceEditMode`, `priceEditModes`
+  - `useEsgStore` import 및 `esgStore` 변수
+- 스타일 정리:
+  - RegisterView의 `.no-spin` 제거
+  - Step3 하위 컴포넌트의 `no-spin` 클래스 제거(입력 타입이 `text`라 실제 효과 없음)
+
+### SkuSelectView 정리 항목
+- 제거한 항목:
+  - `moveToWorkflow` (미사용)
+- 경량 리팩토링:
+  - 선행조건 체크 중복을 `getFilterPrereqState()`로 묶어 중복 분기 축소
+  - 단순 래퍼 함수 제거 및 이벤트 직접 연결
+
+## 4) 더미 데이터/폴백 현황
+
+- 현재 “목업 API 응답 전체”는 남아있지 않음
+- 다만 RegisterView 내 추천 표시용 폴백은 일부 존재:
+  - `mockProducts`
+  - `mockManagers`
+  - 전화번호 폴백(`02-000x-000x`)
+- 위 항목은 API 필드 공백 시 표시 안정성을 위한 UI 폴백 성격
+
+## 5) 빌드 및 회귀 검증
+
+### 빌드
+- 각 단계 완료 후 `npm.cmd run build` 수행
+- 결과: 통과
+
+### 회귀 체크(진행 범위)
+- Stepper 이동 및 가드 동작
+- Step1 SKU 삭제/전체 비우기 이벤트 전파
+- Step2 탭 전환/추천 선택/수동 검색/복귀 가드
+- Step3 입력/blur 클램프/자동 되돌리기/토글/요약 반영
+- FinalReviewModal 진입/닫기/복귀/최종등록 이벤트 위임
+- SkuSelectView 하단바/선택 SKU 모달/초기화 확인 모달 동작
+
+## 6) 파일 변경 목록(핵심)
+
+### 신규 생성
+- `src/components/hq/circular-stock/sales-register/SalesRegisterStepper.vue`
+- `src/components/hq/circular-stock/sales-register/SalesRegisterStep1SkuTable.vue`
+- `src/components/hq/circular-stock/sales-register/SalesRegisterStepFooter.vue`
+- `src/components/hq/circular-stock/sales-register/SalesRegisterFinalReviewModal.vue`
+- `src/components/hq/circular-stock/sales-register/SalesRegisterStep2BuyerSection.vue`
+- `src/components/hq/circular-stock/sales-register/SalesRegisterStep3ConditionsSection.vue`
+- `src/components/hq/circular-stock/sales-select/SalesSkuSelectBottomBar.vue`
+- `src/components/hq/circular-stock/sales-select/SalesSkuSelectSelectedSkuModal.vue`
+- `src/components/hq/circular-stock/sales-select/SalesSkuSelectResetConfirmModal.vue`
+
+### 주요 수정
+- `src/views/hq/circular-stock/HqCircularStockSalesRegisterView.vue`
+- `src/views/hq/circular-stock/HqCircularStockSalesSkuSelectView.vue`
+
+### 문서
+- `docs/codex/recycle-sell/01-plan/순환재고_판매등록_뷰분리_리팩토링_설계서_20260517.md`
+- `docs/codex/recycle-sell/02-implementation/순환재고_판매_리팩토링_구현보고서_20260518.md` (본 문서)
+
+## 7) 남은 TODO / 권장 후속 작업
+
+1. 백엔드 API 스펙 확정 후 2차 정리
+- 추천/등록 응답 필드 확정 시 폴백 텍스트 축소 또는 제거
+- 프론트 중복 검증과 서버 검증 경계 재정리
+
+2. `circularStock.js` 모듈 분리
+- 조회/추천/초안/제출 도메인 단위로 composable/store 분리
+
+3. 인코딩 점검
+- 한글 문자열 UTF-8 저장 상태 최종 점검(모지바케 방지)
+
+---
+
+본 보고서는 “무동작 변경” 원칙 하에 수행된 분리/정리 작업의 구현 결과를 요약한 문서입니다.

--- a/src/components/hq/circular-stock/sales-register/SalesRegisterFinalReviewModal.vue
+++ b/src/components/hq/circular-stock/sales-register/SalesRegisterFinalReviewModal.vue
@@ -1,5 +1,8 @@
-<script setup>
-defineProps({
+﻿<script setup>
+import { computed } from 'vue'
+import { Building2, CircleDollarSign, Info, Scale, Settings2, Shirt, Tag, Truck } from 'lucide-vue-next'
+
+const props = defineProps({
   open: {
     type: Boolean,
     required: true,
@@ -11,6 +14,14 @@ defineProps({
   lockedMaterialType: {
     type: String,
     default: '',
+  },
+  outboundWarehouseLabel: {
+    type: String,
+    default: '-',
+  },
+  outboundWarehouseRegionLabel: {
+    type: String,
+    default: '-',
   },
   drawerSummary: {
     type: Object,
@@ -59,6 +70,49 @@ defineProps({
 })
 
 const emit = defineEmits(['close', 'return-edit', 'submit'])
+
+const groupedDraftItems = computed(() => {
+  const groups = new Map()
+  for (const item of props.draftItems) {
+    const materialLabel = props.formatMaterials(item.materials)
+    const key = `${item.materialType}__${materialLabel}`
+    if (!groups.has(key)) {
+      groups.set(key, {
+        key,
+        materialType: item.materialType,
+        materialLabel,
+        items: [],
+        totalRequestedWeightKg: 0,
+        totalActualWeightKg: 0,
+        totalActualAmount: 0,
+      })
+    }
+
+    const group = groups.get(key)
+    group.items.push(item)
+    group.totalRequestedWeightKg += Number(item.requestedWeightKg) || 0
+    group.totalActualWeightKg += Number(item.actualWeightKg) || 0
+    group.totalActualAmount += Number(item.actualAmount) || 0
+  }
+
+  return Array.from(groups.values())
+})
+
+const includedMaterialBadges = computed(() => {
+  const badgeMap = new Map()
+  for (const item of props.draftItems) {
+    for (const material of item.materials || []) {
+      const name = String(material?.name || '').trim()
+      const ratio = Number(material?.ratio || 0)
+      if (!name || ratio <= 0) continue
+      const key = `${name}-${ratio}`
+      if (!badgeMap.has(key)) {
+        badgeMap.set(key, `${name} ${ratio}%`)
+      }
+    }
+  }
+  return Array.from(badgeMap.values())
+})
 </script>
 
 <template>
@@ -68,14 +122,10 @@ const emit = defineEmits(['close', 'return-edit', 'submit'])
     @click.self="emit('close')"
   >
     <div class="flex h-full w-full items-center justify-center p-4">
-      <div
-        class="flex h-full max-h-[92vh] w-full max-w-7xl flex-col overflow-hidden rounded-md bg-white shadow-2xl"
-      >
+      <div class="flex h-full max-h-[92vh] w-full max-w-7xl flex-col overflow-hidden rounded-md bg-white shadow-2xl">
         <div class="flex items-center justify-between border-b border-gray-200 px-6 py-4">
           <div>
-            <p class="text-[10px] font-black uppercase tracking-[0.18em] text-gray-400">
-              Final Review
-            </p>
+            <p class="text-[10px] font-black uppercase tracking-[0.18em] text-gray-400">Final Review</p>
             <h2 class="mt-1 text-lg font-black text-gray-900">최종 판매 등록서 확인</h2>
           </div>
           <button
@@ -86,240 +136,417 @@ const emit = defineEmits(['close', 'return-edit', 'submit'])
             닫기
           </button>
         </div>
+
         <div class="min-h-0 flex-1 overflow-y-auto px-6 py-5">
-          <section class="border border-gray-200 bg-white">
-            <div class="grid gap-4 px-4 py-4 xl:grid-cols-[minmax(0,1.35fr)_minmax(21rem,0.65fr)]">
+          <section class="border border-gray-200 bg-white p-4">
+            <div class="flex flex-wrap items-start justify-between gap-3">
               <div>
-                <div class="flex flex-wrap items-start justify-between gap-3 pb-3">
-                  <div>
-                    <p class="text-[10px] font-black uppercase tracking-[0.12em] text-gray-400">
-                      거래 요약
-                    </p>
-                    <p class="mt-1 text-base font-black text-gray-900">
-                      {{ selectedBuyer?.companyName ?? '-' }}
-                    </p>
-                    <p class="mt-1 text-xs font-bold text-gray-500">
-                      소재 구분 {{ lockedMaterialType || '-' }} · 담긴 SKU
-                      {{ formatQuantity(drawerSummary.totalItems) }}건
-                    </p>
-                  </div>
-                  <div class="rounded-full bg-[#EAF4F0] px-3 py-1 text-[10px] font-black text-[#255F52]">
-                    {{ materialFitLabel(selectedBuyer?.primaryMaterialFit) || '-' }}
-                  </div>
-                </div>
-
-                <div class="mt-2 grid gap-3 pb-4 md:grid-cols-2 xl:grid-cols-4">
-                  <div class="rounded-md border border-gray-200 bg-gray-50 px-3 py-3">
-                    <p class="text-[10px] font-black uppercase tracking-[0.08em] text-gray-400">
-                      요청 / 실제 KG
-                    </p>
-                    <p class="mt-1 text-sm font-black text-gray-900">
-                      {{ formatKg(finalReviewSummary.totalRequestedWeightKg) }}
-                    </p>
-                    <p class="mt-1 text-sm font-black text-[#0F5C4D]">
-                      {{ formatKg(finalReviewSummary.totalActualWeightKg) }}
-                    </p>
-                  </div>
-                  <div class="rounded-md border border-gray-200 bg-gray-50 px-3 py-3">
-                    <p class="text-[10px] font-black uppercase tracking-[0.08em] text-gray-400">
-                      환산 / 실차감
-                    </p>
-                    <p class="mt-1 text-sm font-black text-gray-900">
-                      {{ Number(finalReviewSummary.totalEstimatedQuantity).toFixed(2) }}벌
-                    </p>
-                    <p class="mt-1 text-sm font-black text-amber-700">
-                      {{ formatQuantity(finalReviewSummary.totalDeductedQuantity) }}벌
-                    </p>
-                  </div>
-                  <div class="rounded-md border border-gray-200 bg-gray-50 px-3 py-3">
-                    <p class="text-[10px] font-black uppercase tracking-[0.08em] text-gray-400">
-                      예상 / 실제 금액
-                    </p>
-                    <p class="mt-1 text-sm font-black text-gray-900">
-                      {{ formatCurrency(finalReviewSummary.totalRequestedAmount) }}
-                    </p>
-                    <p class="mt-1 text-sm font-black text-[#0F5C4D]">
-                      {{ formatCurrency(finalReviewSummary.totalActualAmount) }}
-                    </p>
-                  </div>
-                  <div class="rounded-md border border-gray-200 bg-gray-50 px-3 py-3">
-                    <p class="text-[10px] font-black uppercase tracking-[0.08em] text-gray-400">
-                      포함 소재
-                    </p>
-                    <p class="mt-1 text-sm font-black leading-5 text-gray-900">
-                      {{ includedMaterialNames.join(', ') || '-' }}
-                    </p>
-                  </div>
-                </div>
-
-                <div
-                  v-if="
-                    Math.abs(
-                      finalReviewSummary.totalActualWeightKg -
-                        finalReviewSummary.totalRequestedWeightKg,
-                    ) >= 0.01
-                  "
-                  class="rounded-md border border-[#D7E9E3] bg-[#F3FAF8] px-3 py-3"
-                >
-                  <p class="text-xs font-black text-[#0F5C4D]">
-                    요청 {{ formatKg(finalReviewSummary.totalRequestedWeightKg) }} → 실재고 차감
-                    기준 {{ formatKg(finalReviewSummary.totalActualWeightKg) }} 반영
-                  </p>
-                </div>
+                <p class="text-base !font-semibold uppercase tracking-[0.1em] text-gray-500">거래 요약</p>
+                <p class="mt-1 text-2xl !font-medium text-gray-900">{{ selectedBuyer?.companyName ?? '-' }}</p>
+                <p class="mt-1 text-xs font-bold text-gray-500">
+                  {{ selectedBuyer?.industryGroup ?? '-' }} · SKU {{ formatQuantity(drawerSummary.totalItems) }}종
+                </p>
               </div>
+              <div class="rounded-full bg-[#EAF4F0] px-3 py-1 text-[10px] font-black text-[#255F52]">
+                {{ materialFitLabel(selectedBuyer?.primaryMaterialFit) || '-' }}
+              </div>
+            </div>
 
-              <aside class="border border-gray-200 bg-gray-50 px-4 py-4">
-                <div class="flex items-start justify-between gap-3 pb-3">
-                  <div>
-                    <p class="text-[10px] font-black uppercase tracking-[0.12em] text-gray-400">
-                      거래처 정보
-                    </p>
-                    <div class="mt-1 flex flex-wrap items-center gap-2">
-                      <p class="text-sm font-black text-gray-900">
-                        {{ selectedBuyer?.companyName ?? '-' }}
-                      </p>
-                      <p class="font-mono text-[11px] font-black text-gray-500">
-                        {{ selectedBuyer?.code ?? '-' }}
-                      </p>
-                    </div>
+            <div class="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+              <article class="kpi-card">
+                <p class="kpi-title">
+                  <Shirt :size="12" />
+                  판매 수량
+                </p>
+                <div class="kpi-content-gap">
+                  <p class="text-2xl !font-medium text-gray-900">{{ formatQuantity(finalReviewSummary.totalDeductedQuantity) }}벌</p>
+                  <p class="kpi-subtext">
+                    <Info :size="12" class="kpi-subtext-icon" />
+                    환산 {{ Number(finalReviewSummary.totalEstimatedQuantity).toFixed(2) }}벌
+                    <span class="kpi-emphasis">→ 올림 {{ formatQuantity(finalReviewSummary.totalDeductedQuantity) }}벌</span>
+                  </p>
+                </div>
+              </article>
+
+              <article class="kpi-card">
+                <p class="kpi-title">
+                  <Scale :size="12" />
+                  실제 무게
+                </p>
+                <div class="kpi-content-gap">
+                  <p class="text-2xl !font-medium text-gray-900">{{ formatKg(finalReviewSummary.totalActualWeightKg) }}</p>
+                  <p class="kpi-subtext">
+                    <Info :size="12" class="kpi-subtext-icon" />
+                    요청 {{ formatKg(finalReviewSummary.totalRequestedWeightKg) }} 대비
+                    <span class="kpi-emphasis">
+                      {{ `${finalReviewSummary.totalActualWeightKg - finalReviewSummary.totalRequestedWeightKg >= 0 ? '+' : ''}${formatKg(finalReviewSummary.totalActualWeightKg - finalReviewSummary.totalRequestedWeightKg)}` }}
+                    </span>
+                  </p>
+                </div>
+              </article>
+
+              <article class="kpi-card">
+                <p class="kpi-title">
+                  <Tag :size="12" />
+                  포함 소재
+                </p>
+                <div class="kpi-content-gap">
+                  <div class="grid grid-flow-col auto-cols-max grid-rows-3 gap-x-2 gap-y-1.5">
+                    <span
+                      v-for="badge in includedMaterialBadges"
+                      :key="badge"
+                      class="material-badge"
+                    >
+                      {{ badge }}
+                    </span>
+                    <span v-if="includedMaterialBadges.length === 0" class="text-base !font-medium text-gray-900">
+                      -
+                    </span>
                   </div>
-                  <span class="text-[11px] font-black text-gray-500">{{
-                    selectedBuyer?.industryGroup ?? '-'
-                  }}</span>
                 </div>
+              </article>
 
-                <div class="mt-2 grid grid-cols-2 gap-3">
-                  <div>
-                    <p class="text-[10px] font-black uppercase tracking-[0.08em] text-gray-400">
-                      담당자
-                    </p>
-                    <p class="mt-1 text-xs font-black text-gray-800">
-                      {{ selectedBuyer?.managerName ?? '-' }}
-                    </p>
+              <article class="kpi-card">
+                <p class="kpi-title">
+                  <CircleDollarSign :size="12" />
+                  최종 금액
+                </p>
+                <div class="kpi-content-gap">
+                  <p class="text-2xl !font-medium text-[#1C8E73]">{{ formatCurrency(finalReviewSummary.totalActualAmount) }}</p>
+                  <p class="kpi-subtext">
+                    <Info :size="12" class="kpi-subtext-icon" />
+                    요청 기준
+                    <span class="line-through">{{ formatCurrency(finalReviewSummary.totalRequestedAmount) }}</span>
+                  </p>
+                </div>
+              </article>
+            </div>
+
+            <div
+              v-if="Math.abs(finalReviewSummary.totalActualWeightKg - finalReviewSummary.totalRequestedWeightKg) >= 0.01"
+              class="mt-3 rounded-md border border-[#EADFC8] bg-[#FFFBEB] px-3 py-3"
+            >
+              <p class="flex items-center gap-1.5 text-sm font-black text-gray-900">
+                <Settings2 :size="12" :stroke-width="2.6" class="shrink-0 text-[#0F5C4D]" />
+                <span class="text-gray-900">
+                kg → 벌 수 환산시 올림 처리로 요청 {{ formatKg(finalReviewSummary.totalRequestedWeightKg) }}보다
+                {{ formatKg(Math.abs(finalReviewSummary.totalActualWeightKg - finalReviewSummary.totalRequestedWeightKg)) }}
+                더 출고됩니다. 금액은 실제 출고 무게({{ formatKg(finalReviewSummary.totalActualWeightKg) }}) 기준으로 산정됩니다.
+                </span>
+              </p>
+            </div>
+          </section>
+
+          <section class="mt-4 border border-gray-200 bg-white p-4">
+            <div class="grid gap-6 lg:grid-cols-2">
+              <article>
+                <h3 class="info-header">
+                  <Building2 :size="13" />
+                  거래처 정보
+                </h3>
+                <dl class="mt-3 text-sm">
+                  <div class="info-line">
+                    <dt class="info-key">거래처명</dt>
+                    <dd class="info-value">
+                      {{ selectedBuyer?.companyName ?? '-' }}
+                      <span class="buyer-code">{{ selectedBuyer?.code ?? '-' }}</span>
+                    </dd>
                   </div>
-                  <div>
-                    <p class="text-[10px] font-black uppercase tracking-[0.08em] text-gray-400">
-                      연락처
-                    </p>
-                    <p class="mt-1 text-xs font-black text-gray-800">
-                      {{ selectedBuyer?.phone ?? '-' }}
-                    </p>
+                  <div class="info-line">
+                    <dt class="info-key">유형</dt>
+                    <dd class="info-value">{{ selectedBuyer?.industryGroup ?? '-' }}</dd>
                   </div>
-                </div>
+                  <div class="info-line">
+                    <dt class="info-key">담당자</dt>
+                    <dd class="info-value">{{ selectedBuyer?.managerName ?? '-' }}</dd>
+                  </div>
+                  <div class="info-line">
+                    <dt class="info-key">연락처</dt>
+                    <dd class="info-value">{{ selectedBuyer?.phone ?? '-' }}</dd>
+                  </div>
+                  <div class="info-line">
+                    <dt class="info-key">취급 제품</dt>
+                    <dd class="info-value">{{ selectedBuyer?.productTypes?.join(', ') || selectedBuyer?.productNote || '-' }}</dd>
+                  </div>
+                </dl>
+              </article>
 
-                <div class="mt-4 border-t border-gray-200 pt-3">
-                  <p class="text-[10px] font-black uppercase tracking-[0.08em] text-gray-400">
-                    취급제품 / 생산품
-                  </p>
-                  <p class="mt-1 text-xs font-bold leading-5 text-gray-700">
-                    {{ selectedBuyer?.productTypes?.join(', ') || selectedBuyer?.productNote || '-' }}
-                  </p>
-                </div>
-
-                <div class="mt-4 border-t border-gray-200 pt-3">
-                  <p class="text-[10px] font-black uppercase tracking-[0.08em] text-gray-400">
-                    거래처 설명
-                  </p>
-                  <p class="mt-1 text-xs font-bold leading-5 text-gray-700">
-                    {{ selectedBuyer?.description || '설명 없음' }}
-                  </p>
-                </div>
-
-                <div class="mt-4 border-t border-gray-200 pt-3">
-                  <p class="text-[10px] font-black uppercase tracking-[0.08em] text-gray-400">
-                    판매 메모
-                  </p>
-                  <p class="mt-1 text-xs font-bold leading-5 text-gray-700">
-                    {{ draftMemo?.trim() || '입력된 메모 없음' }}
-                  </p>
-                </div>
-              </aside>
+              <article>
+                <h3 class="info-header">
+                  <Truck :size="13" />
+                  출고 정보
+                </h3>
+                <dl class="mt-3 text-sm">
+                  <div class="info-line">
+                    <dt class="info-key">출고 창고</dt>
+                    <dd class="info-value">{{ outboundWarehouseLabel || '-' }}</dd>
+                  </div>
+                  <div class="info-line">
+                    <dt class="info-key">소재 구분</dt>
+                    <dd class="info-value">{{ lockedMaterialType || '-' }}</dd>
+                  </div>
+                  <div class="info-line">
+                    <dt class="info-key">담긴 SKU</dt>
+                    <dd class="info-value">{{ formatQuantity(drawerSummary.totalItems) }}종</dd>
+                  </div>
+                  <div class="info-line">
+                    <dt class="info-key">판매 메모</dt>
+                    <dd class="info-value info-value-memo text-gray-500 italic">{{ draftMemo?.trim() || '입력된 메모 없음' }}</dd>
+                  </div>
+                </dl>
+              </article>
             </div>
           </section>
 
           <section class="mt-4 min-w-0 border border-gray-200 bg-white">
-            <div class="border-b border-gray-100 px-3 py-3">
-              <h3 class="text-sm font-black text-gray-900">판매 SKU 상세</h3>
+            <div class="border-b border-gray-100 px-4 py-3">
+              <h3 class="text-sm font-black text-gray-900">소재별 판매 상세</h3>
             </div>
-            <div class="overflow-x-auto">
-              <table class="min-w-[1450px] w-full border-collapse text-left text-xs">
-                <thead class="bg-gray-50 text-[10px] uppercase tracking-[0.12em] text-gray-500">
-                  <tr>
-                    <th class="px-3 py-3 font-black">SKU 코드</th>
-                    <th class="pl-0.5 pr-3 py-3 text-left font-black">품목명</th>
-                    <th class="px-3 py-3 text-left font-black">소재 구분</th>
-                    <th class="px-3 py-3 font-black">소재 상세</th>
-                    <th class="px-3 py-3 text-left font-black">현재 재고</th>
-                    <th class="px-3 py-3 text-left font-black">요청 kg</th>
-                    <th class="px-3 py-3 text-left font-black">환산 수량</th>
-                    <th class="px-3 py-3 text-left font-black">실차감 재고</th>
-                    <th class="px-3 py-3 text-left font-black">실제 반영 kg</th>
-                    <th class="px-3 py-3 text-left font-black">kg당 단가</th>
-                    <th class="px-3 py-3 text-left font-black">예상 금액</th>
-                    <th class="px-3 py-3 text-left font-black">실제 금액</th>
-                  </tr>
-                </thead>
-                <tbody class="divide-y divide-gray-100">
-                  <tr v-for="item in draftItems" :key="item.draftId">
-                    <td class="pl-3 pr-0 py-3 font-mono font-bold text-gray-500">
-                      {{ item.skuCode }}
-                    </td>
-                    <td class="pl-0.5 pr-3 py-3 font-black text-gray-900">
-                      {{ item.itemName }}
-                    </td>
-                    <td class="px-3 py-3 text-left font-black text-gray-900">
-                      {{ item.materialType }}
-                    </td>
-                    <td class="px-3 py-3 font-bold text-gray-700">
-                      {{ formatMaterials(item.materials) }}
-                    </td>
-                    <td class="px-3 py-3 text-left font-black text-gray-600">
-                      {{ formatQuantity(item.availableQuantity) }}벌 /
-                      {{ formatKg(item.availableWeightKg) }}
-                    </td>
-                    <td class="px-3 py-3 text-left font-black text-gray-900">
-                      {{ formatKg(item.requestedWeightKg) }}
-                    </td>
-                    <td class="px-3 py-3 text-left font-black text-gray-700">
-                      {{ Number(item.estimatedQuantity || 0).toFixed(2) }}벌
-                    </td>
-                    <td class="px-3 py-3 text-left font-black text-amber-700">
-                      {{ formatQuantity(item.deductedQuantity) }}벌
-                    </td>
-                    <td
-                      class="px-3 py-3 text-left font-black"
-                      :class="hasWeightAdjustment(item) ? 'text-[#0F5C4D]' : 'text-gray-900'"
-                    >
-                      {{ formatKg(item.actualWeightKg) }}
-                    </td>
-                    <td class="px-3 py-3 text-left font-black text-gray-900">
-                      {{ formatCurrency(item.unitPrice) }}
-                    </td>
-                    <td class="px-3 py-3 text-left font-black text-gray-900">
-                      {{ formatCurrency(item.requestedAmount) }}
-                    </td>
-                    <td
-                      class="px-3 py-3 text-left font-black"
-                      :class="hasWeightAdjustment(item) ? 'text-[#0F5C4D]' : 'text-gray-900'"
-                    >
-                      {{ formatCurrency(item.actualAmount) }}
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
+
+            <div class="space-y-3 p-3">
+              <article
+                v-for="group in groupedDraftItems"
+                :key="group.key"
+                class="overflow-hidden rounded-md border border-gray-300 bg-white"
+              >
+                <div class="flex flex-wrap items-end justify-between gap-3 border-b border-gray-300 bg-[#F6F6F4] px-3 py-3">
+                  <div class="flex items-center gap-2">
+                    <span class="rounded-full bg-[#D9EFE7] px-3.5 py-1 text-[13px] !font-semibold text-[#1F7A63]">
+                      {{ group.materialLabel }}
+                    </span>
+                    <p class="text-[13px] font-bold text-gray-500">
+                      SKU {{ formatQuantity(group.items.length) }}종 · {{ formatCurrency(group.items[0]?.unitPrice || 0) }}/kg
+                    </p>
+                  </div>
+                  <div class="flex flex-wrap items-end gap-5 text-right">
+                    <div class="group-kpi">
+                      <p class="group-kpi-label">요청</p>
+                      <p class="group-kpi-value">{{ formatKg(group.totalRequestedWeightKg).replace('kg', ' kg') }}</p>
+                    </div>
+                    <div class="group-kpi">
+                      <p class="group-kpi-label">실출고</p>
+                      <p class="group-kpi-value">{{ formatKg(group.totalActualWeightKg).replace('kg', ' kg') }}</p>
+                    </div>
+                    <div class="group-kpi">
+                      <p class="group-kpi-label">금액</p>
+                      <p class="group-kpi-value group-kpi-value-amount">{{ formatCurrency(group.totalActualAmount) }}</p>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="overflow-x-auto">
+                  <table class="min-w-[980px] w-full table-fixed border-collapse text-right text-sm">
+                    <colgroup>
+                      <col class="w-[15%]" />
+                      <col class="w-[15%]" />
+                      <col class="w-[15%]" />
+                      <col class="w-[10%]" />
+                      <col class="w-[15%]" />
+                      <col class="w-[15%]" />
+                      <col class="w-[15%]" />
+                    </colgroup>
+                    <thead class="border-b border-gray-200 text-[12px] text-gray-500">
+                      <tr>
+                        <th class="cell-head !text-left" style="text-align: left">SKU</th>
+                        <th class="cell-head text-right">재고</th>
+                        <th class="cell-head text-right">배분 kg</th>
+                        <th class="cell-head text-right"></th>
+                        <th class="cell-head text-right">판매 벌 수</th>
+                        <th class="cell-head text-right">실제 무게</th>
+                        <th class="cell-head text-right">금액</th>
+                      </tr>
+                    </thead>
+                    <tbody class="divide-y divide-gray-200">
+                      <tr v-for="item in group.items" :key="item.draftId">
+                        <td class="cell-body !text-left" style="text-align: left">
+                          <p class="font-black text-gray-900">{{ item.itemName }}</p>
+                          <p class="mt-0.5 font-mono text-[11px] text-gray-500">{{ item.skuCode }}</p>
+                        </td>
+                        <td class="cell-body font-black text-gray-700">{{ formatQuantity(item.availableQuantity) }}벌 / {{ formatKg(item.availableWeightKg) }}</td>
+                        <td class="cell-body font-black text-gray-800">{{ formatKg(item.requestedWeightKg).replace('kg', ' kg') }}</td>
+                        <td class="cell-body text-right text-lg font-black text-gray-700">→</td>
+                        <td class="cell-body">
+                          <p class="font-black text-[#0F7C62]">{{ formatQuantity(item.deductedQuantity) }}벌</p>
+                          <p class="mt-0.5 text-[11px] font-bold text-gray-500">{{ Number(item.estimatedQuantity || 0).toFixed(2) }}벌 올림</p>
+                        </td>
+                        <td class="cell-body font-black text-gray-900">{{ formatKg(item.actualWeightKg).replace('kg', ' kg') }}</td>
+                        <td class="cell-body font-black text-gray-900">{{ formatCurrency(item.actualAmount) }}</td>
+                      </tr>
+                      <tr class="bg-[#F6F6F4]">
+                        <td class="cell-body !text-left text-sm font-black text-gray-800" style="text-align: left">합계</td>
+                        <td class="cell-body"></td>
+                        <td class="cell-body"></td>
+                        <td class="cell-body"></td>
+                        <td class="cell-body font-black text-gray-900">{{ formatQuantity(group.items.reduce((sum, item) => sum + (Number(item.deductedQuantity) || 0), 0)) }}벌</td>
+                        <td class="cell-body font-black text-gray-900">{{ formatKg(group.totalActualWeightKg).replace('kg', ' kg') }}</td>
+                        <td class="cell-body font-black text-gray-900">{{ formatCurrency(group.totalActualAmount) }}</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </article>
             </div>
           </section>
         </div>
-        <div class="flex items-center justify-end gap-2 border-t border-gray-200 bg-gray-50 px-6 py-4">
-          <button
-            type="button"
-            class="border border-[#004D3C] bg-[#004D3C] px-4 py-2 text-xs font-black text-white hover:bg-[#00382c]"
-            @click="emit('submit')"
-          >
-            이 내용으로 최종 등록
-          </button>
+
+        <div class="flex items-center justify-between gap-2 border-t border-gray-200 bg-gray-50 px-6 py-4">
+          <p class="text-xs font-bold text-gray-500">등록 후에는 수정이 불가합니다</p>
+          <div class="flex items-center gap-2">
+            <button
+              type="button"
+              class="border border-gray-300 bg-white px-4 py-2 text-xs font-black text-gray-700 hover:bg-gray-50"
+              @click="emit('return-edit')"
+            >
+              페이지로 돌아가 수정
+            </button>
+            <button
+              type="button"
+              class="border border-[#004D3C] bg-[#004D3C] px-4 py-2 text-xs font-black text-white hover:bg-[#00382c]"
+              @click="emit('submit')"
+            >
+              이 내용으로 최종 등록
+            </button>
+          </div>
         </div>
       </div>
     </div>
   </div>
 </template>
+
+<style scoped>
+.label-sm {
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #9ca3af;
+}
+
+.kpi-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 0.375rem;
+  background: #f7f7f5;
+  padding: 0.75rem;
+}
+
+.kpi-subtext {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-top: 0.5rem;
+  border-top: 1px dashed #d1d5db;
+  padding-top: 0.5rem;
+  font-size: 13px;
+  line-height: 1.35;
+  color: #6b7280;
+}
+
+.kpi-subtext-icon {
+  flex-shrink: 0;
+}
+
+.kpi-emphasis {
+  color: #8b5e34;
+}
+
+.kpi-title {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 12px;
+  font-weight: 400;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #6b7280;
+}
+
+.kpi-content-gap {
+  margin-top: 0.5rem;
+}
+
+.material-badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 9999px;
+  background: #eaf4f0;
+  padding: 0.125rem 0.5rem;
+  font-size: 12px;
+  font-weight: 700;
+  color: #255f52;
+}
+
+.info-header {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 14px;
+  font-weight: 600;
+  color: #374151;
+}
+
+.info-line {
+  display: grid;
+  grid-template-columns: 92px minmax(0, 1fr);
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.info-line:last-child {
+  border-bottom: 0;
+}
+
+.info-key {
+  font-size: 13px;
+  font-weight: 400;
+  color: #6b7280;
+}
+
+.info-value {
+  font-size: 14px;
+  font-weight: 500;
+  color: #111827;
+  text-align: right;
+}
+
+.info-value-memo {
+  font-weight: 400;
+  color: #6b7280;
+}
+
+.buyer-code {
+  margin-left: 0.25rem;
+  font-size: 12px;
+  font-weight: 400;
+  color: #9ca3af;
+}
+
+.group-kpi-label {
+  font-size: 12px;
+  font-weight: 400;
+  color: #6b7280;
+}
+
+.group-kpi-value {
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.05;
+  color: #111827;
+}
+
+.group-kpi-value-amount {
+  color: #0f7c62;
+}
+
+.cell-head {
+  padding: 0.5rem;
+  text-align: inherit;
+  font-weight: 400;
+}
+
+.cell-body {
+  padding: 0.5rem;
+  text-align: inherit;
+}
+</style>

--- a/src/components/hq/circular-stock/sales-register/SalesRegisterFinalReviewModal.vue
+++ b/src/components/hq/circular-stock/sales-register/SalesRegisterFinalReviewModal.vue
@@ -1,6 +1,6 @@
 ﻿<script setup>
 import { computed } from 'vue'
-import { Building2, CircleDollarSign, Info, Scale, Settings2, Shirt, Tag, Truck } from 'lucide-vue-next'
+import { Building2, CircleDollarSign, Info, Lock, Scale, Settings2, Shirt, Tag, Truck, X } from 'lucide-vue-next'
 
 const props = defineProps({
   open: {
@@ -119,10 +119,9 @@ const includedMaterialBadges = computed(() => {
   <div
     v-if="open"
     class="fixed inset-0 z-50 bg-black/45 backdrop-blur-sm"
-    @click.self="emit('close')"
   >
-    <div class="flex h-full w-full items-center justify-center p-4">
-      <div class="flex h-full max-h-[92vh] w-full max-w-5xl flex-col overflow-hidden rounded-md bg-white shadow-2xl">
+    <div class="flex h-full w-full items-center justify-center p-4" @click="emit('close')">
+      <div class="flex h-full max-h-[92vh] w-full max-w-5xl flex-col overflow-hidden rounded-md bg-white shadow-2xl" @click.stop>
         <div class="flex items-center justify-between border-b border-gray-200 px-6 py-4">
           <div>
             <p class="text-[10px] font-black uppercase tracking-[0.18em] text-gray-400">Final Review</p>
@@ -130,10 +129,11 @@ const includedMaterialBadges = computed(() => {
           </div>
           <button
             type="button"
-            class="border border-gray-300 bg-white px-3 py-2 text-xs font-black text-gray-700 hover:bg-gray-50"
+            class="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-gray-300 bg-white text-gray-700 transition-colors hover:bg-gray-50"
+            aria-label="닫기"
             @click="emit('close')"
           >
-            닫기
+            <X :size="16" />
           </button>
         </div>
 
@@ -401,18 +401,21 @@ const includedMaterialBadges = computed(() => {
         </div>
 
         <div class="flex items-center justify-between gap-2 border-t border-gray-200 bg-gray-50 px-6 py-4">
-          <p class="text-xs font-bold text-gray-500">등록 후에는 수정이 불가합니다</p>
+          <p class="inline-flex items-center gap-1.5 text-xs font-bold text-gray-500">
+            <Lock :size="12" class="shrink-0" />
+            등록 후에는 수정이 불가합니다
+          </p>
           <div class="flex items-center gap-2">
             <button
               type="button"
-              class="border border-gray-300 bg-white px-4 py-2 text-xs font-black text-gray-700 hover:bg-gray-50"
+              class="h-10 cursor-pointer rounded-xl border border-gray-300 bg-white px-6 text-base font-black text-gray-700 transition-all duration-150 hover:bg-gray-50 hover:shadow-sm"
               @click="emit('return-edit')"
             >
               페이지로 돌아가 수정
             </button>
             <button
               type="button"
-              class="border border-[#004D3C] bg-[#004D3C] px-4 py-2 text-xs font-black text-white hover:bg-[#00382c]"
+              class="h-10 cursor-pointer rounded-xl border border-[#004D3C] bg-[#004D3C] px-7 text-base font-black text-white transition-all duration-150 hover:border-[#00382c] hover:bg-[#00382c] hover:shadow-[0_8px_16px_-10px_rgba(0,77,60,0.55)]"
               @click="emit('submit')"
             >
               이 내용으로 최종 등록

--- a/src/components/hq/circular-stock/sales-register/SalesRegisterFinalReviewModal.vue
+++ b/src/components/hq/circular-stock/sales-register/SalesRegisterFinalReviewModal.vue
@@ -122,7 +122,7 @@ const includedMaterialBadges = computed(() => {
     @click.self="emit('close')"
   >
     <div class="flex h-full w-full items-center justify-center p-4">
-      <div class="flex h-full max-h-[92vh] w-full max-w-7xl flex-col overflow-hidden rounded-md bg-white shadow-2xl">
+      <div class="flex h-full max-h-[92vh] w-full max-w-5xl flex-col overflow-hidden rounded-md bg-white shadow-2xl">
         <div class="flex items-center justify-between border-b border-gray-200 px-6 py-4">
           <div>
             <p class="text-[10px] font-black uppercase tracking-[0.18em] text-gray-400">Final Review</p>
@@ -309,7 +309,7 @@ const includedMaterialBadges = computed(() => {
                 :key="group.key"
                 class="overflow-hidden rounded-md border border-gray-300 bg-white"
               >
-                <div class="flex flex-wrap items-end justify-between gap-3 border-b border-gray-300 bg-[#F6F6F4] px-3 py-3">
+                <div class="flex flex-wrap items-end justify-between gap-3 border-b border-gray-300 bg-[#F6F6F4] pl-3 px-4 py-3">
                   <div class="flex items-center gap-2">
                     <span class="rounded-full bg-[#D9EFE7] px-3.5 py-1 text-[13px] !font-semibold text-[#1F7A63]">
                       {{ group.materialLabel }}
@@ -335,21 +335,21 @@ const includedMaterialBadges = computed(() => {
                 </div>
 
                 <div class="overflow-x-auto">
-                  <table class="min-w-[980px] w-full table-fixed border-collapse text-right text-sm">
+                  <table class="min-w-[700px] w-full table-fixed border-collapse text-right text-sm">
                     <colgroup>
                       <col class="w-[15%]" />
-                      <col class="w-[15%]" />
-                      <col class="w-[15%]" />
+                      <col class="w-[13%]" />
+                      <col class="w-[13%]" />
+                      <col class="w-[7%]" />
                       <col class="w-[10%]" />
-                      <col class="w-[15%]" />
-                      <col class="w-[15%]" />
-                      <col class="w-[15%]" />
+                      <col class="w-[13%]" />
+                      <col class="w-[13%]" />
                     </colgroup>
                     <thead class="border-b border-gray-200 text-[12px] text-gray-500">
                       <tr>
                         <th class="cell-head !text-left" style="text-align: left">SKU</th>
                         <th class="cell-head text-right">재고</th>
-                        <th class="cell-head text-right">배분 kg</th>
+                        <th class="cell-head text-right">요청 kg</th>
                         <th class="cell-head text-right"></th>
                         <th class="cell-head text-right">판매 벌 수</th>
                         <th class="cell-head text-right">실제 무게</th>
@@ -548,5 +548,15 @@ const includedMaterialBadges = computed(() => {
 .cell-body {
   padding: 0.5rem;
   text-align: inherit;
+}
+
+th.cell-head:first-child,
+td.cell-body:first-child {
+  padding-left: 1.2rem;
+}
+
+th.cell-head:last-child,
+td.cell-body:last-child {
+  padding-right: 1.2rem;
 }
 </style>

--- a/src/components/hq/circular-stock/sales-register/SalesRegisterFinalReviewModal.vue
+++ b/src/components/hq/circular-stock/sales-register/SalesRegisterFinalReviewModal.vue
@@ -140,10 +140,12 @@ const includedMaterialBadges = computed(() => {
         <div class="min-h-0 flex-1 overflow-y-auto px-6 py-5">
           <section class="bg-white p-4 pr-6 pl-6">
             <div class="flex flex-wrap items-start justify-between gap-3">
-              <div>
+              <div class="flex flex-col">
                 <p class="text-base !font-semibold uppercase tracking-[0.1em] text-gray-500">거래 요약</p>
-                <p class="mt-1 text-2xl !font-medium text-gray-900">{{ selectedBuyer?.companyName ?? '-' }}</p>
-                <p class="mt-1 text-xs font-bold text-gray-500">
+                <div class="h-3"></div>
+                <p class="text-2xl !font-medium text-gray-900">{{ selectedBuyer?.companyName ?? '-' }}</p>
+                <div class="h-1"></div>
+                <p class="text-xs font-bold text-gray-500">
                   {{ selectedBuyer?.industryGroup ?? '-' }} · SKU {{ formatQuantity(drawerSummary.totalItems) }}종
                 </p>
               </div>
@@ -152,7 +154,8 @@ const includedMaterialBadges = computed(() => {
               </div>
             </div>
 
-            <div class="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+            <div class="h-2"></div>
+            <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
               <article class="kpi-card">
                 <p class="kpi-title">
                   <Shirt :size="12" />
@@ -222,11 +225,12 @@ const includedMaterialBadges = computed(() => {
               </article>
             </div>
 
+            <div class="h-4"></div>
             <div
               v-if="Math.abs(finalReviewSummary.totalActualWeightKg - finalReviewSummary.totalRequestedWeightKg) >= 0.01"
-              class="mt-3 rounded-md border border-[#EADFC8] bg-[#FFFBEB] px-3 py-3"
+              class="rounded-md border border-[#EADFC8] bg-[#FFFBEB] px-3 py-3"
             >
-              <p class="flex items-center gap-1.5 text-sm font-black text-gray-900">
+              <p class="flex items-center gap-3 text-sm font-black text-gray-900">
                 <Settings2 :size="12" :stroke-width="2.6" class="shrink-0 text-[#0F5C4D]" />
                 <span class="text-gray-900">
                 kg → 벌 수 환산시 올림 처리로 요청 {{ formatKg(finalReviewSummary.totalRequestedWeightKg) }}보다
@@ -237,7 +241,7 @@ const includedMaterialBadges = computed(() => {
             </div>
           </section>
 
-          <div class="mx-6 py-6">
+          <div class="mx-6 py-2">
             <div class="border-t border-gray-300"></div>
           </div>
           <section class="px-5 bg-white">
@@ -301,7 +305,7 @@ const includedMaterialBadges = computed(() => {
             </div>
           </section>
 
-          <div class="mx-6 py-6">
+          <div class="mx-6 py-5.5">
             <div class="border-t border-gray-300"></div>
           </div>
           <section class="min-w-0 bg-white">
@@ -310,9 +314,8 @@ const includedMaterialBadges = computed(() => {
             </div>
 
             <div class="space-y-3 p-3 pr-5 pl-5">
+              <template v-for="(group, groupIndex) in groupedDraftItems" :key="group.key">
               <article
-                v-for="group in groupedDraftItems"
-                :key="group.key"
                 class="overflow-hidden rounded-md border border-gray-300 bg-white"
               >
                 <div class="flex flex-wrap items-end justify-between gap-3 border-b border-gray-300 bg-[#F6F6F4] pl-3 px-4 py-3">
@@ -391,6 +394,8 @@ const includedMaterialBadges = computed(() => {
                   </table>
                 </div>
               </article>
+              <div v-if="groupIndex < groupedDraftItems.length - 1" class="h-6.5"></div>
+              </template>
             </div>
           </section>
         </div>
@@ -485,6 +490,8 @@ const includedMaterialBadges = computed(() => {
   display: flex;
   align-items: center;
   gap: 0.375rem;
+  margin-top: 1rem;
+  margin-bottom: 0.7rem;
   font-size: 14px;
   font-weight: 500;
   color: #374151;

--- a/src/components/hq/circular-stock/sales-register/SalesRegisterFinalReviewModal.vue
+++ b/src/components/hq/circular-stock/sales-register/SalesRegisterFinalReviewModal.vue
@@ -138,7 +138,7 @@ const includedMaterialBadges = computed(() => {
         </div>
 
         <div class="min-h-0 flex-1 overflow-y-auto px-6 py-5">
-          <section class="border border-gray-200 bg-white p-4">
+          <section class="bg-white p-4 pr-6 pl-6">
             <div class="flex flex-wrap items-start justify-between gap-3">
               <div>
                 <p class="text-base !font-semibold uppercase tracking-[0.1em] text-gray-500">거래 요약</p>
@@ -237,8 +237,11 @@ const includedMaterialBadges = computed(() => {
             </div>
           </section>
 
-          <section class="mt-4 border border-gray-200 bg-white p-4">
-            <div class="grid gap-6 lg:grid-cols-2">
+          <div class="mx-6 py-6">
+            <div class="border-t border-gray-300"></div>
+          </div>
+          <section class="px-5 bg-white">
+            <div class="grid gap-8 px-1 lg:grid-cols-2">
               <article>
                 <h3 class="info-header">
                   <Building2 :size="13" />
@@ -298,12 +301,15 @@ const includedMaterialBadges = computed(() => {
             </div>
           </section>
 
-          <section class="mt-4 min-w-0 border border-gray-200 bg-white">
-            <div class="border-b border-gray-100 px-4 py-3">
-              <h3 class="text-sm font-black text-gray-900">소재별 판매 상세</h3>
+          <div class="mx-6 py-6">
+            <div class="border-t border-gray-300"></div>
+          </div>
+          <section class="min-w-0 bg-white">
+            <div class="px-6">
+              <h3 class="text-sm !font-semibold text-gray-500">소재별 판매 상세</h3>
             </div>
 
-            <div class="space-y-3 p-3">
+            <div class="space-y-3 p-3 pr-5 pl-5">
               <article
                 v-for="group in groupedDraftItems"
                 :key="group.key"
@@ -480,7 +486,7 @@ const includedMaterialBadges = computed(() => {
   align-items: center;
   gap: 0.375rem;
   font-size: 14px;
-  font-weight: 600;
+  font-weight: 500;
   color: #374151;
 }
 

--- a/src/components/hq/circular-stock/sales-register/SalesRegisterStep3ConditionsSection.vue
+++ b/src/components/hq/circular-stock/sales-register/SalesRegisterStep3ConditionsSection.vue
@@ -268,7 +268,7 @@ const emit = defineEmits([
         </article>
       </div>
 
-      <aside class="rounded-xl border border-gray-200 bg-[#F7F8F7] px-4 py-4">
+      <aside class="h-fit self-start rounded-xl border border-gray-200 bg-[#F7F8F7] px-4 py-4">
         <div class="flex flex-col gap-3">
           <section>
             <p class="text-xs text-gray-500" style="font-weight: 600; margin-bottom: 6px">출고 창고</p>

--- a/src/views/hq/circular-stock/HqCircularStockSalesRegisterView.vue
+++ b/src/views/hq/circular-stock/HqCircularStockSalesRegisterView.vue
@@ -1057,6 +1057,8 @@ onBeforeUnmount(() => {
         :open="showFinalReviewModal"
         :selected-buyer="selectedBuyer"
         :locked-material-type="lockedMaterialType"
+        :outbound-warehouse-label="outboundWarehouseLabel"
+        :outbound-warehouse-region-label="outboundWarehouseRegionLabel"
         :drawer-summary="drawerSummary"
         :final-review-summary="finalReviewSummary"
         :included-material-names="includedMaterialNames"
@@ -1087,15 +1089,3 @@ onBeforeUnmount(() => {
     </div>
   </AppLayout>
 </template>
-
-<style scoped>
-.no-spin::-webkit-outer-spin-button,
-.no-spin::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
-.no-spin {
-  -moz-appearance: textfield;
-}
-</style>


### PR DESCRIPTION
## 📌 요약
- 순환 재고 판매 `최종 판매 등록서 확인 모달` UI를 전면 리팩토링했습니다.
- 기능/동작/검증 로직은 유지한 채, 정보 위계·가독성·스타일 일관성을 개선했습니다.
- Step3 우측 판매 요약 카드가 좌측 높이에 의해 늘어나는 이슈를 수정했습니다.


<br><br>

## 🎯 작업 내용
- `SalesRegisterFinalReviewModal.vue`
  - 모달 구조를 `거래 요약 / 거래처·출고 정보 / 소재별 판매 상세 / 액션` 중심으로 재정비
  - KPI 카드, 안내 문구, 아이콘, 타이포/간격, 버튼 스타일을 일관되게 정리
  - 소재별 판매 상세를 그룹 헤더 + 상세 테이블 + 합계 행 형태로 개선
  - 모달 바깥 클릭 시 닫힘 동작 보강 (`backdrop click close`)
- `HqCircularStockSalesRegisterView.vue`
  - 모달 표시용 출고 정보 props 전달 확장(`outboundWarehouseLabel`, `outboundWarehouseRegionLabel`)
- `SalesRegisterStep3ConditionsSection.vue`
  - 우측 판매 요약 카드에 `h-fit self-start` 적용하여 좌측 콘텐츠 길이에 따른 세로 stretch 제거


<br><br>

## ✔️ 참고 사항
- 이벤트 계약(`close`, `return-edit`, `submit`) 및 기존 검증 흐름은 유지했습니다.
- 수치 계산/조건식/포맷 함수 호출 로직 변경 없이 UI 레이어 중심으로 리팩토링했습니다.
- 빌드 검증 완료: `npm.cmd run build` 성공


<br><br>

## ✔️ 관련 이슈

- Close #489 

<br><br>