### PR TITLE
485 feat 알림 기능 구현

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,22 @@
 <script setup>
+import { onMounted, watch } from 'vue'
 import { RouterView } from 'vue-router'
+import { useAuthStore } from '@/stores/auth.js'
+import { useNotificationStore } from '@/stores/notification.js'
+
+// 인증 복원(F5) 시 알림 store 도 함께 초기화 (SSE 재연결).
+// 로그인 직후엔 authStore.login() 안에서 이미 init 됨 — 중복 호출은 store init 가드로 무시.
+const auth = useAuthStore()
+const notif = useNotificationStore()
+
+onMounted(() => {
+  if (auth.isAuthenticated) notif.init()
+})
+
+watch(
+  () => auth.isAuthenticated,
+  (now) => { if (now) notif.init() },
+)
 </script>
 
 <template>

--- a/src/api/notification.js
+++ b/src/api/notification.js
@@ -1,0 +1,69 @@
+/**
+ * notification.js — 알림 BE 연동
+ *
+ * BE 엔드포인트:
+ *   GET    /api/notifications/stream             (SSE 구독, text/event-stream)
+ *   GET    /api/notifications                    (목록, page/size/unreadOnly)
+ *   GET    /api/notifications/unread-count       (미읽음 카운트)
+ *   PATCH  /api/notifications/{id}/read          (단건 읽음)
+ *   PATCH  /api/notifications/read-all           (전체 읽음)
+ *
+ * 응답: BaseResponse<T>. unwrap() 으로 result 만 추출.
+ */
+
+import { apiClient, unwrap } from './axios.js'
+
+export const notificationApi = {
+  /**
+   * 본인 수신 알림 목록 조회
+   * @param {{ page?: number, size?: number, unreadOnly?: boolean }} params
+   */
+  list: (params = {}) =>
+    apiClient.get('/api/notifications', { params }).then(unwrap),
+
+  /** 미읽음 카운트 */
+  unreadCount: () =>
+    apiClient.get('/api/notifications/unread-count').then(unwrap),
+
+  /** 단건 읽음 처리 */
+  read: (id) =>
+    apiClient.patch(`/api/notifications/${id}/read`).then(unwrap),
+
+  /** 본인 수신분 전체 읽음 처리 */
+  readAll: () =>
+    apiClient.patch('/api/notifications/read-all').then(unwrap),
+}
+
+/**
+ * SSE 구독 — EventSource 는 axios 와 별도. 쿠키 자동 전송을 위해 withCredentials.
+ * 호출 측에서 반환된 EventSource 의 close() 를 책임진다 (언마운트/로그아웃 시).
+ *
+ * @param {{
+ *   onConnect?: (data: string) => void,
+ *   onNotification?: (payload: object) => void,
+ *   onError?: (event: Event) => void,
+ * }} handlers
+ * @returns {EventSource}
+ */
+export function subscribeNotificationStream(handlers = {}) {
+  const base = import.meta.env.VITE_API_BASE ?? ''
+  const url = `${base}/api/notifications/stream`
+  const es = new EventSource(url, { withCredentials: true })
+
+  if (handlers.onConnect) {
+    es.addEventListener('connect', (e) => handlers.onConnect(e.data))
+  }
+  if (handlers.onNotification) {
+    es.addEventListener('notification', (e) => {
+      try {
+        handlers.onNotification(JSON.parse(e.data))
+      } catch (err) {
+        console.error('[subscribeNotificationStream] JSON parse failed', err, e.data)
+      }
+    })
+  }
+  if (handlers.onError) {
+    es.onerror = handlers.onError
+  }
+  return es
+}

--- a/src/components/common/AppLayout.vue
+++ b/src/components/common/AppLayout.vue
@@ -1,7 +1,8 @@
 ﻿<script setup>
-import { computed, nextTick, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth.js'
+import { useNotificationStore } from '@/stores/notification.js'
 import { useLogout } from '@/composables/useLogout.js'
 import EsgTreeWidget from '@/components/common/EsgTreeWidget.vue'
 import {
@@ -309,6 +310,80 @@ const onSubmenuAfterLeave = (el) => {
   el.style.transition = ''
 }
 
+// ───────────────────── 알림 (상단 종 아이콘 + 미니 드롭다운) ─────────────────────
+// BE 연동 — useNotificationStore (전역). 로그인 직후 init() 에서 초기 로드 + SSE 구독.
+const notifStore = useNotificationStore()
+const unreadCount = computed(() => notifStore.unreadCount)
+const recentNotifications = computed(() => notifStore.recent)
+
+const showNotifPanel = ref(false)
+const notifPanelRef = ref(null)
+const notifButtonRef = ref(null)
+
+const notificationPagePath = computed(() => {
+  switch (auth.user?.role) {
+    case 'hq':        return '/hq/notifications'
+    case 'store':     return '/store/notifications'
+    case 'warehouse': return '/warehouse/notifications'
+    default:          return null
+  }
+})
+
+const toggleNotifPanel = () => { showNotifPanel.value = !showNotifPanel.value }
+const closeNotifPanel = () => { showNotifPanel.value = false }
+
+const goToNotificationsPage = () => {
+  closeNotifPanel()
+  if (notificationPagePath.value) router.push(notificationPagePath.value)
+}
+
+const markAllNotifRead = async () => {
+  try { await notifStore.markAllAsRead() } catch { /* 에러는 store 가 콘솔 로깅 */ }
+}
+
+const handleNotifClick = async (n) => {
+  // 단건 클릭 → 읽음 처리(BE 호출) + 알림 페이지 이동
+  try { if (!n.read) await notifStore.markAsRead(n.id) } catch { /* ignore */ }
+  goToNotificationsPage()
+}
+
+const notifSeverityBadgeCls = (severity) => {
+  switch (severity) {
+    case 'CRITICAL': return 'bg-red-100 text-red-700 border-red-300'
+    case 'WARNING':  return 'bg-amber-100 text-amber-700 border-amber-300'
+    default:         return 'bg-sky-100 text-sky-700 border-sky-300'
+  }
+}
+
+const notifSeverityLabel = (severity) => {
+  switch (severity) {
+    case 'CRITICAL': return '긴급'
+    case 'WARNING':  return '주의'
+    default:         return '정보'
+  }
+}
+
+const handleClickOutsideNotif = (event) => {
+  if (!showNotifPanel.value) return
+  const panel = notifPanelRef.value
+  const btn = notifButtonRef.value
+  if (panel && panel.contains(event.target)) return
+  if (btn && btn.contains(event.target)) return
+  closeNotifPanel()
+}
+
+onMounted(() => {
+  if (typeof window !== 'undefined') {
+    window.addEventListener('mousedown', handleClickOutsideNotif)
+  }
+})
+
+onBeforeUnmount(() => {
+  if (typeof window !== 'undefined') {
+    window.removeEventListener('mousedown', handleClickOutsideNotif)
+  }
+})
+
 const iconMap = {
   layout: LayoutDashboard,
   warehouse: Warehouse,
@@ -336,6 +411,7 @@ const iconMap = {
   user: Users,
   inbound: PackagePlus,
   outbound: Truck,
+  bell: Bell,
 }
 </script>
 
@@ -367,9 +443,83 @@ const iconMap = {
             <Sprout :size="14" />
             <span>ESG 대시보드</span>
           </button>
-          <button type="button" class="p-1.5 text-white/80 transition-colors hover:bg-white/10">
-            <Bell :size="16" />
-          </button>
+          <div class="relative">
+            <button
+              ref="notifButtonRef"
+              type="button"
+              class="relative p-1.5 text-white/80 transition-colors hover:bg-white/10"
+              title="알림"
+              @click="toggleNotifPanel"
+            >
+              <Bell :size="16" />
+              <span
+                v-if="unreadCount > 0"
+                class="absolute -right-0.5 -top-0.5 flex h-3.5 min-w-[14px] items-center justify-center rounded-full bg-red-500 px-1 text-[9px] font-bold leading-none text-white ring-1 ring-[#004D3C]"
+              >
+                {{ unreadCount > 99 ? '99+' : unreadCount }}
+              </span>
+            </button>
+
+            <div
+              v-if="showNotifPanel"
+              ref="notifPanelRef"
+              class="absolute right-0 top-full z-30 mt-1 w-80 overflow-hidden rounded-lg border border-gray-200 bg-white text-gray-900 shadow-lg"
+            >
+              <div class="flex items-center justify-between border-b border-gray-100 bg-gray-50 px-3 py-2">
+                <div class="flex items-center gap-1.5">
+                  <Bell :size="14" class="text-emerald-700" />
+                  <span class="text-xs font-bold">알림</span>
+                  <span v-if="unreadCount > 0" class="rounded-full bg-red-100 px-1.5 py-0.5 text-[9px] font-bold text-red-700">
+                    {{ unreadCount }}
+                  </span>
+                </div>
+                <button
+                  v-if="unreadCount > 0"
+                  type="button"
+                  class="text-[10px] font-semibold text-emerald-700 hover:underline"
+                  @click="markAllNotifRead"
+                >
+                  모두 읽음
+                </button>
+              </div>
+
+              <ul v-if="recentNotifications.length > 0" class="max-h-72 divide-y divide-gray-100 overflow-y-auto">
+                <li
+                  v-for="n in recentNotifications"
+                  :key="n.id"
+                  class="cursor-pointer px-3 py-2 transition-colors hover:bg-gray-50"
+                  :class="{ 'bg-emerald-50/40': !n.read }"
+                  @click="handleNotifClick(n)"
+                >
+                  <div class="flex items-start gap-2">
+                    <span
+                      class="mt-0.5 shrink-0 rounded border px-1.5 py-0.5 text-[9px] font-bold"
+                      :class="notifSeverityBadgeCls(n.severity)"
+                    >
+                      {{ notifSeverityLabel(n.severity) }}
+                    </span>
+                    <div class="min-w-0 flex-1">
+                      <p class="truncate text-[11px] font-semibold">{{ n.title }}</p>
+                      <p class="mt-0.5 truncate text-[10px] text-gray-500">{{ n.message }}</p>
+                    </div>
+                  </div>
+                </li>
+              </ul>
+
+              <div v-else class="flex flex-col items-center gap-1 px-3 py-6 text-center">
+                <Bell :size="20" class="text-gray-300" />
+                <p class="text-[11px] text-gray-500">새 알림이 없습니다.</p>
+              </div>
+
+              <button
+                type="button"
+                class="block w-full border-t border-gray-100 bg-gray-50 px-3 py-2 text-center text-[11px] font-semibold text-emerald-700 transition-colors hover:bg-gray-100"
+                @click="goToNotificationsPage"
+              >
+                전체 보기
+              </button>
+            </div>
+          </div>
           <button
             type="button"
             class="ml-2 flex items-center gap-2 p-1 transition-colors hover:bg-white/10"

--- a/src/config/roleMenus.js
+++ b/src/config/roleMenus.js
@@ -69,6 +69,11 @@
       path: '/hq/accounts',
       icon: 'user',
     },
+    {
+      label: '알림',
+      path: '/hq/notifications',
+      icon: 'bell',
+    },
   ],
   store: [
     {
@@ -104,6 +109,11 @@
       path: '/store/inbound/list',
       icon: 'check',
     },
+    {
+      label: '알림',
+      path: '/store/notifications',
+      icon: 'bell',
+    },
   ],
   warehouse: [
     {
@@ -125,6 +135,11 @@
       label: '출고 관리',
       path: '/warehouse/outbound',
       icon: 'outbound',
+    },
+    {
+      label: '알림',
+      path: '/warehouse/notifications',
+      icon: 'bell',
     },
   ],
 }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -56,6 +56,9 @@ import HqAnalyticsOrderStatsView from '@/views/hq/analytics/HqAnalyticsOrderStat
 import HqAnalyticsTurnoverView from '@/views/hq/analytics/HqAnalyticsTurnoverView.vue'
 import HqAnalyticsSalesView from '@/views/hq/analytics/HqAnalyticsSalesView.vue'
 import HqAnalyticsVendorView from '@/views/hq/analytics/HqAnalyticsVendorView.vue'
+import HqNotificationView from '@/views/hq/notification/HqNotificationView.vue'
+import StoreNotificationView from '@/views/store/notification/StoreNotificationView.vue'
+import WarehouseNotificationView from '@/views/warehouse/notification/WarehouseNotificationView.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -160,6 +163,7 @@ const router = createRouter({
     { path: '/hq/esg', name: 'hq-esg', component: EsgDashBoardView, meta: { requiresAuth: true, role: 'hq' } },
     { path: '/hq/esg/tree-score', name: 'hq-esg-tree-score', component: EsgTreeScoreView, meta: { requiresAuth: true, role: 'hq' } },
     { path: '/hq/esg/carbon-price', name: 'hq-esg-carbon-price', component: EsgCarbonPriceView, meta: { requiresAuth: true, role: 'hq' } },
+    { path: '/hq/notifications', name: 'hq-notifications', component: HqNotificationView, meta: { requiresAuth: true, role: 'hq' } },
 
     { path: '/store/dashboard', name: 'store-dashboard', component: StoreDashboardView, meta: { requiresAuth: true, role: 'store' } },
     { path: '/store/dashboard2', name: 'store-dashboard2', component: StoreDashboardView2, meta: { requiresAuth: true, role: 'store' } },
@@ -177,6 +181,7 @@ const router = createRouter({
     { path: '/store/inbound/list/:id', name: 'store-inbound-detail', component: StoreInboundDetailView, meta: { requiresAuth: true, role: 'store' } },
     { path: '/store/inbound/history', redirect: { name: 'store-inbound-list' } },
     { path: '/store/inbound/history/:id', redirect: (to) => ({ name: 'store-inbound-detail', params: { id: to.params.id } }) },
+    { path: '/store/notifications', name: 'store-notifications', component: StoreNotificationView, meta: { requiresAuth: true, role: 'store' } },
 
     {
       path: '/warehouse/dashboard',
@@ -206,6 +211,12 @@ const router = createRouter({
       path: '/warehouse/outbound/:id',
       name: 'wh-outbound-detail',
       component: WarehouseOutboundDetailView,
+      meta: { requiresAuth: true, role: 'warehouse' },
+    },
+    {
+      path: '/warehouse/notifications',
+      name: 'wh-notifications',
+      component: WarehouseNotificationView,
       meta: { requiresAuth: true, role: 'warehouse' },
     },
 

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { roleHomeMap } from '@/config/roleMenus.js'
 import { authApi } from '@/api/user/auth.js'
 import { extractErrorMessage } from '@/api/axios.js'
+import { useNotificationStore } from '@/stores/notification.js'
 
 // HttpOnly Cookie 방식이라 토큰은 JS에서 접근 불가.
 // localStorage 에는 사용자 정보(UI 표시용)만 저장.
@@ -43,6 +44,13 @@ export const useAuthStore = defineStore('auth', () => {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(user.value))
       sessionStorage.removeItem('stockit:openTopMenus')
 
+      // 알림 store — 로그인 직후 초기 로드 + SSE 구독
+      try {
+        await useNotificationStore().init()
+      } catch (e) {
+        console.warn('[auth.login] notification init failed:', e)
+      }
+
       return { success: true, redirectTo: roleHomeMap[role] ?? '/dev-login' }
     } catch (err) {
       return {
@@ -66,6 +74,12 @@ export const useAuthStore = defineStore('auth', () => {
       user.value = null
       localStorage.removeItem(STORAGE_KEY)
       sessionStorage.removeItem('stockit:openTopMenus')
+      // 알림 store — SSE close + 상태 비우기
+      try {
+        useNotificationStore().dispose()
+      } catch (e) {
+        console.warn('[auth.logout] notification dispose failed:', e)
+      }
     }
   }
 

--- a/src/stores/notification.js
+++ b/src/stores/notification.js
@@ -1,0 +1,147 @@
+/**
+ * notification.js — 알림 전역 상태 (Pinia)
+ *
+ * 책임:
+ * - 페이지/헤더 양쪽에서 공유되는 알림 목록 + 미읽음 카운트
+ * - 로그인 직후 init() 호출 → 초기 로드 + SSE 구독
+ * - 로그아웃 직전 dispose() 호출 → SSE close + 상태 초기화
+ *
+ * 데이터 흐름:
+ *   초기 로드: notificationApi.list({ size:50 })  →  notifications[]
+ *   실시간 :   SSE notification 이벤트 수신       →  notifications 앞에 prepend
+ *   읽음   :   PATCH 후 로컬 상태도 갱신
+ */
+
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { notificationApi, subscribeNotificationStream } from '@/api/notification.js'
+
+export const useNotificationStore = defineStore('notification', () => {
+  const notifications = ref([])           // 최신순 (id desc)
+  const totalElements = ref(0)
+  const initialized = ref(false)
+  const loading = ref(false)
+  const error = ref('')
+
+  let eventSource = null
+
+  const unreadCount = computed(
+    () => notifications.value.filter((n) => !n.read).length,
+  )
+
+  const recent = computed(() => notifications.value.slice(0, 5))
+
+  /**
+   * 초기 로드 + SSE 구독.
+   * 로그인 직후 또는 인증 복원 직후 1회 호출.
+   */
+  async function init() {
+    if (initialized.value) return
+    initialized.value = true
+
+    await refresh()
+    connectStream()
+  }
+
+  /** 서버에서 최신 50건 다시 가져오기 */
+  async function refresh() {
+    loading.value = true
+    error.value = ''
+    try {
+      const data = await notificationApi.list({ page: 0, size: 50 })
+      notifications.value = data?.items ?? []
+      totalElements.value = data?.totalElements ?? 0
+    } catch (e) {
+      error.value = e?.message ?? '알림을 불러오지 못했습니다.'
+      console.error('[notificationStore.refresh]', e)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  /** SSE 연결 — 중복 연결 방지 */
+  function connectStream() {
+    if (eventSource) return
+    eventSource = subscribeNotificationStream({
+      onConnect: () => {
+        // 연결 성공
+      },
+      onNotification: (payload) => {
+        // BE SsePayload (id/type/severity/title/message/createdAt) — read=false 기본
+        const exists = notifications.value.some((n) => n.id === payload.id)
+        if (exists) return
+        notifications.value.unshift({
+          ...payload,
+          refType: payload.refType ?? null,
+          refId: payload.refId ?? null,
+          read: false,
+          readAt: null,
+        })
+        totalElements.value += 1
+      },
+      onError: (e) => {
+        // EventSource 는 자동 재연결 시도. 로그만.
+        console.warn('[notificationStore SSE] error', e)
+      },
+    })
+  }
+
+  /** 단건 읽음 처리 */
+  async function markAsRead(id) {
+    try {
+      await notificationApi.read(id)
+      const idx = notifications.value.findIndex((n) => n.id === id)
+      if (idx >= 0 && !notifications.value[idx].read) {
+        notifications.value[idx] = {
+          ...notifications.value[idx],
+          read: true,
+          readAt: new Date().toISOString(),
+        }
+      }
+    } catch (e) {
+      console.error('[notificationStore.markAsRead]', e)
+      throw e
+    }
+  }
+
+  /** 본인 수신분 전체 읽음 */
+  async function markAllAsRead() {
+    try {
+      await notificationApi.readAll()
+      const now = new Date().toISOString()
+      notifications.value = notifications.value.map((n) =>
+        n.read ? n : { ...n, read: true, readAt: now },
+      )
+    } catch (e) {
+      console.error('[notificationStore.markAllAsRead]', e)
+      throw e
+    }
+  }
+
+  /** SSE close + 상태 초기화 — 로그아웃 시 호출 */
+  function dispose() {
+    if (eventSource) {
+      try { eventSource.close() } catch { /* ignore */ }
+      eventSource = null
+    }
+    notifications.value = []
+    totalElements.value = 0
+    initialized.value = false
+    loading.value = false
+    error.value = ''
+  }
+
+  return {
+    notifications,
+    totalElements,
+    unreadCount,
+    recent,
+    loading,
+    error,
+    init,
+    refresh,
+    markAsRead,
+    markAllAsRead,
+    dispose,
+  }
+})

--- a/src/views/hq/dashboard/OperationStatusView.vue
+++ b/src/views/hq/dashboard/OperationStatusView.vue
@@ -35,7 +35,36 @@ const dateLabel = computed(() =>
 // ───────── 운영현황 상태 ─────────
 const isLoading = ref(false)
 const loadError = ref('')
-const kpiOps = ref([])
+// KPI 카드 — 카드 슬롯을 항상 보장하기 위해 ref 분리 + computed 로 구성.
+// 'loading' 상태에서도 카드 자리는 즉시 그려지고, 각 API 응답 도착 시 카드별로 독립 갱신됨.
+const activeStoreCount = ref(0)
+const storeCardState = ref('loading')          // 'loading' | 'ok' | 'error'
+const inTransitTransferCount = ref(0)
+const transferCardState = ref('loading')
+const kpiOps = computed(() => [
+  {
+    label: '운영 매장 수',
+    value: storeCardState.value === 'ok' ? `${activeStoreCount.value}` : '–',
+    unit: '곳',
+    caption: storeCardState.value === 'ok'
+      ? '상태 ACTIVE 매장'
+      : (storeCardState.value === 'error' ? '불러오기 실패' : '불러오는 중…'),
+    tone: 'green',
+    route: '/hq/infrastructure',
+    hoverCls: 'hover:border-emerald-400',
+  },
+  {
+    label: '재고이동 진행',
+    value: transferCardState.value === 'ok' ? `${inTransitTransferCount.value}` : '–',
+    unit: '건',
+    caption: transferCardState.value === 'ok'
+      ? '실시간 · 출고 준비중 + 배송중'
+      : (transferCardState.value === 'error' ? '불러오기 실패' : '불러오는 중…'),
+    tone: 'blue',
+    route: '/hq/inventory/warehouse-comparison',
+    hoverCls: 'hover:border-blue-400',
+  },
+])
 const inventoryRisks = ref([])
 const purchaseStatusBreakdown = ref([])
 
@@ -87,18 +116,42 @@ const statusByAvailableAndSafety = (available, safety) => {
 const fetchOperationData = async () => {
   isLoading.value = true
   loadError.value = ''
+  storeCardState.value = 'loading'
+  transferCardState.value = 'loading'
 
   const { fromDate, toDate } = getDefaultDateRange(30)
   // 재고이동 진행은 실시간(현재 시점 진행 중) 기준으로 표시 — 기간 필터 우회용 넓은 범위
   const TRANSFER_FROM = '2020-01-01'
   const TRANSFER_TO = '2099-12-31'
-  // Promise.allSettled — 부분 실패해도 나머지 KPI는 표시
-  const results = await Promise.allSettled([
-    getCompanyWideInventories(),
-    purchaseOrderApi.list({ from: fromDate, to: toDate }),
-    getWarehouseTransfers({ fromDate: TRANSFER_FROM, toDate: TRANSFER_TO }),
-    getInfrastructures({ type: 'STORE', status: 'ACTIVE' }),
-  ])
+
+  // 4개 API — 한 번씩만 호출 (Promise 객체 재사용)
+  const companyWideP = getCompanyWideInventories()
+  const purchaseP = purchaseOrderApi.list({ from: fromDate, to: toDate })
+  const transferP = getWarehouseTransfers({ fromDate: TRANSFER_FROM, toDate: TRANSFER_TO })
+  const storeP = getInfrastructures({ type: 'STORE', status: 'ACTIVE' })
+
+  // 운영 매장 수 카드 — 매장 API 응답 도착 즉시 갱신 (다른 API 와 무관)
+  storeP
+    .then((r) => {
+      const stores = Array.isArray(r) ? r : (r?.content || [])
+      activeStoreCount.value = stores.length
+      storeCardState.value = 'ok'
+    })
+    .catch(() => { storeCardState.value = 'error' })
+
+  // 재고이동 진행 카드 — 이동 API 응답 도착 즉시 갱신
+  transferP
+    .then((r) => {
+      const transfers = Array.isArray(r) ? r : (r?.content || [])
+      inTransitTransferCount.value = transfers.filter(
+        (row) => String(row.status || '').toUpperCase() !== 'ARRIVED',
+      ).length
+      transferCardState.value = 'ok'
+    })
+    .catch(() => { transferCardState.value = 'error' })
+
+  // 4개 모두 끝나면 나머지 영역 집계 + 에러 라벨
+  const results = await Promise.allSettled([companyWideP, purchaseP, transferP, storeP])
   const [companyWideRes, purchaseOrdersRes, transfersRes, storesRes] = results
 
   const companyWide = companyWideRes.status === 'fulfilled' ? companyWideRes.value : null
@@ -107,12 +160,6 @@ const fetchOperationData = async () => {
   const purchaseOrders = Array.isArray(purchaseOrdersRaw)
     ? purchaseOrdersRaw
     : (Array.isArray(purchaseOrdersRaw?.content) ? purchaseOrdersRaw.content : [])
-  const transfers = transfersRes.status === 'fulfilled'
-    ? (Array.isArray(transfersRes.value) ? transfersRes.value : (transfersRes.value?.content || []))
-    : []
-  const stores = storesRes.status === 'fulfilled'
-    ? (Array.isArray(storesRes.value) ? storesRes.value : (storesRes.value?.content || []))
-    : []
 
   const failedLabels = []
   if (companyWideRes.status === 'rejected') failedLabels.push('전사 재고')
@@ -122,8 +169,6 @@ const fetchOperationData = async () => {
   loadError.value = failedLabels.length
     ? `일부 데이터를 불러오지 못했습니다 (${failedLabels.join(', ')}). 네트워크 상태나 BE 상태를 확인해주세요.`
     : ''
-
-  const activeStoreCount = Array.isArray(stores) ? stores.length : 0
 
   const items = Array.isArray(companyWide?.items) ? companyWide.items : []
   const shortages = items
@@ -155,31 +200,7 @@ const fetchOperationData = async () => {
     count: statusCountMap[s.code] || 0,
   }))
 
-  const inTransitTransferCount = (transfers || []).filter(
-    (row) => String(row.status || '').toUpperCase() !== 'ARRIVED',
-  ).length
-
-  kpiOps.value = [
-    {
-      label: '운영 매장 수',
-      value: `${activeStoreCount}`,
-      unit: '곳',
-      caption: storesRes.status === 'fulfilled' ? '상태 ACTIVE 매장' : '불러오기 실패',
-      tone: 'green',
-      route: '/hq/infrastructure',
-      hoverCls: 'hover:border-emerald-400',
-    },
-    {
-      label: '재고이동 진행',
-      value: `${inTransitTransferCount}`,
-      unit: '건',
-      caption: transfersRes.status === 'fulfilled' ? '실시간 · 출고 준비중 + 배송중' : '불러오기 실패',
-      tone: 'blue',
-      route: '/hq/inventory/warehouse-comparison',
-      hoverCls: 'hover:border-blue-400',
-    },
-  ]
-
+  // kpiOps 는 computed 라 별도 할당 불필요 — 각 카드 ref/state 가 이미 갱신됨
   isLoading.value = false
 }
 

--- a/src/views/hq/notification/HqNotificationView.vue
+++ b/src/views/hq/notification/HqNotificationView.vue
@@ -1,0 +1,164 @@
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import { Bell, Filter, RefreshCw } from 'lucide-vue-next'
+import AppLayout from '@/components/common/AppLayout.vue'
+import { roleMenus } from '@/config/roleMenus.js'
+import { useNotificationStore } from '@/stores/notification.js'
+
+const topMenus = roleMenus.hq
+const activeTopMenu = computed(() => '알림')
+
+const notifStore = useNotificationStore()
+const filterMode = ref('all')
+
+const filteredNotifications = computed(() => {
+  if (filterMode.value === 'unread') {
+    return notifStore.notifications.filter((n) => !n.read)
+  }
+  return notifStore.notifications
+})
+
+const unreadCount = computed(() => notifStore.unreadCount)
+const loading = computed(() => notifStore.loading)
+const error = computed(() => notifStore.error)
+
+async function reload() { await notifStore.refresh() }
+async function handleClick(n) {
+  if (!n.read) {
+    try { await notifStore.markAsRead(n.id) } catch { /* ignore */ }
+  }
+}
+async function handleReadAll() {
+  try { await notifStore.markAllAsRead() } catch { /* ignore */ }
+}
+
+function severityBadgeCls(severity) {
+  switch (severity) {
+    case 'CRITICAL': return 'bg-red-100 text-red-700 border-red-300'
+    case 'WARNING':  return 'bg-amber-100 text-amber-700 border-amber-300'
+    default:         return 'bg-sky-100 text-sky-700 border-sky-300'
+  }
+}
+function severityLabel(severity) {
+  switch (severity) {
+    case 'CRITICAL': return '긴급'
+    case 'WARNING':  return '주의'
+    default:         return '정보'
+  }
+}
+function formatDateTime(value) {
+  if (!value) return ''
+  try {
+    const d = new Date(value)
+    return new Intl.DateTimeFormat('ko-KR', {
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit',
+    }).format(d)
+  } catch { return String(value) }
+}
+
+onMounted(() => { notifStore.init() })
+</script>
+
+<template>
+  <AppLayout
+    :top-menus="topMenus"
+    :side-menus="[]"
+    :active-top-menu="activeTopMenu"
+    :active-side-menu="''"
+  >
+    <div class="space-y-3">
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-2">
+          <Bell :size="18" class="text-emerald-700" />
+          <h1 class="text-base font-bold text-gray-900">알림</h1>
+          <span
+            v-if="unreadCount > 0"
+            class="rounded-full bg-red-100 px-2 py-0.5 text-[10px] font-bold text-red-700"
+          >
+            미확인 {{ unreadCount }}
+          </span>
+        </div>
+
+        <div class="flex items-center gap-2">
+          <Filter :size="13" class="text-gray-500" />
+          <button
+            type="button"
+            class="rounded border px-2 py-1 text-[11px] font-semibold transition-colors"
+            :class="filterMode === 'all'
+              ? 'border-emerald-300 bg-emerald-50 text-emerald-700'
+              : 'border-gray-300 bg-white text-gray-600 hover:bg-gray-50'"
+            @click="filterMode = 'all'"
+          >전체</button>
+          <button
+            type="button"
+            class="rounded border px-2 py-1 text-[11px] font-semibold transition-colors"
+            :class="filterMode === 'unread'
+              ? 'border-emerald-300 bg-emerald-50 text-emerald-700'
+              : 'border-gray-300 bg-white text-gray-600 hover:bg-gray-50'"
+            @click="filterMode = 'unread'"
+          >미확인만</button>
+
+          <button
+            type="button"
+            class="ml-1 flex items-center gap-1 rounded border border-gray-300 bg-white px-2 py-1 text-[11px] font-semibold text-gray-600 transition-colors hover:bg-gray-50"
+            :disabled="loading"
+            @click="reload"
+          >
+            <RefreshCw :size="11" :class="{ 'animate-spin': loading }" />
+            새로고침
+          </button>
+
+          <button
+            v-if="unreadCount > 0"
+            type="button"
+            class="rounded border border-emerald-300 bg-emerald-50 px-2 py-1 text-[11px] font-semibold text-emerald-700 transition-colors hover:bg-emerald-100"
+            @click="handleReadAll"
+          >모두 읽음</button>
+        </div>
+      </div>
+
+      <div v-if="error" class="rounded border border-red-200 bg-red-50 px-3 py-2 text-[11px] text-red-700">
+        {{ error }}
+      </div>
+
+      <div class="rounded-lg border border-gray-200 bg-white shadow-sm">
+        <div v-if="loading && filteredNotifications.length === 0" class="p-6 text-center text-xs text-gray-500">
+          불러오는 중…
+        </div>
+
+        <ul v-else-if="filteredNotifications.length > 0" class="divide-y divide-gray-100">
+          <li
+            v-for="n in filteredNotifications"
+            :key="n.id"
+            class="flex cursor-pointer items-start gap-3 px-4 py-3 transition-colors hover:bg-gray-50"
+            :class="{ 'bg-emerald-50/40': !n.read }"
+            @click="handleClick(n)"
+          >
+            <span
+              class="mt-0.5 rounded border px-2 py-0.5 text-[10px] font-bold"
+              :class="severityBadgeCls(n.severity)"
+            >
+              {{ severityLabel(n.severity) }}
+            </span>
+            <div class="min-w-0 flex-1">
+              <p class="truncate text-xs font-semibold text-gray-900">{{ n.title }}</p>
+              <p class="mt-0.5 truncate text-[11px] text-gray-600">{{ n.message }}</p>
+            </div>
+            <div class="flex shrink-0 flex-col items-end gap-1">
+              <span class="text-[10px] text-gray-400">{{ formatDateTime(n.createdAt) }}</span>
+              <span v-if="!n.read" class="rounded-full bg-red-500 px-1.5 py-0.5 text-[9px] font-bold text-white">NEW</span>
+            </div>
+          </li>
+        </ul>
+
+        <div v-else class="flex flex-col items-center justify-center gap-2 p-10 text-center">
+          <Bell :size="32" class="text-gray-300" />
+          <p class="text-xs text-gray-500">
+            {{ filterMode === 'unread' ? '미확인 알림이 없습니다.' : '표시할 알림이 없습니다.' }}
+          </p>
+        </div>
+      </div>
+    </div>
+  </AppLayout>
+</template>

--- a/src/views/store/notification/StoreNotificationView.vue
+++ b/src/views/store/notification/StoreNotificationView.vue
@@ -1,0 +1,164 @@
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import { Bell, Filter, RefreshCw } from 'lucide-vue-next'
+import AppLayout from '@/components/common/AppLayout.vue'
+import { roleMenus } from '@/config/roleMenus.js'
+import { useNotificationStore } from '@/stores/notification.js'
+
+const topMenus = roleMenus.store
+const activeTopMenu = computed(() => '알림')
+
+const notifStore = useNotificationStore()
+const filterMode = ref('all')
+
+const filteredNotifications = computed(() => {
+  if (filterMode.value === 'unread') {
+    return notifStore.notifications.filter((n) => !n.read)
+  }
+  return notifStore.notifications
+})
+
+const unreadCount = computed(() => notifStore.unreadCount)
+const loading = computed(() => notifStore.loading)
+const error = computed(() => notifStore.error)
+
+async function reload() { await notifStore.refresh() }
+async function handleClick(n) {
+  if (!n.read) {
+    try { await notifStore.markAsRead(n.id) } catch { /* ignore */ }
+  }
+}
+async function handleReadAll() {
+  try { await notifStore.markAllAsRead() } catch { /* ignore */ }
+}
+
+function severityBadgeCls(severity) {
+  switch (severity) {
+    case 'CRITICAL': return 'bg-red-100 text-red-700 border-red-300'
+    case 'WARNING':  return 'bg-amber-100 text-amber-700 border-amber-300'
+    default:         return 'bg-sky-100 text-sky-700 border-sky-300'
+  }
+}
+function severityLabel(severity) {
+  switch (severity) {
+    case 'CRITICAL': return '긴급'
+    case 'WARNING':  return '주의'
+    default:         return '정보'
+  }
+}
+function formatDateTime(value) {
+  if (!value) return ''
+  try {
+    const d = new Date(value)
+    return new Intl.DateTimeFormat('ko-KR', {
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit',
+    }).format(d)
+  } catch { return String(value) }
+}
+
+onMounted(() => { notifStore.init() })
+</script>
+
+<template>
+  <AppLayout
+    :top-menus="topMenus"
+    :side-menus="[]"
+    :active-top-menu="activeTopMenu"
+    :active-side-menu="''"
+  >
+    <div class="space-y-3">
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-2">
+          <Bell :size="18" class="text-emerald-700" />
+          <h1 class="text-base font-bold text-gray-900">알림</h1>
+          <span
+            v-if="unreadCount > 0"
+            class="rounded-full bg-red-100 px-2 py-0.5 text-[10px] font-bold text-red-700"
+          >
+            미확인 {{ unreadCount }}
+          </span>
+        </div>
+
+        <div class="flex items-center gap-2">
+          <Filter :size="13" class="text-gray-500" />
+          <button
+            type="button"
+            class="rounded border px-2 py-1 text-[11px] font-semibold transition-colors"
+            :class="filterMode === 'all'
+              ? 'border-emerald-300 bg-emerald-50 text-emerald-700'
+              : 'border-gray-300 bg-white text-gray-600 hover:bg-gray-50'"
+            @click="filterMode = 'all'"
+          >전체</button>
+          <button
+            type="button"
+            class="rounded border px-2 py-1 text-[11px] font-semibold transition-colors"
+            :class="filterMode === 'unread'
+              ? 'border-emerald-300 bg-emerald-50 text-emerald-700'
+              : 'border-gray-300 bg-white text-gray-600 hover:bg-gray-50'"
+            @click="filterMode = 'unread'"
+          >미확인만</button>
+
+          <button
+            type="button"
+            class="ml-1 flex items-center gap-1 rounded border border-gray-300 bg-white px-2 py-1 text-[11px] font-semibold text-gray-600 transition-colors hover:bg-gray-50"
+            :disabled="loading"
+            @click="reload"
+          >
+            <RefreshCw :size="11" :class="{ 'animate-spin': loading }" />
+            새로고침
+          </button>
+
+          <button
+            v-if="unreadCount > 0"
+            type="button"
+            class="rounded border border-emerald-300 bg-emerald-50 px-2 py-1 text-[11px] font-semibold text-emerald-700 transition-colors hover:bg-emerald-100"
+            @click="handleReadAll"
+          >모두 읽음</button>
+        </div>
+      </div>
+
+      <div v-if="error" class="rounded border border-red-200 bg-red-50 px-3 py-2 text-[11px] text-red-700">
+        {{ error }}
+      </div>
+
+      <div class="rounded-lg border border-gray-200 bg-white shadow-sm">
+        <div v-if="loading && filteredNotifications.length === 0" class="p-6 text-center text-xs text-gray-500">
+          불러오는 중…
+        </div>
+
+        <ul v-else-if="filteredNotifications.length > 0" class="divide-y divide-gray-100">
+          <li
+            v-for="n in filteredNotifications"
+            :key="n.id"
+            class="flex cursor-pointer items-start gap-3 px-4 py-3 transition-colors hover:bg-gray-50"
+            :class="{ 'bg-emerald-50/40': !n.read }"
+            @click="handleClick(n)"
+          >
+            <span
+              class="mt-0.5 rounded border px-2 py-0.5 text-[10px] font-bold"
+              :class="severityBadgeCls(n.severity)"
+            >
+              {{ severityLabel(n.severity) }}
+            </span>
+            <div class="min-w-0 flex-1">
+              <p class="truncate text-xs font-semibold text-gray-900">{{ n.title }}</p>
+              <p class="mt-0.5 truncate text-[11px] text-gray-600">{{ n.message }}</p>
+            </div>
+            <div class="flex shrink-0 flex-col items-end gap-1">
+              <span class="text-[10px] text-gray-400">{{ formatDateTime(n.createdAt) }}</span>
+              <span v-if="!n.read" class="rounded-full bg-red-500 px-1.5 py-0.5 text-[9px] font-bold text-white">NEW</span>
+            </div>
+          </li>
+        </ul>
+
+        <div v-else class="flex flex-col items-center justify-center gap-2 p-10 text-center">
+          <Bell :size="32" class="text-gray-300" />
+          <p class="text-xs text-gray-500">
+            {{ filterMode === 'unread' ? '미확인 알림이 없습니다.' : '표시할 알림이 없습니다.' }}
+          </p>
+        </div>
+      </div>
+    </div>
+  </AppLayout>
+</template>

--- a/src/views/warehouse/notification/WarehouseNotificationView.vue
+++ b/src/views/warehouse/notification/WarehouseNotificationView.vue
@@ -1,0 +1,164 @@
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import { Bell, Filter, RefreshCw } from 'lucide-vue-next'
+import AppLayout from '@/components/common/AppLayout.vue'
+import { roleMenus } from '@/config/roleMenus.js'
+import { useNotificationStore } from '@/stores/notification.js'
+
+const topMenus = roleMenus.warehouse
+const activeTopMenu = computed(() => '알림')
+
+const notifStore = useNotificationStore()
+const filterMode = ref('all')
+
+const filteredNotifications = computed(() => {
+  if (filterMode.value === 'unread') {
+    return notifStore.notifications.filter((n) => !n.read)
+  }
+  return notifStore.notifications
+})
+
+const unreadCount = computed(() => notifStore.unreadCount)
+const loading = computed(() => notifStore.loading)
+const error = computed(() => notifStore.error)
+
+async function reload() { await notifStore.refresh() }
+async function handleClick(n) {
+  if (!n.read) {
+    try { await notifStore.markAsRead(n.id) } catch { /* ignore */ }
+  }
+}
+async function handleReadAll() {
+  try { await notifStore.markAllAsRead() } catch { /* ignore */ }
+}
+
+function severityBadgeCls(severity) {
+  switch (severity) {
+    case 'CRITICAL': return 'bg-red-100 text-red-700 border-red-300'
+    case 'WARNING':  return 'bg-amber-100 text-amber-700 border-amber-300'
+    default:         return 'bg-sky-100 text-sky-700 border-sky-300'
+  }
+}
+function severityLabel(severity) {
+  switch (severity) {
+    case 'CRITICAL': return '긴급'
+    case 'WARNING':  return '주의'
+    default:         return '정보'
+  }
+}
+function formatDateTime(value) {
+  if (!value) return ''
+  try {
+    const d = new Date(value)
+    return new Intl.DateTimeFormat('ko-KR', {
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit',
+    }).format(d)
+  } catch { return String(value) }
+}
+
+onMounted(() => { notifStore.init() })
+</script>
+
+<template>
+  <AppLayout
+    :top-menus="topMenus"
+    :side-menus="[]"
+    :active-top-menu="activeTopMenu"
+    :active-side-menu="''"
+  >
+    <div class="space-y-3">
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-2">
+          <Bell :size="18" class="text-emerald-700" />
+          <h1 class="text-base font-bold text-gray-900">알림</h1>
+          <span
+            v-if="unreadCount > 0"
+            class="rounded-full bg-red-100 px-2 py-0.5 text-[10px] font-bold text-red-700"
+          >
+            미확인 {{ unreadCount }}
+          </span>
+        </div>
+
+        <div class="flex items-center gap-2">
+          <Filter :size="13" class="text-gray-500" />
+          <button
+            type="button"
+            class="rounded border px-2 py-1 text-[11px] font-semibold transition-colors"
+            :class="filterMode === 'all'
+              ? 'border-emerald-300 bg-emerald-50 text-emerald-700'
+              : 'border-gray-300 bg-white text-gray-600 hover:bg-gray-50'"
+            @click="filterMode = 'all'"
+          >전체</button>
+          <button
+            type="button"
+            class="rounded border px-2 py-1 text-[11px] font-semibold transition-colors"
+            :class="filterMode === 'unread'
+              ? 'border-emerald-300 bg-emerald-50 text-emerald-700'
+              : 'border-gray-300 bg-white text-gray-600 hover:bg-gray-50'"
+            @click="filterMode = 'unread'"
+          >미확인만</button>
+
+          <button
+            type="button"
+            class="ml-1 flex items-center gap-1 rounded border border-gray-300 bg-white px-2 py-1 text-[11px] font-semibold text-gray-600 transition-colors hover:bg-gray-50"
+            :disabled="loading"
+            @click="reload"
+          >
+            <RefreshCw :size="11" :class="{ 'animate-spin': loading }" />
+            새로고침
+          </button>
+
+          <button
+            v-if="unreadCount > 0"
+            type="button"
+            class="rounded border border-emerald-300 bg-emerald-50 px-2 py-1 text-[11px] font-semibold text-emerald-700 transition-colors hover:bg-emerald-100"
+            @click="handleReadAll"
+          >모두 읽음</button>
+        </div>
+      </div>
+
+      <div v-if="error" class="rounded border border-red-200 bg-red-50 px-3 py-2 text-[11px] text-red-700">
+        {{ error }}
+      </div>
+
+      <div class="rounded-lg border border-gray-200 bg-white shadow-sm">
+        <div v-if="loading && filteredNotifications.length === 0" class="p-6 text-center text-xs text-gray-500">
+          불러오는 중…
+        </div>
+
+        <ul v-else-if="filteredNotifications.length > 0" class="divide-y divide-gray-100">
+          <li
+            v-for="n in filteredNotifications"
+            :key="n.id"
+            class="flex cursor-pointer items-start gap-3 px-4 py-3 transition-colors hover:bg-gray-50"
+            :class="{ 'bg-emerald-50/40': !n.read }"
+            @click="handleClick(n)"
+          >
+            <span
+              class="mt-0.5 rounded border px-2 py-0.5 text-[10px] font-bold"
+              :class="severityBadgeCls(n.severity)"
+            >
+              {{ severityLabel(n.severity) }}
+            </span>
+            <div class="min-w-0 flex-1">
+              <p class="truncate text-xs font-semibold text-gray-900">{{ n.title }}</p>
+              <p class="mt-0.5 truncate text-[11px] text-gray-600">{{ n.message }}</p>
+            </div>
+            <div class="flex shrink-0 flex-col items-end gap-1">
+              <span class="text-[10px] text-gray-400">{{ formatDateTime(n.createdAt) }}</span>
+              <span v-if="!n.read" class="rounded-full bg-red-500 px-1.5 py-0.5 text-[9px] font-bold text-white">NEW</span>
+            </div>
+          </li>
+        </ul>
+
+        <div v-else class="flex flex-col items-center justify-center gap-2 p-10 text-center">
+          <Bell :size="32" class="text-gray-300" />
+          <p class="text-xs text-gray-500">
+            {{ filterMode === 'unread' ? '미확인 알림이 없습니다.' : '표시할 알림이 없습니다.' }}
+          </p>
+        </div>
+      </div>
+    </div>
+  </AppLayout>
+</template>


### PR DESCRIPTION
## 📌 요약
- 권한별(HQ/STORE/WAREHOUSE) 알림 UI 및 SSE 실시간 구독 통합
- 본사 대시보드 KPI 카드 비동기 로딩 개선(재고이동/운영 매장 수 지연 표시 이슈 해소)

<br><br>

## 🎯 작업 내용
- 알림 API/스토어 신규
  - `src/api/notification.js` — REST 4종(목록/단건 읽음/전체 읽음/미읽음 수) + `subscribeNotificationStream` (EventSource, `withCredentials`)
  - `src/stores/notification.js` — Pinia 스토어: 목록·미읽음 수 관리, SSE 구독/해제(`init` / `dispose`)
- 인증 연동
  - `src/stores/auth.js` — 로그인 시 `notification.init()`, 로그아웃 시 `notification.dispose()` 훅
  - `src/App.vue` — F5 새로고침 시 인증 복원 후 알림 스토어 재초기화
- 헤더 종 아이콘 + 드롭다운
  - `src/components/common/AppLayout.vue` — ESG 대시보드 버튼 우측에 종 아이콘, 미읽음 수 뱃지, 클릭 시 미니 드롭다운 + “모두 보기” 진입
- 권한별 메뉴/라우트
  - `src/config/roleMenus.js` — HQ/STORE/WAREHOUSE 사이드바 메뉴에 알림 항목 추가
  - `src/router/index.js` — `/hq/notification`, `/store/notification`, `/warehouse/notification` 라우트
  - `src/views/{hq,store,warehouse}/notification/` — 권한별 알림 페이지(목록 + 필터 + 읽음 처리)
- 본사 대시보드 KPI 카드 비동기 로딩 분리
  - `src/views/hq/dashboard/OperationStatusView.vue` — “재고이동” / “운영 매장 수” 카드가 다른 카드보다 늦게 뜨는 문제 → 카드별 독립 fetch + 개별 로딩 상태로 리팩토링

<br><br>

## ✔️ 참고 사항
- 호출 방식: 기존 컨벤션대로 axios 사용(HttpOnly 쿠키 인증). SSE만 EventSource(`withCredentials: true`)
- 로그아웃/만료 시 EventSource 명시적 close — 의미 없는 재연결 방지
- 알림 뱃지 카운트는 SSE 수신 시 즉시 증가, 읽음 처리 시 즉시 감소(낙관적 갱신)
- BE PR 머지 후 develop 머지 권장 — 알림 API 미반영 상태에서 본 PR 머지 시 SSE 연결 실패 로그 발생 가능
- KPI 카드 비동기 분리는 알림 작업 중 발견된 사이드 이슈로, 별도 커밋(`refactor(hq-dashboard)`)으로 분리

<br><br>

## ✔️ 관련 이슈

- Close #485 
