### PR TITLE
fix(hq-purchase-order): 발주 배치 후 화면 stale + warehouseStock 시드 의존 정정

### DIFF
--- a/src/api/hq/purchaseOrder.js
+++ b/src/api/hq/purchaseOrder.js
@@ -66,8 +66,9 @@ export const purchaseOrderApi = {
 
   /**
    * SYS-001 강제 트리거 — 시연·QA·장애 대응용.
-   * 30분 대기 조건을 무시하고 PENDING/APPROVED 모두 즉시 다음 단계로 자동 전환.
-   * @returns {Promise<{approved: number, shipping: number}>}
+   * 시간 조건(wait-minutes) 무시하고 거래처 책임 4단계(REQUESTED/APPROVED/READY_TO_SHIP/IN_TRANSIT)
+   * 모두 즉시 다음 단계로 자동 전환.
+   * @returns {Promise<{approved: number, readyToShip: number, inTransit: number, arrived: number}>}
    */
   runBatch: () => apiClient.post(`${BASE}/batch/run`).then(unwrap),
 

--- a/src/components/hq/purchase-order/PurchaseOrderCatalog.vue
+++ b/src/components/hq/purchase-order/PurchaseOrderCatalog.vue
@@ -29,7 +29,6 @@ const emit = defineEmits(['add-sku-to-cart', 'add-group-to-cart', 'scroll-to-car
 
 const poStore = usePurchaseOrderStore()
 const {
-  stockStore,
   rowStock,
   rowStockLevel,
   rowSuggested,
@@ -121,10 +120,10 @@ const skuRows = computed(() => catalogRows.value)
 
 const matchedSkuCount = computed(() => poStore.catalogTotalElements)
 
+// 카탈로그 응답에 safetyStock 미포함 — 품절(availableQty === 0) row 개수만 카운트.
 const shortageCount = computed(() => {
   if (!props.selectedWarehouseCode) return 0
-  const skuCodes = catalogRows.value.map((r) => r.skuCode)
-  return stockStore.getSkuShortageCount(props.selectedWarehouseCode, skuCodes)
+  return catalogRows.value.filter((r) => Number(r.availableQty ?? 0) === 0).length
 })
 
 function isInCart(skuCode) {
@@ -364,14 +363,9 @@ void emit
               <td
                 class="px-2 py-2 text-right align-middle font-bold"
                 :class="stockLevelClass(rowStockLevel(row.skuCode))"
-                :title="
-                  rowStock(row.skuCode)
-                    ? `실재고 ${rowStock(row.skuCode).onHand} · 안전 ${rowStock(row.skuCode).safetyStock}`
-                    : `BE 가용 ${row.availableQty}`
-                "
+                :title="`가용재고 ${row.availableQty}`"
               >
-                <template v-if="rowStock(row.skuCode)">{{ rowStock(row.skuCode).available }}</template>
-                <template v-else>{{ row.availableQty }}</template>
+                {{ row.availableQty }}
               </td>
               <td class="px-2 py-2 text-right align-middle">
                 <template v-if="rowStock(row.skuCode)">

--- a/src/composables/hq/purchaseOrder/useStockSim.js
+++ b/src/composables/hq/purchaseOrder/useStockSim.js
@@ -1,56 +1,79 @@
-import { useWarehouseStockStore } from '@/stores/warehouse/warehouseStock.js'
+import { computed } from 'vue'
+import { usePurchaseOrderStore } from '@/stores/purchaseOrder.js'
 
-// 카탈로그 행이 SKU 단위라 행마다 가용/실/안전/권장 4값 노출.
-// 인벤토리 SKU BE 합류 시 store 의 시뮬레이션 함수만 axios 로 교체하면 view 수정 0.
-export function usePurchaseOrderStockSim(selectedWarehouseCode) {
-  const stockStore = useWarehouseStockStore()
+/**
+ * 본사 발주 카탈로그 행의 재고 보조 함수.
+ *
+ * 입력은 BE `PurchaseOrderCatalogRepository.findCatalogPage` 응답의 SKU 평탄 row.
+ * 가용재고(`row.availableQty`)는 BE 가 `inventory_status='NORMAL'` + 선택 창고 SUM 으로
+ * 정확히 산출 (`PurchaseOrderCatalogRepository.java:35-43`). FE 는 그 값으로만 평가.
+ *
+ * 안전재고(`safetyStock`)는 BE catalog 응답에 없음 — `availableQty === 0` 만 품절로
+ * 단순 평가하는 2단계 (품절/정상). 추후 BE 가 `warehouseSafetyStock` 을 응답에 추가하면
+ * 본 composable 만 정교화 — 호출자 시그니처 유지.
+ *
+ * 호출자 시그니처: `usePurchaseOrderStockSim(selectedWarehouseCode)` 그대로 (호환).
+ * 단 선택 창고 변수는 본 composable 안에서 직접 사용하지 않음 — BE 가 store.catalogRows
+ * 응답 시점에 이미 그 창고 한정 `availableQty` 를 박아 보내기 때문.
+ */
+export function usePurchaseOrderStockSim(_selectedWarehouseCode) {
+  const poStore = usePurchaseOrderStore()
+
+  // skuCode → catalog row Map (lookup O(1))
+  const rowsBySku = computed(() => {
+    const map = new Map()
+    for (const row of poStore.catalogRows ?? []) {
+      if (row?.skuCode) map.set(row.skuCode, row)
+    }
+    return map
+  })
 
   function rowStock(skuCode) {
-    if (!selectedWarehouseCode.value || !skuCode) return null
-    return stockStore.getSkuStock(selectedWarehouseCode.value, skuCode)
+    const row = rowsBySku.value.get(skuCode)
+    if (!row) return null
+    // safetyStock 은 catalog 응답 미포함 — null 로 명시. 호출자는 ?? 0 패턴.
+    return {
+      onHand: null,
+      available: Number(row.availableQty ?? 0),
+      safetyStock: null,
+    }
   }
 
   function rowStockLevel(skuCode) {
-    return stockStore.getSkuStockLevel(rowStock(skuCode))
+    const stock = rowStock(skuCode)
+    if (!stock) return 'unknown'
+    return stock.available === 0 ? 'critical' : 'normal'
   }
 
-  function rowSuggested(skuCode) {
-    return stockStore.getSkuSuggestedQuantity(rowStock(skuCode))
+  // 안전재고 미상이라 추천 불가 — 0 반환 시 PurchaseOrderCatalog 의 "권장" 버튼 자동 숨김.
+  function rowSuggested(_skuCode) {
+    return 0
   }
 
-  // 재고 숫자 색상은 항상 중립 회색 — 부족/주의/품절 상태는 별도 "상태" 컬럼 칩이 담당.
-  // level 인자는 호환을 위해 받지만 사용 안 함.
+  // 재고 숫자 색상은 중립 회색 — 상태 칩이 시각화 담당.
   function stockLevelClass(_level) {
     return 'text-gray-700'
   }
 
-  // 상태 칩 — 매장 발주 요청 페이지(StoreOrderRequestView) 의 패턴을 본사용으로 확장.
-  // stockStore 의 stockLevel(critical/warning/normal) + available 0 분리해 4단계.
+  // 상태 칩 — 품절(available 0) / 정상 2단계.
   function statusChipForSku(skuCode) {
     const stock = rowStock(skuCode)
     if (!stock) return null
     if (stock.available === 0) {
       return { label: '품절', class: 'bg-red-100 text-red-700' }
     }
-    const level = stockStore.getSkuStockLevel(stock)
-    if (level === 'critical') return { label: '부족', class: 'bg-orange-100 text-orange-700' }
-    if (level === 'warning') return { label: '주의', class: 'bg-yellow-50 text-yellow-700' }
     return { label: '정상', class: 'bg-[#EBF5F5] text-gray-700' }
   }
 
-  // 부족 SKU 우선 정렬용 rank — 작을수록 위로.
+  // 부족 SKU 우선 정렬 rank — 품절(0) / 정상(3).
   function shortageRank(skuCode) {
     const stock = rowStock(skuCode)
     if (!stock) return 4
     if (stock.available === 0) return 0
-    const level = stockStore.getSkuStockLevel(stock)
-    if (level === 'critical') return 1
-    if (level === 'warning') return 2
     return 3
   }
 
   return {
-    stockStore,
     rowStock,
     rowStockLevel,
     rowSuggested,

--- a/src/stores/purchaseOrder.js
+++ b/src/stores/purchaseOrder.js
@@ -254,12 +254,19 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
       // BE 가 Page<ListRes> (po-list-pagination-be) 또는 List 둘 다 대응.
       // 페이지네이션 UI 도입은 별 phase 책임 — 일단 첫 페이지 데이터만 표시.
       const list = Array.isArray(res) ? res : (res?.content ?? [])
-      // ListRes 는 items/statusHistory 미포함 — 빈 배열로 채워둠
-      purchaseOrders.value = list.map((o) => ({
-        ...toFeOrder(o),
-        items: [],
-        statusHistory: [],
-      }))
+      // detail fetch 로 이미 채워진 items/statusHistory 는 list 응답에 미포함 →
+      // 통째 reassign 시 덮어쓰지 않도록 prev 캐시 merge. 신규 발주 직후 selectOrder →
+      // fetchDetail prepend 와 View 마운트 fetchOrders 의 race 보호.
+      const prevMap = new Map(purchaseOrders.value.map((o) => [o.id, o]))
+      purchaseOrders.value = list.map((o) => {
+        const fe = toFeOrder(o)
+        const prev = prevMap.get(fe.id)
+        return {
+          ...fe,
+          items: prev?.items?.length ? prev.items : [],
+          statusHistory: prev?.statusHistory?.length ? prev.statusHistory : [],
+        }
+      })
     } catch (e) {
       error.value = e?.message ?? '발주 목록을 불러오지 못했습니다.'
       console.error('[purchaseOrder] fetchOrders 실패', e)
@@ -292,15 +299,30 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
 
   function selectOrder(id) {
     selectedOrderId.value = id
-    if (id) {
-      // 상세 정보(items/statusHistory) 가 비어있으면 fetch
-      const order = purchaseOrders.value.find((o) => o.id === id)
-      if (order && (order.items.length === 0 || order.statusHistory.length === 0)) {
-        fetchDetail(id).catch(() => {
-          // fetchDetail 안에서 이미 처리
-        })
-      }
+    if (!id) return
+    // 상세 fetch 조건:
+    //   1) store 에 order 가 아직 없음 (신규 batch 생성 직후 — cartStore.createBatch 는 poStore push 안 함)
+    //   2) order 는 있지만 list 응답이라 items/statusHistory 깡통
+    // fetchDetail 은 idx < 0 일 때 prepend 로 push 하므로 두 경우 모두 안전.
+    const order = purchaseOrders.value.find((o) => o.id === id)
+    if (!order || order.items.length === 0 || order.statusHistory.length === 0) {
+      fetchDetail(id).catch(() => {
+        // fetchDetail 안에서 이미 처리
+      })
     }
+  }
+
+  /**
+   * BE batch 응답(DetailRes[]) 을 store 에 직접 흡수.
+   * createBatch 응답은 items + statusHistory 까지 완전 — 별도 fetchDetail 불필요.
+   * 같은 id 가 이미 있으면 교체, 없으면 prepend. 정렬은 filteredOrders 가 담당.
+   */
+  function ingestOrders(beOrders) {
+    if (!Array.isArray(beOrders) || beOrders.length === 0) return
+    const incoming = beOrders.map(toFeOrder).filter(Boolean)
+    const incomingIds = new Set(incoming.map((o) => o.id))
+    const kept = purchaseOrders.value.filter((o) => !incomingIds.has(o.id))
+    purchaseOrders.value = [...incoming, ...kept]
   }
 
   async function createOrder(payload) {
@@ -343,7 +365,11 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
   async function runBatch() {
     try {
       const result = await purchaseOrderApi.runBatch()
-      const changed = (result?.approved ?? 0) + (result?.shipping ?? 0)
+      const changed =
+        (result?.approved ?? 0) +
+        (result?.readyToShip ?? 0) +
+        (result?.inTransit ?? 0) +
+        (result?.arrived ?? 0)
       if (changed > 0) {
         await fetchOrders()
         if (selectedOrderId.value) {
@@ -414,6 +440,7 @@ export const usePurchaseOrderStore = defineStore('purchaseOrder', () => {
     selectOrder,
     fetchOrders,
     fetchDetail,
+    ingestOrders,
     fetchWarehouses,
     createOrder,
     updateOrder,

--- a/src/stores/warehouse/warehouseStock.js
+++ b/src/stores/warehouse/warehouseStock.js
@@ -1,96 +1,117 @@
 import { defineStore } from 'pinia'
-import { usePurchaseOrderStore } from '../purchaseOrder.js'
+import { ref } from 'vue'
+import {
+  getWarehouseInventories,
+  getWarehouseInventorySkus,
+} from '@/api/warehouse/inventory.js'
 
 /**
- * 발주 카탈로그 전용 창고-제품 재고 store.
+ * 창고 권한군 화면 전용 재고 캐시 store.
  *
- * 김사라 작품 `stores/inventory.js`(SKU 단위, 단일 창고)는 손대지 않고,
- * 본사 발주 카탈로그(`HqPurchaseOrderCreateView`) 가 "선택된 창고에서 이 ProductMaster
- * 의 재고가 얼마인지" 를 빨리 보여주기 위한 별 store. 다중 창고 × productCode lookup.
+ * BE `/api/warehouse/inventories` + `/skus` 응답을 캐시. BE 가 자기 창고 한정 응답이므로
+ * (`@AuthenticationPrincipal.locationCode` 로 결정) 단일 자기 창고 캐시로 충분 —
+ * warehouseId 인자는 호출자 시그니처 호환을 위해 받지만 lookup 키로는 사용하지 않는다.
  *
- * 재고 정의 (사용자 합의):
- *   - 실재고 (onHand)     = 현재 보유 — 시드 정적 값
- *   - 안전재고 (safetyStock) = 이 밑으로 떨어지면 안 됨 — 시드 정적 값
- *   - 가용재고 (available)  = onHand + incoming - outgoing — 동적
- *     · incoming = `purchaseOrder` store 의 SHIPPING 발주 중 같은 (warehouseId, productCode)
- *                  의 quantity 합 (시연 시 발주가 SHIPPING 으로 가면 가용재고 자동 증가)
- *     · outgoing = 0 (매장 주문/출고 도메인 미구현 — Phase 1 모킹)
+ * 재고 의미 (BE 응답 → store 필드):
+ *   actualStock    → onHand    (실재고)
+ *   availableStock → available  (가용재고)
+ *   safetyStock    → safetyStock (안전재고)
  *
- * BE 미구현 — inventory + warehouse-stock 도메인 BE 가 만들어지면 이 store 를 axios 로 교체한다.
- *
- * productCode 시드 전략:
- *   - 알려진 시연 의도 값은 KNOWN_SEEDS hard-code
- *   - 그 외는 productCode + warehouseId 해시 기반 deterministic default — 새로고침해도 같은 값
+ * 본사 발주 카탈로그(`PurchaseOrderCatalog`) 는 본 store 의존하지 않는다 —
+ * 본사 권한군이라 `/api/warehouse/inventories` 호출 불가. 카탈로그는 BE catalog
+ * 응답의 `row.availableQty` 단독으로 평가 (`useStockSim` composable 참조).
  */
-
-const KNOWN_SEEDS = {
-  // 'WH-001:PM-0001': { onHand: 50, safetyStock: 10 },
-}
-
-const WAREHOUSE_FACTORS = {
-  'WH-001': 1.4, // 서울 1센터 — 가장 많이 비축
-  'WH-002': 1.0, // 인천 제1센터
-  'WH-003': 0.8, // 경기 남부센터
-  'WH-004': 0.6, // 부산 물류센터
-  'WH-005': 0.5, // 대구 통합센터 — 가장 적게 비축
-}
-
-function hashSeed(s) {
-  let h = 5381
-  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) >>> 0
-  return h
-}
-
-function defaultStock(warehouseId, productCode) {
-  const seed = hashSeed(`${warehouseId}|${productCode}`)
-  const factor = WAREHOUSE_FACTORS[warehouseId] ?? 1.0
-  const onHand = Math.round(((seed % 80) + 5) * factor)
-  const safetyStock = 5 + ((seed >> 8) % 11) // 5~15
-  return { onHand, safetyStock }
-}
-
 export const useWarehouseStockStore = defineStore('warehouseStock', () => {
-  const poStore = usePurchaseOrderStore()
-
-  function getBaseStock(warehouseId, productCode) {
-    if (!warehouseId || !productCode) return null
-    const key = `${warehouseId}:${productCode}`
-    return KNOWN_SEEDS[key] ?? defaultStock(warehouseId, productCode)
-  }
+  // productCode → { onHand, available, safetyStock }
+  const productStocks = ref(new Map())
+  // skuCode → { onHand, available, safetyStock }
+  const skuStocks = ref(new Map())
+  const productLoaded = ref(false)
+  const skuLoaded = ref(false)
+  const loading = ref(false)
+  const error = ref(null)
 
   /**
-   * 가용재고 = onHand + incoming - outgoing
-   * - incoming = SHIPPING 발주 중 같은 (warehouseId, productCode) 의 quantity 합
-   * - outgoing = 0 (매장 주문 도메인 미구현)
+   * 자기 창고 ProductMaster 단위 재고 fetch. warehouseId 는 시그니처 호환만 — BE 가
+   * locationCode 로 자기 창고 결정. 첫 호출 시만 BE call, 이후 캐시 hit no-op.
+   * page=0, size=1000 — 한 창고 상품 수가 1000 미만이라 단일 페이지로 충분.
    */
-  function getStock(warehouseId, productCode) {
-    const base = getBaseStock(warehouseId, productCode)
-    if (!base) return null
+  async function loadProductStocks(_warehouseId) {
+    if (productLoaded.value) return
+    loading.value = true
+    error.value = null
+    try {
+      const res = await getWarehouseInventories({ page: 0, size: 1000 })
+      const items = Array.isArray(res?.items) ? res.items : []
+      const next = new Map()
+      for (const row of items) {
+        next.set(row.itemCode, {
+          onHand: Number(row.actualStock ?? 0),
+          available: Number(row.availableStock ?? 0),
+          safetyStock: Number(row.safetyStock ?? 0),
+        })
+      }
+      productStocks.value = next
+      productLoaded.value = true
+    } catch (e) {
+      error.value = e?.message ?? '창고 재고를 불러오지 못했습니다.'
+      console.error('[warehouseStock] loadProductStocks 실패', e)
+    } finally {
+      loading.value = false
+    }
+  }
 
-    const incoming = poStore.purchaseOrders
-      .filter((o) => o.status === 'IN_TRANSIT' && o.warehouseId === warehouseId)
-      .flatMap((o) => o.items ?? [])
-      .filter((it) => it.productCode === productCode)
-      .reduce((sum, it) => sum + (Number(it.quantity) || 0), 0)
-
-    const outgoing = 0
-    const available = base.onHand + incoming - outgoing
-
-    return {
-      onHand: base.onHand,
-      safetyStock: base.safetyStock,
-      incoming,
-      outgoing,
-      available,
+  async function loadSkuStocks(_warehouseId) {
+    if (skuLoaded.value) return
+    loading.value = true
+    error.value = null
+    try {
+      const res = await getWarehouseInventorySkus({ page: 0, size: 1000 })
+      const items = Array.isArray(res?.items) ? res.items : []
+      const next = new Map()
+      for (const row of items) {
+        next.set(row.skuCode, {
+          onHand: Number(row.actualStock ?? 0),
+          available: Number(row.availableStock ?? 0),
+          safetyStock: Number(row.safetyStock ?? 0),
+        })
+      }
+      skuStocks.value = next
+      skuLoaded.value = true
+    } catch (e) {
+      error.value = e?.message ?? 'SKU 재고를 불러오지 못했습니다.'
+      console.error('[warehouseStock] loadSkuStocks 실패', e)
+    } finally {
+      loading.value = false
     }
   }
 
   /**
+   * 입고 확정·발주 배치 등 mutation 직후 호출. 다음 load 시 자동 refetch.
+   * warehouseId 인자는 시그니처 호환만.
+   */
+  function invalidate(_warehouseId) {
+    productLoaded.value = false
+    skuLoaded.value = false
+    productStocks.value = new Map()
+    skuStocks.value = new Map()
+  }
+
+  function getStock(_warehouseId, productCode) {
+    if (!productCode) return null
+    return productStocks.value.get(productCode) ?? null
+  }
+
+  function getSkuStock(_warehouseId, skuCode) {
+    if (!skuCode) return null
+    return skuStocks.value.get(skuCode) ?? null
+  }
+
+  /**
    * 경고 임계 — 가용재고(available) 기준.
-   * 발주 결정은 "입고예정 합쳐도 부족인가" 가 핵심이라 available 로 통일 (직전 사이클의 onHand 기준에서 정련).
-   *   available < safetyStock        → 'critical' (위험, 빨강)
-   *   available < safetyStock × 1.5  → 'warning'  (주의, 주황)
-   *   그 외                           → 'normal'   (정상, 회색)
+   *   available < safetyStock        → 'critical'
+   *   available < safetyStock × 1.5  → 'warning'
+   *   그 외                           → 'normal'
    */
   function getStockLevel(stock) {
     if (!stock) return 'unknown'
@@ -99,11 +120,6 @@ export const useWarehouseStockStore = defineStore('warehouseStock', () => {
     return 'normal'
   }
 
-  /**
-   * 권장 발주 수량 — 안전재고 × 1.5 까지 채우는 만큼.
-   * 부족 아닌 행(가용재고 ≥ safetyStock × 1.5) 은 0 반환. 음수 절대 0 으로 clamp.
-   * 셀 클릭 시 cart 수량을 이 값으로 덮어쓰기 (set 모드).
-   */
   function getSuggestedQuantity(stock) {
     if (!stock) return 0
     const target = stock.safetyStock * 1.5
@@ -112,30 +128,30 @@ export const useWarehouseStockStore = defineStore('warehouseStock', () => {
     return Math.ceil(need)
   }
 
-  /**
-   * 부족 품목 수 — 입력된 productCode 목록 중 안전재고 미달 (critical/warning) 행의 개수.
-   * 창고 대시보드 KPI / 발주 카탈로그 토글 헤더 카운트에서 활용.
-   */
-  function getShortageCount(warehouseId, productCodes = []) {
-    if (!warehouseId || !productCodes.length) return 0
+  function getShortageCount(_warehouseId, productCodes = []) {
+    if (!productCodes.length) return 0
     let count = 0
     for (const pc of productCodes) {
-      const level = getStockLevel(getStock(warehouseId, pc))
+      const level = getStockLevel(getStock(null, pc))
       if (level === 'critical' || level === 'warning') count++
     }
     return count
   }
 
   /**
-   * 입고 확정 후 재고 변화 미리보기 — 한 발주의 items 배열을 받아 품목별 변화 산출.
-   * @returns {Array<{productCode, productName, quantity, before:{onHand,available,safetyStock},
-   *                  after:{onHand,available}, shortageAfter:boolean}>}
-   *   shortageAfter = 입고 후에도 onHand 가 safetyStock 미달인지.
+   * 입고 확정 미리보기 — 발주 items 배열을 받아 품목별 변화 산출.
+   * SKU 단위 lookup (skuCode) — 발주 라인이 SKU 단위라 productCode(master 합산)
+   * 으로 보면 다른 색상·사이즈의 재고까지 섞여 표기됨.
+   * before = 현재 onHand/available/safetyStock.
+   * after.onHand    = before.onHand + qty      (실재고 합류)
+   * after.available = before.available         (SHIPPING 시 선반영분 유지 — ADR-024 정정 의도)
+   *
+   * 캐시 미스 시 null before/after — 화면이 그래시 처리.
    */
   function getInboundPreview(warehouseId, items = []) {
-    if (!warehouseId || !items.length) return []
+    if (!items.length) return []
     return items.map((it) => {
-      const stock = getStock(warehouseId, it.productCode)
+      const stock = getSkuStock(warehouseId, it.skuCode)
       if (!stock) {
         return {
           productCode: it.productCode,
@@ -148,9 +164,6 @@ export const useWarehouseStockStore = defineStore('warehouseStock', () => {
       }
       const qty = Number(it.quantity) || 0
       const afterOnHand = stock.onHand + qty
-      // 입고 확정 = onHand 증가 + incoming 감소(이 발주분이 더 이상 SHIPPING 아님 — 단, 현재 시연 시드는
-      //   DELIVERED 상태에서 incoming 에서 빠졌을 수 있어 단순화)
-      const afterAvailable = stock.available + qty
       return {
         productCode: it.productCode,
         productName: it.productName,
@@ -162,76 +175,48 @@ export const useWarehouseStockStore = defineStore('warehouseStock', () => {
         },
         after: {
           onHand: afterOnHand,
-          available: afterAvailable,
+          available: stock.available,
         },
         shortageAfter: afterOnHand < stock.safetyStock,
       }
     })
   }
 
-  // ─── SKU 단위 시뮬레이션 (인벤토리 SKU BE 합류 전 임시) ────────────────────────
-  // 같은 패턴 — onHand/safetyStock 은 (warehouseId, skuCode) 해시 기반 deterministic.
-  // incoming 은 SHIPPING 발주 items 중 skuCode 매칭 합산. items.skuCode 가 빈 문자열이면 매칭 X (옛 발주 가드).
-  function defaultSkuStock(warehouseId, skuCode) {
-    const seed = hashSeed(`SKU|${warehouseId}|${skuCode}`)
-    const factor = WAREHOUSE_FACTORS[warehouseId] ?? 1.0
-    const onHand = Math.round(((seed % 60) + 3) * factor)
-    const safetyStock = 3 + ((seed >> 8) % 8) // 3~10
-    return { onHand, safetyStock }
-  }
-
-  function getSkuStock(warehouseId, skuCode) {
-    if (!warehouseId || !skuCode) return null
-    const base = defaultSkuStock(warehouseId, skuCode)
-    const incoming = poStore.purchaseOrders
-      .filter((o) => o.status === 'IN_TRANSIT' && o.warehouseId === warehouseId)
-      .flatMap((o) => o.items ?? [])
-      .filter((it) => it.skuCode && it.skuCode === skuCode)
-      .reduce((sum, it) => sum + (Number(it.quantity) || 0), 0)
-    const outgoing = 0
-    const available = base.onHand + incoming - outgoing
-    return {
-      onHand: base.onHand,
-      safetyStock: base.safetyStock,
-      incoming,
-      outgoing,
-      available,
-    }
-  }
-
+  // SKU 단위 wrap — 시그니처 호환.
   function getSkuStockLevel(stock) {
-    if (!stock) return 'unknown'
-    if (stock.available < stock.safetyStock) return 'critical'
-    if (stock.available < stock.safetyStock * 1.5) return 'warning'
-    return 'normal'
+    return getStockLevel(stock)
   }
 
   function getSkuSuggestedQuantity(stock) {
-    if (!stock) return 0
-    const target = stock.safetyStock * 1.5
-    const need = target - stock.available
-    if (need <= 0) return 0
-    return Math.ceil(need)
+    return getSuggestedQuantity(stock)
   }
 
-  function getSkuShortageCount(warehouseId, skuCodes = []) {
-    if (!warehouseId || !skuCodes.length) return 0
+  function getSkuShortageCount(_warehouseId, skuCodes = []) {
+    if (!skuCodes.length) return 0
     let count = 0
     for (const sc of skuCodes) {
-      const level = getSkuStockLevel(getSkuStock(warehouseId, sc))
+      const level = getSkuStockLevel(getSkuStock(null, sc))
       if (level === 'critical' || level === 'warning') count++
     }
     return count
   }
 
   return {
-    getBaseStock,
+    // state
+    loading,
+    error,
+    productLoaded,
+    skuLoaded,
+    // actions
+    loadProductStocks,
+    loadSkuStocks,
+    invalidate,
+    // getters — 시그니처 유지
     getStock,
     getStockLevel,
     getSuggestedQuantity,
     getShortageCount,
     getInboundPreview,
-    // SKU 단위
     getSkuStock,
     getSkuStockLevel,
     getSkuSuggestedQuantity,

--- a/src/views/hq/purchase-order/HqPurchaseOrderCreateView.vue
+++ b/src/views/hq/purchase-order/HqPurchaseOrderCreateView.vue
@@ -421,6 +421,9 @@ async function confirmSubmitOrder() {
       cart.value = []
       cartStore.clearAll()
       clearDraftStorage()
+      // BE 응답(DetailRes[]) 을 직접 store 에 ingest — items/statusHistory 포함이라
+      // 라우팅 후 마운트 fetchOrders 와의 race 없이 상세 패널 즉시 정상 표시.
+      poStore.ingestOrders?.(res?.orders ?? [])
       const firstCode = res?.orders?.[0]?.code
       if (firstCode) poStore.selectOrder?.(firstCode)
       const orderCount = res?.orders?.length ?? 0

--- a/src/views/warehouse/dashboard/WarehouseDashboardView.vue
+++ b/src/views/warehouse/dashboard/WarehouseDashboardView.vue
@@ -83,8 +83,9 @@ const rangeParams = computed(() => {
 
 onMounted(() => {
   dashStore.fetchInboundProgress(rangeParams.value)
-  // 안전재고 미달 KPI 산출용 — vendor_product 카탈로그 fetch (이미 있으면 no-op)
+  // 안전재고 미달 KPI 산출용 — vendor_product 카탈로그 + 자기 창고 재고 캐시 fetch.
   vendorStore.fetchAllVendorProducts('ACTIVE').catch(() => {})
+  stockStore.loadProductStocks().catch(() => {})
 })
 
 watch(range, () => {

--- a/src/views/warehouse/inbound/WarehouseInboundView.vue
+++ b/src/views/warehouse/inbound/WarehouseInboundView.vue
@@ -51,14 +51,16 @@ const inboundPreview = computed(() => {
 
 const previewHasShortage = computed(() => inboundPreview.value.some((row) => row.shortageAfter))
 
-// 우측 상세 품목 표 — 행마다 현재 실재고/안전재고 표시용 캐시
+// 우측 상세 품목 표 — 행마다 현재 실재고/안전재고 표시용 캐시.
+// 발주 라인 = 단일 SKU 이므로 SKU 단위 lookup (master 합산값과 혼동 방지 —
+// 창고재고조회 화면이 SKU 단위로 보여주는 것과 정합).
 const itemStocks = computed(() => {
   const order = inbound.selectedOrder
   if (!order || !order.warehouseId) return new Map()
   const map = new Map()
   for (const item of order.items ?? []) {
-    if (!item.productCode) continue
-    map.set(item.id, stockStore.getStock(order.warehouseId, item.productCode))
+    if (!item.skuCode) continue
+    map.set(item.id, stockStore.getSkuStock(order.warehouseId, item.skuCode))
   }
   return map
 })
@@ -75,6 +77,9 @@ async function confirmInbound() {
   showConfirmInbound.value = false
   try {
     await inbound.confirmInbound(id)
+    // 입고 확정 직후 재고 캐시 무효화 + 즉시 재로딩 — onHand 변화 반영.
+    stockStore.invalidate()
+    await stockStore.loadProductStocks().catch(() => {})
     triggerToast('입고가 확정되었습니다')
   } catch (e) {
     triggerToast(e?.message ?? '입고 확정에 실패했습니다')
@@ -89,9 +94,13 @@ function handleKeydown(e) {
 }
 
 // 화면 진입 시 입고 목록 강제 fetch — 다른 화면에서 status 변경됐을 수 있으므로 stale 방지.
+// stockStore SKU + master 둘 다 트리거 — itemStocks 는 SKU 단위, inboundPreview 도 SKU 단위.
+// master 캐시는 다른 화면 호환 위해 같이 채워둠 (no-op if already loaded).
 onMounted(() => {
   window.addEventListener('keydown', handleKeydown)
   inbound.fetchAll().catch(() => {})
+  stockStore.loadProductStocks().catch(() => {})
+  stockStore.loadSkuStocks().catch(() => {})
 })
 onUnmounted(() => window.removeEventListener('keydown', handleKeydown))
 </script>


### PR DESCRIPTION
## 📌 요약
- 본사 발주 배치 실행 후 화면이 stale 하던 회귀 정정 + warehouseStock 의 해시 시드 의존을 BE 응답 기반으로 교체

<br><br>

## 🎯 작업 내용
- `purchaseOrder.runBatch` 응답을 4단계(approved/readyToShip/inTransit/arrived) 합산으로 변경 — 7단계 상태머신 전환 후 옛 2단계 합산이라 changed=0 으로 fetchOrders 가 안 돌던 버그
- `fetchOrders` 가 list 응답(items/statusHistory 미포함)으로 store 를 통째 reassign 하던 부분에 prev 캐시 merge 추가 — selectOrder→fetchDetail 과의 race 보호
- `ingestOrders` 추가 + `HqPurchaseOrderCreateView.confirmSubmitOrder` 가 batch 응답(DetailRes[]) 을 직접 ingest — 라우팅 후 마운트 fetchOrders 와의 race 없이 상세 패널 즉시 정상 표시
- `warehouseStock` 해시 시드 → `/api/warehouse/inventories(+/skus)` 응답 캐시로 전면 교체 (productCode/skuCode 두 단위 Map), 입고 확정 직후 `invalidate()` + 재로딩 hook
- 카탈로그 재고 표기(`useStockSim` + `PurchaseOrderCatalog.shortageCount`) 를 BE `availableQty` 단독 평가로 단순화 — 본사 권한군은 `/api/warehouse/*` 호출 불가라 warehouseStock 의존 자체가 잘못된 가정이었음

<br><br>

## ✔️ 참고 사항
- 

<br><br>

## ✔️ 관련 이슈

- Close #492

<br><br>
