### PR TITLE
fix(warehouse-inbound): 입고 상세 패널 실재고·안전재고 미표시 정정

### DIFF
--- a/src/components/warehouse/inbound/WarehouseInboundDetailPanel.vue
+++ b/src/components/warehouse/inbound/WarehouseInboundDetailPanel.vue
@@ -28,7 +28,7 @@ const {
 } = useWarehouseStatusFormat()
 
 function getItemStock(item) {
-  return props.itemStocks.get(item.id) ?? null
+  return props.itemStocks.get(item.skuCode) ?? null
 }
 
 function isItemShortage(item) {

--- a/src/stores/warehouse/warehouseStock.js
+++ b/src/stores/warehouse/warehouseStock.js
@@ -66,7 +66,7 @@ export const useWarehouseStockStore = defineStore('warehouseStock', () => {
     loading.value = true
     error.value = null
     try {
-      const res = await getWarehouseInventorySkus({ page: 0, size: 1000 })
+      const res = await getWarehouseInventorySkus({ page: 0, size: 2000 })
       const items = Array.isArray(res?.items) ? res.items : []
       const next = new Map()
       for (const row of items) {

--- a/src/views/warehouse/inbound/WarehouseInboundView.vue
+++ b/src/views/warehouse/inbound/WarehouseInboundView.vue
@@ -54,13 +54,14 @@ const previewHasShortage = computed(() => inboundPreview.value.some((row) => row
 // 우측 상세 품목 표 — 행마다 현재 실재고/안전재고 표시용 캐시.
 // 발주 라인 = 단일 SKU 이므로 SKU 단위 lookup (master 합산값과 혼동 방지 —
 // 창고재고조회 화면이 SKU 단위로 보여주는 것과 정합).
+// BE inbound items 응답에 id 필드 없음 — skuCode 를 map key 로 사용 (panel lookup 도 동기화).
 const itemStocks = computed(() => {
   const order = inbound.selectedOrder
   if (!order || !order.warehouseId) return new Map()
   const map = new Map()
   for (const item of order.items ?? []) {
     if (!item.skuCode) continue
-    map.set(item.id, stockStore.getSkuStock(order.warehouseId, item.skuCode))
+    map.set(item.skuCode, stockStore.getSkuStock(order.warehouseId, item.skuCode))
   }
   return map
 })


### PR DESCRIPTION
## 📌 요약
- 창고 입고관리 상세 패널의 [발주 품목] 표에서 "실재고"·"안전" 두 열이 항상 `—` 로만 표시되던 문제 정정.

<br><br>

## 🎯 작업 내용
- `warehouseStock.loadSkuStocks` 의 size 를 1000 → 2000 으로 상향 (현재 총 SKU 1350 + 헤드룸).
- `WarehouseInboundView.itemStocks` Map key 를 `item.id` (undefined) → `item.skuCode` 로 교체.
- `WarehouseInboundDetailPanel.getItemStock` lookup 도 `item.skuCode` 로 동기화.

<br><br>

## ✔️ 참고 사항
- 
- 

<br><br>

## ✔️ 관련 이슈

- Close #501

<br><br>
