### PR TITLE
503 refactor 회원가입 신청사유 수정

### DIFF
--- a/src/api/hq/account.js
+++ b/src/api/hq/account.js
@@ -2,13 +2,13 @@
  * account.js — 본사 관리자 회원 관리 BE 연동
  *
  * BE 엔드포인트:
- *   GET    /api/hq/account                           (전체 회원 목록, HQ)
- *   GET    /api/hq/account/pending                   (대기 회원 목록, HQ)
+ *   GET    /api/hq/account?keyword=&role=&status=&page=0&size=20   (전체, 페이징)
+ *   GET    /api/hq/account/pending?keyword=&page=0&size=20         (대기, 페이징)
  *   POST   /api/hq/account/{id}/approve              (가입 승인, HQ)
  *   POST   /api/hq/account/{id}/reject               (가입 거절, HQ)
  *   POST   /api/hq/account/{id}/withdraw             (탈퇴 처리, HQ)
  *
- * 응답: BaseResponse<T>. unwrap() 으로 result 만 추출.
+ * 응답: BaseResponse<Page<T>>. unwrap() 후 { content, totalElements, totalPages, number, size, ... } 구조.
  *
  * NOTE: 회원가입(signup)은 user 도메인이므로 src/api/user/user.js 로 이동됨.
  */
@@ -16,11 +16,51 @@
 import { apiClient, unwrap } from '../axios.js'
 
 export const accountApi = {
-  /** 전체 회원 목록 조회 (PENDING/APPROVED/REJECTED/WITHDRAWN) */
-  listAll: () => apiClient.get('/api/hq/account').then(unwrap),
+  /**
+   * 전체 회원 목록 조회 (PENDING/APPROVED/REJECTED/WITHDRAWN) — 페이징·검색·필터 지원
+   *
+   * @param {{
+   *   page?: number,     // 0-based 페이지 번호 (기본 0)
+   *   size?: number,     // 페이지 크기 (기본 20, 최대 100)
+   *   keyword?: string,  // 이름/이메일/사원코드 LIKE 검색
+   *   role?: 'HQ' | 'STORE' | 'WAREHOUSE',
+   *   status?: 'PENDING' | 'APPROVED' | 'REJECTED' | 'WITHDRAWN',
+   * }} params
+   * @returns {Promise<{
+   *   content: Array,
+   *   totalElements: number,
+   *   totalPages: number,
+   *   number: number,
+   *   size: number,
+   *   first: boolean,
+   *   last: boolean,
+   *   empty: boolean,
+   * }>}
+   */
+  listAll: ({ page = 0, size = 20, keyword, role, status } = {}) =>
+    apiClient.get('/api/hq/account', {
+      params: {
+        page,
+        size,
+        keyword: keyword || undefined,   // 빈 문자열은 보내지 않음 (BE 가 null 처리)
+        role: role || undefined,
+        status: status || undefined,
+      },
+    }).then(unwrap),
 
-  /** 대기 회원 목록 조회 */
-  listPending: () => apiClient.get('/api/hq/account/pending').then(unwrap),
+  /**
+   * 대기 회원 목록 조회 (PENDING 만) — 페이징·검색 지원
+   *
+   * @param {{ page?: number, size?: number, keyword?: string }} params
+   */
+  listPending: ({ page = 0, size = 20, keyword } = {}) =>
+    apiClient.get('/api/hq/account/pending', {
+      params: {
+        page,
+        size,
+        keyword: keyword || undefined,
+      },
+    }).then(unwrap),
 
   /** 가입 신청 승인 (사원코드 자동 채번) */
   approve: (id) => apiClient.post(`/api/hq/account/${id}/approve`).then(unwrap),

--- a/src/views/hq/account/AccountApprovalView.vue
+++ b/src/views/hq/account/AccountApprovalView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, watch, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import {
   ClipboardList,
@@ -10,11 +10,13 @@ import {
   AlertCircle,
   X,
   UserMinus,
+  Search,
 } from 'lucide-vue-next'
 import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
 import { accountApi } from '@/api/hq/account.js'
+import { extractErrorMessage } from '@/api/axios.js'
 const auth = useAuthStore()
 const router = useRouter()
 const hqMenus = roleMenus.hq
@@ -25,49 +27,19 @@ const sideMenus = [
 ]
 const activeTopMenu = computed(() => '계정 관리')
 
+const roleLabel = (r) => ({ HQ: '본사 관리자', STORE: '매장 관리자', WAREHOUSE: '창고 관리자' })[r] ?? r
 
-// ── BE에서 받아온 전체 회원 목록 (PENDING / APPROVED / REJECTED)
-const requests = ref([])
+// ── 서버 페이징 결과 ({ content, totalElements, totalPages, number, size, ... })
+const accountPage = ref(null)
+const pendingCount = ref(0)         // PENDING 뱃지/배너용 별도 카운트
 const loading = ref(false)
 const loadError = ref('')
 
-const roleLabel = (r) => ({ HQ: '본사 관리자', STORE: '매장 관리자', WAREHOUSE: '창고 관리자' })[r] ?? r
-
-/** 전체 회원 목록 조회 (status 별 필터는 화면에서 처리) */
-async function loadAccounts() {
-  loading.value = true
-  loadError.value = ''
-  try {
-    const list = await accountApi.listAll()
-    // BE 응답 → 화면 필드 형식 변환
-    requests.value = list.map(item => ({
-      id: item.id,                              // Long
-      employeeCode: item.employeeCode,          // APPROVED만 채워져 있음
-      name: item.name,
-      email: item.email,
-      phone: item.phoneNumber,
-      storeCode: item.locationCode,
-      storeName: item.locationName,
-      role: item.role,                          // HQ / STORE / WAREHOUSE
-      reason: item.applicationReason ?? '',
-      requestedAt: item.appliedAt,
-      processedAt: item.processedAt,            // 승인/거절 시각
-      status: item.status,                      // PENDING / APPROVED / REJECTED
-    }))
-  } catch (err) {
-    loadError.value = err?.message ?? '목록을 불러오지 못했습니다.'
-  } finally {
-    loading.value = false
-  }
-}
-
-onMounted(() => loadAccounts())
-
-const filterStatus = ref('ALL')
-const selectedRequest = ref(null)
-const rejectReason = ref('')
-const rejectReasonError = ref('')
-const modalMode = ref(null) // 'approve' | 'reject' | null
+// ── 필터 + 검색 + 페이징 상태
+const filterStatus = ref('ALL')     // 'ALL' | 'PENDING' | 'APPROVED' | 'REJECTED'
+const keyword = ref('')             // 이름/이메일/사원코드 검색어
+const PAGE_SIZE = 20
+const currentPage = ref(1)
 
 const statusOptions = [
   { value: 'ALL',      label: '전체' },
@@ -76,13 +48,116 @@ const statusOptions = [
   { value: 'REJECTED', label: '거절됨' },
 ]
 
-const filteredRequests = computed(() =>
-  filterStatus.value === 'ALL'
-    ? requests.value
-    : requests.value.filter(r => r.status === filterStatus.value)
+// BE content → 화면 필드 매핑 (storeCode/storeName/phone 등 기존 키 유지)
+const requests = computed(() =>
+  (accountPage.value?.content ?? []).map(item => ({
+    id: item.id,
+    employeeCode: item.employeeCode,
+    name: item.name,
+    email: item.email,
+    phone: item.phoneNumber,
+    storeCode: item.locationCode,
+    storeName: item.locationName,
+    role: item.role,
+    reason: item.applicationReason ?? '',
+    requestedAt: item.appliedAt,
+    processedAt: item.processedAt,
+    status: item.status,
+  }))
 )
 
-const pendingCount = computed(() => requests.value.filter(r => r.status === 'PENDING').length)
+const totalElements = computed(() => accountPage.value?.totalElements ?? 0)
+const totalPages = computed(() => Math.max(1, accountPage.value?.totalPages ?? 1))
+
+// ── BE 호출 — 현재 필터/검색어/페이지로 조회
+async function loadAccounts() {
+  loading.value = true
+  loadError.value = ''
+  try {
+    accountPage.value = await accountApi.listAll({
+      page: currentPage.value - 1,                                     // BE 는 0-based
+      size: PAGE_SIZE,
+      keyword: keyword.value.trim(),
+      status: filterStatus.value === 'ALL' ? '' : filterStatus.value,  // 'ALL' 은 status 미전송
+    })
+  } catch (err) {
+    loadError.value = extractErrorMessage(err, '목록을 불러오지 못했습니다.')
+  } finally {
+    loading.value = false
+  }
+}
+
+// PENDING 카운트 (탭 뱃지/배너용) — size=1 로 totalElements 만 가져옴
+async function loadPendingCount() {
+  try {
+    const result = await accountApi.listAll({ page: 0, size: 1, status: 'PENDING' })
+    pendingCount.value = result?.totalElements ?? 0
+  } catch {
+    pendingCount.value = 0
+  }
+}
+
+// 검색어 입력 — 300ms 디바운스 후 첫 페이지로 BE 호출
+let keywordDebounce = null
+watch(keyword, () => {
+  clearTimeout(keywordDebounce)
+  keywordDebounce = setTimeout(() => {
+    currentPage.value = 1
+    loadAccounts()
+  }, 300)
+})
+
+// 상태 필터 변경 — 즉시 첫 페이지로
+watch(filterStatus, () => {
+  currentPage.value = 1
+  loadAccounts()
+})
+
+// 페이지 변경 — BE 재호출
+watch(currentPage, () => loadAccounts())
+
+const selectedRequest = ref(null)
+const rejectReason = ref('')
+const rejectReasonError = ref('')
+const modalMode = ref(null) // 'approve' | 'reject' | null
+
+/**
+ * 페이지네이션 — 5개씩 그룹으로 표시
+ *  버튼 구성: << <  1 2 3 4 5  > >>
+ */
+const PAGES_PER_GROUP = 5
+const currentGroup = computed(() => Math.ceil(currentPage.value / PAGES_PER_GROUP))
+const totalGroups = computed(() => Math.max(1, Math.ceil(totalPages.value / PAGES_PER_GROUP)))
+
+const visiblePages = computed(() => {
+  const start = (currentGroup.value - 1) * PAGES_PER_GROUP + 1
+  const end = Math.min(start + PAGES_PER_GROUP - 1, totalPages.value)
+  return Array.from({ length: end - start + 1 }, (_, i) => start + i)
+})
+
+function goPrevGroup() {
+  const prevGroupStart = Math.max(1, (currentGroup.value - 2) * PAGES_PER_GROUP + 1)
+  currentPage.value = prevGroupStart
+}
+
+function goNextGroup() {
+  const nextGroupStart = Math.min(totalPages.value, currentGroup.value * PAGES_PER_GROUP + 1)
+  currentPage.value = nextGroupStart
+}
+
+// 필터 변경 — watch 가 currentPage=1 리셋 + BE 호출
+function setFilterStatus(value) {
+  filterStatus.value = value
+}
+
+// 컴포넌트 진입 시 필터 초기화 + 첫 페이지 + BE 호출
+onMounted(() => {
+  filterStatus.value = 'ALL'
+  keyword.value = ''
+  currentPage.value = 1
+  loadAccounts()
+  loadPendingCount()
+})
 
 // 처리 컬럼은 PENDING이 보이는 화면(전체/대기중)에서만 노출
 const showActionColumn = computed(() => filterStatus.value === 'ALL' || filterStatus.value === 'PENDING')
@@ -135,9 +210,10 @@ async function confirmApprove() {
     const result = await accountApi.approve(selectedRequest.value.id)
     alert(`승인 완료\n사원코드: ${result.employeeCode}`)
     closeDetail()
-    await loadAccounts()
+    // 목록 + PENDING 카운트 재조회 (탭 뱃지/배너 갱신)
+    await Promise.all([loadAccounts(), loadPendingCount()])
   } catch (err) {
-    alert(err?.message ?? '승인에 실패했습니다.')
+    alert(extractErrorMessage(err, '승인에 실패했습니다.'))
   }
 }
 
@@ -150,9 +226,9 @@ async function confirmReject() {
   try {
     await accountApi.reject(selectedRequest.value.id)
     closeDetail()
-    await loadAccounts()
+    await Promise.all([loadAccounts(), loadPendingCount()])
   } catch (err) {
-    alert(err?.message ?? '거절에 실패했습니다.')
+    alert(extractErrorMessage(err, '거절에 실패했습니다.'))
   }
 }
 </script>
@@ -221,29 +297,42 @@ async function confirmReject() {
       <!-- 테이블 카드 -->
       <section v-else class="border border-gray-300 bg-white shadow-sm">
 
-        <!-- 카드 헤더 + 필터 탭 -->
+        <!-- 카드 헤더 + 검색/필터 -->
         <div class="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 px-3 py-2.5">
           <h3 class="inline-flex items-center gap-2 text-sm font-medium text-gray-800">
             <Users :size="16" />
             계정 신청 목록
           </h3>
-          <div class="flex items-center gap-1">
-            <button
-              v-for="opt in statusOptions"
-              :key="opt.value"
-              type="button"
-              class="inline-flex h-8 items-center gap-1.5 border px-3 text-[12px] font-medium transition"
-              :class="filterStatus === opt.value
-                ? 'border-gray-300 bg-white text-gray-900'
-                : 'border-transparent bg-transparent text-gray-500 hover:bg-gray-100'"
-              @click="filterStatus = opt.value"
-            >
-              {{ opt.label }}
-              <span
-                v-if="opt.value === 'PENDING' && pendingCount > 0"
-                class="flex h-4 min-w-[16px] items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-bold text-white"
-              >{{ pendingCount }}</span>
-            </button>
+          <div class="flex flex-wrap items-center gap-2">
+            <!-- 검색 입력 (이름/이메일/사원코드 — 300ms 디바운스, watch 가 BE 호출) -->
+            <div class="relative flex items-center">
+              <Search :size="13" class="absolute left-2.5 text-gray-400 pointer-events-none" />
+              <input
+                v-model="keyword"
+                type="text"
+                placeholder="이름/이메일/사원코드 검색"
+                class="h-8 w-56 rounded-none border border-gray-300 bg-gray-50 pl-8 pr-3 text-[12px] text-gray-800 outline-none transition placeholder:text-gray-400 focus:border-[#004D3C] focus:bg-white"
+              />
+            </div>
+            <!-- 상태 필터 탭 -->
+            <div class="flex items-center gap-1">
+              <button
+                v-for="opt in statusOptions"
+                :key="opt.value"
+                type="button"
+                class="inline-flex h-8 items-center gap-1.5 border px-3 text-[12px] font-medium transition"
+                :class="filterStatus === opt.value
+                  ? 'border-gray-300 bg-white text-gray-900'
+                  : 'border-transparent bg-transparent text-gray-500 hover:bg-gray-100'"
+                @click="setFilterStatus(opt.value)"
+              >
+                {{ opt.label }}
+                <span
+                  v-if="opt.value === 'PENDING' && pendingCount > 0"
+                  class="flex h-4 min-w-[16px] items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-bold text-white"
+                >{{ pendingCount }}</span>
+              </button>
+            </div>
           </div>
         </div>
 
@@ -264,7 +353,7 @@ async function confirmReject() {
             </thead>
             <tbody class="divide-y divide-gray-100 border-t border-gray-200">
               <tr
-                v-for="req in filteredRequests"
+                v-for="req in requests"
                 :key="req.id"
                 class="cursor-pointer transition-colors hover:bg-gray-50/50"
                 :class="{ 'bg-[#eef7f4] hover:bg-[#e4f2ef]': selectedRequest?.id === req.id }"
@@ -289,7 +378,7 @@ async function confirmReject() {
                   <div v-if="req.status === 'PENDING'" class="flex gap-1.5">
                     <button
                       type="button"
-                      class="h-7 bg-emerald-500 px-3 text-[11px] font-medium text-white transition hover:bg-emerald-600"
+                      class="h-7 bg-emerald-50 px-3 text-[11px] font-medium text-emerald-700 border border-emerald-200 transition hover:bg-emerald-100"
                       @click="openDetail(req); modalMode = 'approve'"
                     >승인</button>
                     <button
@@ -301,15 +390,64 @@ async function confirmReject() {
                   <span v-else class="text-gray-300">—</span>
                 </td>
               </tr>
-              <tr v-if="filteredRequests.length === 0">
+              <tr v-if="requests.length === 0">
                 <td :colspan="showActionColumn ? 8 : 7" class="px-3 py-10 text-center text-[13px] text-gray-400">조회된 신청이 없습니다.</td>
               </tr>
             </tbody>
           </table>
         </div>
 
-        <div class="border-t border-gray-200 bg-gray-50 px-3 py-2 text-[11px] font-medium text-gray-400">
-          전체 {{ filteredRequests.length }}건
+        <!-- 페이지네이션 (한 페이지 30건) -->
+        <div class="flex items-center justify-between border-t border-gray-200 bg-gray-50 px-3 py-2">
+          <span class="text-[11px] font-medium text-gray-400">
+            <template v-if="totalElements > 0">
+              {{ (currentPage - 1) * PAGE_SIZE + 1 }}–{{ Math.min(currentPage * PAGE_SIZE, totalElements) }} / 전체 {{ totalElements }}건
+            </template>
+            <template v-else>0건</template>
+          </span>
+          <div class="flex items-center gap-1">
+            <!-- << 이전 5페이지 그룹 -->
+            <button
+              type="button"
+              :disabled="currentGroup === 1"
+              class="flex h-7 w-7 items-center justify-center border border-gray-300 bg-white text-[12px] text-gray-500 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
+              @click="goPrevGroup"
+              title="이전 5페이지"
+            >«</button>
+            <!-- < 한 페이지 이전 -->
+            <button
+              type="button"
+              :disabled="currentPage === 1"
+              class="flex h-7 w-7 items-center justify-center border border-gray-300 bg-white text-[12px] text-gray-500 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
+              @click="currentPage--"
+              title="이전 페이지"
+            >‹</button>
+            <!-- 페이지 번호 (5개씩) -->
+            <button
+              v-for="p in visiblePages"
+              :key="p"
+              type="button"
+              class="flex h-7 min-w-[28px] items-center justify-center border text-[12px] font-medium transition"
+              :class="p === currentPage ? 'border-[#004D3C] bg-[#004D3C] text-white' : 'border-gray-300 bg-white text-gray-500 hover:bg-gray-100'"
+              @click="currentPage = p"
+            >{{ p }}</button>
+            <!-- > 한 페이지 다음 -->
+            <button
+              type="button"
+              :disabled="currentPage === totalPages"
+              class="flex h-7 w-7 items-center justify-center border border-gray-300 bg-white text-[12px] text-gray-500 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
+              @click="currentPage++"
+              title="다음 페이지"
+            >›</button>
+            <!-- >> 다음 5페이지 그룹 -->
+            <button
+              type="button"
+              :disabled="currentGroup === totalGroups"
+              class="flex h-7 w-7 items-center justify-center border border-gray-300 bg-white text-[12px] text-gray-500 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
+              @click="goNextGroup"
+              title="다음 5페이지"
+            >»</button>
+          </div>
         </div>
       </section>
 
@@ -431,7 +569,7 @@ async function confirmReject() {
                   <XCircle :size="14" />
                   거절
                 </button>
-                <button type="button" class="inline-flex h-9 items-center gap-1.5 bg-emerald-500 px-5 text-[13px] font-medium text-white transition hover:bg-emerald-600" @click="modalMode = 'approve'">
+                <button type="button" class="inline-flex h-9 items-center gap-1.5 bg-emerald-50 px-5 text-[13px] font-medium text-emerald-700 border border-emerald-200 transition hover:bg-emerald-100" @click="modalMode = 'approve'">
                   <CheckCircle2 :size="14" />
                   승인
                 </button>
@@ -446,7 +584,7 @@ async function confirmReject() {
               </div>
               <div class="flex justify-end gap-2">
                 <button type="button" class="h-9 border border-gray-300 bg-white px-5 text-[13px] font-medium text-gray-600 transition hover:bg-gray-50" @click="modalMode = null">취소</button>
-                <button type="button" class="inline-flex h-9 items-center gap-1.5 bg-emerald-500 px-5 text-[13px] font-medium text-white transition hover:bg-emerald-600" @click="confirmApprove">
+                <button type="button" class="inline-flex h-9 items-center gap-1.5 bg-emerald-50 px-5 text-[13px] font-medium text-emerald-700 border border-emerald-200 transition hover:bg-emerald-100" @click="confirmApprove">
                   <CheckCircle2 :size="14" />
                   최종 승인
                 </button>

--- a/src/views/hq/account/AccountListView.vue
+++ b/src/views/hq/account/AccountListView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, reactive, onMounted } from 'vue'
+import { ref, computed, reactive, watch, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import {
   Users,
@@ -72,41 +72,18 @@ const formatDateTime = (iso) => {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
 }
 
-// ── BE 회원 목록 (활성 + 탈퇴만 표시 — 승인 대기/거절은 회원가입 승인 탭에서 처리)
+// ── BE 응답 페이지 객체 ({ content, totalElements, totalPages, number, size, ... })
+//    PENDING/REJECTED 는 회원가입 승인 탭에서 처리 → 클라이언트에서 1차 필터
 const VISIBLE_STATUSES = ['APPROVED', 'WITHDRAWN']
 
-const allAccounts = ref([]) // 전체 상태 (PENDING 포함) — 탭 뱃지용
+const accountPage = ref(null)        // 서버 페이징 결과
+const pendingCount = ref(0)          // PENDING 뱃지용 별도 카운트
 const loading = ref(false)
 const loadError = ref('')
 
-const members = computed(() => allAccounts.value.filter((m) => VISIBLE_STATUSES.includes(m.status)))
-const pendingCount = computed(() => allAccounts.value.filter((m) => m.status === 'PENDING').length)
-
-async function loadAccounts() {
-  loading.value = true
-  loadError.value = ''
-  try {
-    allAccounts.value = await accountApi.listAll()
-  } catch (err) {
-    loadError.value = extractErrorMessage(err, '계정 목록을 불러오지 못했습니다.')
-  } finally {
-    loading.value = false
-  }
-}
-
-onMounted(() => loadAccounts())
-
-// ── 통계 (활성 / 탈퇴만)
-const stats = computed(() => {
-  const total = members.value.length
-  const approved = members.value.filter(m => m.status === 'APPROVED').length
-  const withdrawn = members.value.filter(m => m.status === 'WITHDRAWN').length
-  return { total, approved, withdrawn }
-})
-
-// ── 필터
+// ── 필터 + 페이징 상태
 const filter = reactive({ keyword: '', role: '', status: '' })
-const PAGE_SIZE = 10
+const PAGE_SIZE = 20
 const currentPage = ref(1)
 
 const roleOptions = [
@@ -121,32 +98,115 @@ const statusOptions = [
   { value: 'WITHDRAWN', label: '탈퇴' },
 ]
 
-const filtered = computed(() =>
-  members.value.filter(m => {
-    if (filter.keyword) {
-      const kw = filter.keyword.trim().toLowerCase()
-      const haystack = `${m.name ?? ''} ${m.email ?? ''} ${m.employeeCode ?? ''}`.toLowerCase()
-      if (!haystack.includes(kw)) return false
-    }
-    if (filter.role && m.role !== filter.role) return false
-    if (filter.status && m.status !== filter.status) return false
-    return true
-  })
+// ── 화면 표시 데이터 — BE content 에서 VISIBLE_STATUSES 만
+const visibleMembers = computed(() =>
+  (accountPage.value?.content ?? []).filter(m => VISIBLE_STATUSES.includes(m.status))
 )
+const totalElements = computed(() => accountPage.value?.totalElements ?? 0)
+const totalPages = computed(() => Math.max(1, accountPage.value?.totalPages ?? 1))
 
-const totalPages = computed(() => Math.max(1, Math.ceil(filtered.value.length / PAGE_SIZE)))
-
-const paginated = computed(() => {
-  const start = (currentPage.value - 1) * PAGE_SIZE
-  return filtered.value.slice(start, start + PAGE_SIZE)
+// 통계 (현재 검색 결과 기준)
+const stats = computed(() => {
+  const members = visibleMembers.value
+  return {
+    total: totalElements.value,
+    approved: members.filter(m => m.status === 'APPROVED').length,
+    withdrawn: members.filter(m => m.status === 'WITHDRAWN').length,
+  }
 })
 
-// 컴포넌트 진입(새로고침/페이지 재방문) 시 필터 강제 초기화 — keep-alive 도입 시에도 정상 동작 보장
+// ── BE 호출 — 현재 필터/페이지로 조회
+async function loadAccounts() {
+  loading.value = true
+  loadError.value = ''
+  try {
+    accountPage.value = await accountApi.listAll({
+      page: currentPage.value - 1,     // BE 는 0-based
+      size: PAGE_SIZE,
+      keyword: filter.keyword.trim(),
+      role: filter.role,
+      status: filter.status,
+    })
+  } catch (err) {
+    loadError.value = extractErrorMessage(err, '계정 목록을 불러오지 못했습니다.')
+  } finally {
+    loading.value = false
+  }
+}
+
+// PENDING 뱃지용 카운트 — size=1 로 totalElements 만 가져옴
+async function loadPendingCount() {
+  try {
+    const result = await accountApi.listAll({ page: 0, size: 1, status: 'PENDING' })
+    pendingCount.value = result?.totalElements ?? 0
+  } catch {
+    pendingCount.value = 0
+  }
+}
+
+// 키워드 입력 — 300ms 디바운스 후 첫 페이지로 BE 호출
+let keywordDebounce = null
+watch(() => filter.keyword, () => {
+  clearTimeout(keywordDebounce)
+  keywordDebounce = setTimeout(() => {
+    currentPage.value = 1
+    loadAccounts()
+  }, 300)
+})
+
+// 권한/상태 필터 — 즉시 첫 페이지로
+watch([() => filter.role, () => filter.status], () => {
+  currentPage.value = 1
+  loadAccounts()
+})
+
+// 페이지 변경 시 — BE 재호출
+watch(currentPage, () => loadAccounts())
+
+/**
+ * 페이지네이션 — 5개씩 그룹으로 표시
+ *  버튼 구성: << <  1 2 3 4 5  > >>
+ *  - <<  : 이전 5페이지 그룹으로 이동
+ *  - <   : 한 페이지 이전
+ *  - >   : 한 페이지 다음
+ *  - >>  : 다음 5페이지 그룹으로 이동
+ *
+ *  예시 (총 82페이지):
+ *   현재 3페이지 → [1 2 3 4 5]
+ *   현재 7페이지 → [6 7 8 9 10]
+ *   현재 82페이지 → [81 82]
+ */
+const PAGES_PER_GROUP = 5
+const currentGroup = computed(() => Math.ceil(currentPage.value / PAGES_PER_GROUP))
+const totalGroups = computed(() => Math.max(1, Math.ceil(totalPages.value / PAGES_PER_GROUP)))
+
+const visiblePages = computed(() => {
+  const start = (currentGroup.value - 1) * PAGES_PER_GROUP + 1
+  const end = Math.min(start + PAGES_PER_GROUP - 1, totalPages.value)
+  return Array.from({ length: end - start + 1 }, (_, i) => start + i)
+})
+
+function goPrevGroup() {
+  // 이전 그룹의 첫 페이지로
+  const prevGroupStart = Math.max(1, (currentGroup.value - 2) * PAGES_PER_GROUP + 1)
+  currentPage.value = prevGroupStart
+}
+
+function goNextGroup() {
+  // 다음 그룹의 첫 페이지로
+  const nextGroupStart = Math.min(totalPages.value, currentGroup.value * PAGES_PER_GROUP + 1)
+  currentPage.value = nextGroupStart
+}
+
+// 컴포넌트 진입(새로고침/페이지 재방문) 시 필터 강제 초기화 + BE 호출
+//  - watch 가 이미 등록되어 있어도 onMounted 시점에는 트리거되지 않으므로 최초 1회 명시 호출
 onMounted(() => {
   filter.keyword = ''
   filter.role = ''
   filter.status = ''
   currentPage.value = 1
+  loadAccounts()       // 첫 페이지 목록 조회
+  loadPendingCount()   // PENDING 뱃지 카운트
 })
 
 // ── 상세 패널
@@ -177,8 +237,8 @@ async function confirmWithdraw() {
     // 로컬 상태 갱신
     selected.value.status = 'WITHDRAWN'
     selected.value.processedAt = result.processedAt
-    // 목록 재조회
-    await loadAccounts()
+    // 목록 + 대기 카운트 재조회 (다른 탭에서 변동되었을 수 있음)
+    await Promise.all([loadAccounts(), loadPendingCount()])
     withdrawConfirm.value = false
   } catch (err) {
     alert(extractErrorMessage(err, '탈퇴 처리에 실패했습니다.'))
@@ -250,24 +310,22 @@ async function confirmWithdraw() {
             type="text"
             placeholder="이름/이메일/사원코드 검색"
             class="h-9 w-64 rounded-none border border-gray-300 bg-gray-50 pl-8 pr-3 text-[13px] text-gray-800 outline-none transition placeholder:text-gray-400 focus:border-[#004D3C] focus:bg-white"
-            @input="currentPage = 1"
           />
         </div>
         <select
           v-model="filter.role"
           class="h-9 rounded-none border border-gray-300 bg-gray-50 px-3 text-[13px] text-gray-700 outline-none transition focus:border-[#004D3C] focus:bg-white"
-          @change="currentPage = 1"
         >
           <option v-for="o in roleOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
         </select>
         <select
           v-model="filter.status"
           class="h-9 rounded-none border border-gray-300 bg-gray-50 px-3 text-[13px] text-gray-700 outline-none transition focus:border-[#004D3C] focus:bg-white"
-          @change="currentPage = 1"
         >
           <option v-for="o in statusOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
         </select>
-        <span class="text-[12px] font-medium text-gray-400">{{ filtered.length }}건</span>
+        <!-- 서버 페이징 총 건수 (검색 결과 기준) -->
+        <span class="text-[12px] font-medium text-gray-400">{{ totalElements }}건</span>
       </section>
 
       <!-- 로딩 / 에러 -->
@@ -303,7 +361,7 @@ async function confirmWithdraw() {
             </thead>
             <tbody class="divide-y divide-gray-100 border-t border-gray-200">
               <tr
-                v-for="m in paginated"
+                v-for="m in visibleMembers"
                 :key="m.id"
                 class="cursor-pointer transition-colors hover:bg-gray-50/50"
                 :class="{
@@ -332,7 +390,7 @@ async function confirmWithdraw() {
                   </span>
                 </td>
               </tr>
-              <tr v-if="paginated.length === 0">
+              <tr v-if="visibleMembers.length === 0">
                 <td colspan="7" class="px-3 py-10 text-center text-[13px] text-gray-400">조회된 계정이 없습니다.</td>
               </tr>
             </tbody>
@@ -342,32 +400,53 @@ async function confirmWithdraw() {
         <!-- 페이지네이션 -->
         <div class="flex items-center justify-between border-t border-gray-200 bg-gray-50 px-3 py-2">
           <span class="text-[11px] font-medium text-gray-400">
-            <template v-if="filtered.length > 0">
-              {{ (currentPage - 1) * PAGE_SIZE + 1 }}–{{ Math.min(currentPage * PAGE_SIZE, filtered.length) }} / 전체 {{ filtered.length }}건
+            <template v-if="totalElements > 0">
+              {{ (currentPage - 1) * PAGE_SIZE + 1 }}–{{ Math.min(currentPage * PAGE_SIZE, totalElements) }} / 전체 {{ totalElements }}건
             </template>
             <template v-else>0건</template>
           </span>
           <div class="flex items-center gap-1">
+            <!-- << 이전 5페이지 그룹 -->
+            <button
+              type="button"
+              :disabled="currentGroup === 1"
+              class="flex h-7 w-7 items-center justify-center border border-gray-300 bg-white text-[12px] text-gray-500 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
+              @click="goPrevGroup"
+              title="이전 5페이지"
+            >«</button>
+            <!-- < 한 페이지 이전 -->
             <button
               type="button"
               :disabled="currentPage === 1"
               class="flex h-7 w-7 items-center justify-center border border-gray-300 bg-white text-[12px] text-gray-500 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
               @click="currentPage--"
+              title="이전 페이지"
             >‹</button>
+            <!-- 페이지 번호 (5개씩) -->
             <button
-              v-for="p in totalPages"
+              v-for="p in visiblePages"
               :key="p"
               type="button"
               class="flex h-7 min-w-[28px] items-center justify-center border text-[12px] font-medium transition"
               :class="p === currentPage ? 'border-[#004D3C] bg-[#004D3C] text-white' : 'border-gray-300 bg-white text-gray-500 hover:bg-gray-100'"
               @click="currentPage = p"
             >{{ p }}</button>
+            <!-- > 한 페이지 다음 -->
             <button
               type="button"
               :disabled="currentPage === totalPages"
               class="flex h-7 w-7 items-center justify-center border border-gray-300 bg-white text-[12px] text-gray-500 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
               @click="currentPage++"
+              title="다음 페이지"
             >›</button>
+            <!-- >> 다음 5페이지 그룹 -->
+            <button
+              type="button"
+              :disabled="currentGroup === totalGroups"
+              class="flex h-7 w-7 items-center justify-center border border-gray-300 bg-white text-[12px] text-gray-500 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
+              @click="goNextGroup"
+              title="다음 5페이지"
+            >»</button>
           </div>
         </div>
       </section>

--- a/src/views/user/SignupView.vue
+++ b/src/views/user/SignupView.vue
@@ -583,11 +583,21 @@ function onInfraChange() {
             <p class="text-[12px] font-black text-[#004D3C]">추가 정보</p>
           </div>
           <label class="flex flex-col gap-1.5">
-            <span class="text-[12px] font-bold text-gray-600">신청 사유 (선택)</span>
+            <div class="flex items-center justify-between">
+              <span class="text-[12px] font-bold text-gray-600">신청 사유 (선택)</span>
+              <!-- 글자수 카운트 (500자 한정) -->
+              <span
+                class="text-[11px] font-medium"
+                :class="(form.reason?.length || 0) > 500 ? 'text-red-600' : 'text-gray-400'"
+              >
+                {{ form.reason?.length || 0 }} / 500
+              </span>
+            </div>
             <textarea
                 v-model="form.reason"
                 placeholder="추가 전달 사항 입력"
                 rows="2"
+                maxlength="500"
                 class="resize-none border border-gray-300 bg-gray-50 px-3 py-2 text-sm text-gray-900 outline-none transition placeholder:text-gray-400 focus:border-[#004D3C] focus:bg-white"
             />
           </label>


### PR DESCRIPTION
## 📌 요약
- 계정 관리/승인 화면 서버 사이드 페이징 전환 + 회원가입 신청 사유 글자수 카운트 추가

<br><br>

## 🎯 작업 내용
- **`AccountListView` / `AccountApprovalView` 서버 페이징 전환** — 클라이언트 전체 로드/필터 제거, BE Page 응답 기반 페이징
- **`account.js` API 시그니처 확장** — `listAll`/`listPending` 에 `page/size/keyword/role/status` 파라미터 추가, 빈 문자열은 미전송 처리
- **키워드 검색 디바운스 + 필터/페이지 watch** — 키워드 300ms 디바운스 후 첫 페이지 호출, 권한/상태/페이지 변경 시 즉시 BE 재호출
- **PENDING 뱃지 카운트 정확화** — size=1 별도 API 호출로 `totalElements` 만 받아 탭 뱃지 표시
- **회원가입 신청 사유 글자수 카운트** — 우상단 실시간 글자수 표시 + `maxlength=500` 입력 제한, 초과 시 빨간색 강조

<br><br>

## ✔️ 참고 사항
- **BE PR 과 함께 머지 필요** — BE 응답 구조 `List → Page` 변경 의존
- 1665명 더미 데이터 환경에서 검색 / 권한 필터 / 상태 필터 / 페이지 이동 모두 동작 확인 완료
- 승인/거절/탈퇴 성공 시 목록 + PENDING 카운트 동시 갱신 (`Promise.all`)
- 키워드 디바운스 300ms 적용으로 BE 호출 빈도 최소화

<br><br>

## ✔️ 관련 이슈

- Close #503 

<br><br>