### PR TITLE
511 refactor 피드백 작업

### DIFF
--- a/src/api/hq/analytics.js
+++ b/src/api/hq/analytics.js
@@ -5,7 +5,7 @@
  *   GET /api/hq/analytics/sales       — 판매량 통계
  *   GET /api/hq/analytics/order-stats — 발주량 통계
  *   GET /api/hq/analytics/turnover    — 재고 회전율 통계
- *   GET /api/hq/analytics/vendor      — 순환재고 거래처 통계
+ *   GET /api/hq/analytics/vendor      — 순환재고 판매 통계
  *   GET /api/hq/analytics/dashboard   — 통합 KPI 대시보드
  */
 
@@ -70,7 +70,7 @@ export const turnoverAnalyticsApi = {
 
 export const vendorAnalyticsApi = {
   /**
-   * 순환재고 거래처 통계 조회.
+   * 순환재고 판매 통계 조회.
    * @param {{ period: 'MONTH'|'HALF_YEAR'|'YEAR',
    *           from: string,   // 'YYYY-MM-DD'
    *           to: string }} params

--- a/src/api/hq/esg.js
+++ b/src/api/hq/esg.js
@@ -103,25 +103,64 @@ export const circularRevenueApi = {
 }
 
 /**
- * 친환경 나무 키우기 점수 — 연간 sale 거래 이벤트.
+ * 친환경 나무 키우기 점수 — 연간 sale 거래 이벤트 + 통계/차트 풀세트 (Phase 3 A''-1).
  *
  * 응답 형태:
  *   {
  *     year: 2026,
- *     events: [
- *       { id, date: 'yyyy-MM-dd', type: 'sale', buyer, material, weightKg,
- *         isNewBuyer, isLocalPartner }, ...
- *     ]
+ *     events: [ // 페이지 슬라이스 (필터 적용 후)
+ *       { id, date, type:'sale', buyer, material, weightKg,
+ *         isNewBuyer, isLocalPartner, mainMaterialCode, mainMaterialRatio,
+ *         saleExecution, carbon, newBuyer, localPartner, total, scoreValid }, ...
+ *     ],
+ *     summary:           { totalScore, saleExecutionSum, carbonSum, newBuyerSum, localPartnerSum,
+ *                          totalEventCount, validEventCount, totalKg, avgScore },
+ *     monthlyBreakdown:  [{ month: 1, score: ... }, ... 12개 고정 (필터 적용 후)],
+ *     categoryBreakdown: { saleExecution, carbon, newBuyer, localPartner },
+ *     page, size, totalElements, totalPages
  *   }
  *
- * 기부 이벤트는 BE 에 도메인 없으므로 FE 에서 mock 으로 머지.
+ * 통계(summary/monthly/category)는 "필터 적용 후 전체" 기준 → 페이지 이동 시에도 차트/KPI 유지.
  */
 export const scoreEventsApi = {
   /**
-   * @param {number} [year] — 미지정 시 BE 가 현재 연도 사용
+   * @param {object} [params]
+   * @param {number} [params.year]
+   * @param {number} [params.page=0]    — 0-based 페이지 번호
+   * @param {number} [params.size=20]   — 페이지 크기 (서버에서 1~200 클램프)
+   * @param {string} [params.dateFrom]  — 'yyyy-MM-dd'
+   * @param {string} [params.dateTo]    — 'yyyy-MM-dd'
+   * @param {'ALL'|'saleExecution'|'carbon'|'newBuyer'|'localPartner'} [params.category='ALL']
    */
-  get: (year) =>
-    apiClient
-      .get('/api/hq/esg/score-events', { params: year ? { year } : {} })
-      .then(unwrap),
+  get: (params = {}) => {
+    // 빈 값/undefined 는 url 에 포함하지 않도록 정리 — BE 가 defaultValue 로 처리
+    const query = {}
+    if (params.year != null)               query.year     = params.year
+    if (params.page != null)               query.page     = params.page
+    if (params.size != null)               query.size     = params.size
+    if (params.dateFrom)                   query.dateFrom = params.dateFrom
+    if (params.dateTo)                     query.dateTo   = params.dateTo
+    if (params.category && params.category !== 'ALL') query.category = params.category
+    return apiClient.get('/api/hq/esg/score-events', { params: query }).then(unwrap)
+  },
+}
+
+/**
+ * 소재 환산 계수 마스터 (Phase 1 BE 이관).
+ *  - FE 가 ESG 페이지 진입 시 1회 호출 → esgStore.materialFactors 캐싱
+ *  - 본사 운영자가 material.carbon_factor 만 갱신해도 FE 재배포 없이 즉시 반영
+ *  - Higg MSI v3 / EU PEF 표준값 + 동물성 섬유 cap 적용된 값
+ *
+ * 응답 형태:
+ *   {
+ *     factors: [
+ *       { code: 'COTTON', label: '면', group: 'NATURAL_SINGLE', factor: 6.000 },
+ *       { code: 'POLYESTER', label: '폴리에스터', group: 'SYNTHETIC', factor: 6.500 },
+ *       { code: 'BLEND', label: '혼방', group: 'BLEND', factor: 5.500 },
+ *       ...
+ *     ]
+ *   }
+ */
+export const materialFactorsApi = {
+  get: () => apiClient.get('/api/hq/esg/material-factors').then(unwrap),
 }

--- a/src/components/common/AppLayout.vue
+++ b/src/components/common/AppLayout.vue
@@ -456,7 +456,7 @@ const iconMap = {
                 v-if="unreadCount > 0"
                 class="absolute -right-0.5 -top-0.5 flex h-3.5 min-w-[14px] items-center justify-center rounded-full bg-red-500 px-1 text-[9px] font-bold leading-none text-white ring-1 ring-[#004D3C]"
               >
-                {{ unreadCount > 99 ? '99+' : unreadCount }}
+                {{ unreadCount > 9 ? '9+' : unreadCount }}
               </span>
             </button>
 
@@ -470,7 +470,7 @@ const iconMap = {
                   <Bell :size="14" class="text-emerald-700" />
                   <span class="text-xs font-bold">알림</span>
                   <span v-if="unreadCount > 0" class="rounded-full bg-red-100 px-1.5 py-0.5 text-[9px] font-bold text-red-700">
-                    {{ unreadCount }}
+                    {{ unreadCount > 9 ? '9+' : unreadCount }}
                   </span>
                 </div>
                 <button

--- a/src/components/common/EsgTreeWidget.vue
+++ b/src/components/common/EsgTreeWidget.vue
@@ -8,15 +8,33 @@ defineProps({
 })
 
 const esg = useEsgStore()
-const { totalPoints, stage, stageProgress, pointsToNext, maxStage } = storeToRefs(esg)
+// stage / stageProgress / pointsToNext 는 computed → storeToRefs 로 ref 추출 가능.
+// maxStage / stageThresholds 는 store 내부 상수 (ref 아님) → esg 객체로 직접 접근.
+const { totalPoints, stage, stageProgress, pointsToNext } = storeToRefs(esg)
+
+// ─────────── DEV 단계 미리보기 (디자인 확인용 임시 컨트롤) ───────────
+// import.meta.env.DEV 가 true 인 환경(npm run dev)에서만 노출, 빌드 결과물에는 미포함.
+// 테스트 완료 후 이 블록과 템플릿의 v-if="isDev" 영역만 삭제하면 됨.
+const isDev = import.meta.env.DEV
+
+function prevStage() {
+  if (stage.value <= 1) return
+  // 한 단계 아래의 임계값 시작점으로 totalPoints 강제 세팅
+  esg.setTotalPoints(esg.stageThresholds[stage.value - 2])
+}
+function nextStage() {
+  if (stage.value >= esg.maxStage) return
+  // 다음 단계 임계값 시작점으로 강제 세팅
+  esg.setTotalPoints(esg.stageThresholds[stage.value])
+}
 
 const stageLabels = [
   '씨앗',
   '새싹',
+  '떡잎 새싹',
   '어린 묘목',
-  '묘목',
+  '청년 묘목',
   '청년 나무',
-  '성장 나무',
   '풍성한 나무',
   '튼튼한 나무',
   '거목',
@@ -24,14 +42,8 @@ const stageLabels = [
 ]
 const stageLabel = computed(() => stageLabels[stage.value - 1])
 
-// 성장 공식 — Stage 1 씨앗(매우 작음) → Stage 10 거목(viewBox top 까지 길쭉)
-// viewBox `0 -32 100 132` 기준: 지면 cy=100 (viewBox 최하단, 라벨 글자 바로 위)
-const TRUNK_BOTTOM = 99   // 줄기 바닥 y (지면 cy=100 바로 위)
-const trunkHeight = computed(() => 5 + stage.value * 8.5)      // 1:13.5, 5:47.5, 10:90
-const crownRadius = computed(() => 3 + stage.value * 2.7)      // 1:5.7, 5:16.5, 10:30
-const crownCenterY = computed(() => TRUNK_BOTTOM - trunkHeight.value - crownRadius.value * 0.35)
-const showSideLeaves = computed(() => stage.value >= 4)
-const showFruits = computed(() => stage.value >= 8)
+// Lv.7~10 은 Lv.6 의 곡선 트렁크/잎 클러스터 무드를 따라 각 레벨별 별도 SVG 로 손그림.
+// 이전 버전의 trunkHeight/crownRadius 자동 계산 로직은 폐기 — 동일 톤의 풍성한 성장 표현을 위해 손튜닝 채택.
 </script>
 
 <template>
@@ -53,66 +65,423 @@ const showFruits = computed(() => stage.value >= 8)
       </div>
 
       <div :class="expanded ? 'flex min-h-0 flex-1 items-end justify-center' : 'flex h-36 items-end justify-center'">
-        <svg viewBox="0 -32 100 132" class="h-full w-auto" aria-hidden="true">
+        <svg viewBox="0 -32 100 170" preserveAspectRatio="xMidYMax meet" class="h-full w-auto" aria-hidden="true">
           <ellipse cx="50" cy="100" rx="30" ry="2" class="fill-emerald-200/70" />
 
-          <rect
-            x="48"
-            :y="TRUNK_BOTTOM - trunkHeight"
-            width="4"
-            :height="trunkHeight"
-            rx="1.2"
-            class="fill-amber-800"
-          />
+          <!-- Lv.1 씨앗: 흙더미 + 흙에 더 깊이 묻힌 씨앗 (트렁크/왕관 미표시) -->
+          <template v-if="stage === 1">
+            <!-- 흙더미 (작은 갈색 언덕) -->
+            <ellipse cx="50" cy="100" rx="13" ry="4" class="fill-amber-900" />
+            <ellipse cx="50" cy="99" rx="10" ry="2.5" class="fill-amber-800" />
+            <!-- 씨앗 (흙 안쪽으로 내려가 거의 묻힌 형태 — 위쪽만 살짝 보임) -->
+            <ellipse cx="50" cy="99.5" rx="3.5" ry="2.3" class="fill-amber-700" />
+            <!-- 씨앗 표면의 갈라진 선 (디테일) -->
+            <line
+              x1="48.6" y1="99.1" x2="51.4" y2="99.1"
+              class="stroke-amber-950"
+              stroke-width="0.4"
+              stroke-linecap="round"
+            />
+          </template>
 
-          <circle
-            v-if="stage >= 2"
-            cx="50"
-            :cy="crownCenterY"
-            :r="crownRadius"
-            class="fill-emerald-500"
-          />
-          <circle
-            v-if="showSideLeaves"
-            :cx="50 - crownRadius * 0.55"
-            :cy="crownCenterY + crownRadius * 0.15"
-            :r="crownRadius * 0.7"
-            class="fill-emerald-600"
-          />
-          <circle
-            v-if="showSideLeaves"
-            :cx="50 + crownRadius * 0.55"
-            :cy="crownCenterY + crownRadius * 0.15"
-            :r="crownRadius * 0.7"
-            class="fill-emerald-400"
-          />
-          <circle
-            v-if="stage >= 6"
-            cx="50"
-            :cy="crownCenterY - crownRadius * 0.5"
-            :r="crownRadius * 0.55"
-            class="fill-emerald-300"
-          />
+          <!-- Lv.2 새싹: 흙 + 가는 녹색 줄기 + 양쪽 떡잎 (트렁크/왕관 미표시) -->
+          <template v-if="stage === 2">
+            <!-- 흙더미 (Lv.1 의 흙 연속성 유지) -->
+            <ellipse cx="50" cy="100" rx="13" ry="4" class="fill-amber-900" />
+            <ellipse cx="50" cy="99" rx="10" ry="2.5" class="fill-amber-800" />
+            <!-- 새싹 줄기 (가는 연한 녹색 막대) -->
+            <rect x="49.3" y="89" width="1.4" height="10.5" rx="0.7" class="fill-emerald-600" />
+            <!-- 좌측 떡잎 (살짝 위로 기울어진 작은 타원) -->
+            <ellipse
+              cx="46" cy="88.5" rx="4" ry="1.8"
+              transform="rotate(-35 46 88.5)"
+              class="fill-emerald-500"
+            />
+            <!-- 우측 떡잎 (살짝 위로 기울어진 작은 타원, 톤 변경) -->
+            <ellipse
+              cx="54" cy="88.5" rx="4" ry="1.8"
+              transform="rotate(35 54 88.5)"
+              class="fill-emerald-400"
+            />
+            <!-- 줄기 끝 중앙 작은 새순 점 (성장 표현) -->
+            <circle cx="50" cy="88" r="0.9" class="fill-emerald-300" />
+          </template>
 
-          <template v-if="showFruits">
-            <circle
-              :cx="50 - crownRadius * 0.4"
-              :cy="crownCenterY + crownRadius * 0.1"
-              r="1.8"
-              class="fill-rose-400"
+          <!-- Lv.3 본잎: 새싹의 연장 — 떡잎 + 위쪽 본잎 2개 추가 + 줄기 살짝 더 길어짐 -->
+          <template v-if="stage === 3">
+            <!-- 흙더미 -->
+            <ellipse cx="50" cy="100" rx="13" ry="4" class="fill-amber-900" />
+            <ellipse cx="50" cy="99" rx="10" ry="2.5" class="fill-amber-800" />
+            <!-- 줄기 (Lv.2 보다 길어짐) -->
+            <rect x="49.2" y="82" width="1.6" height="17.5" rx="0.8" class="fill-emerald-700" />
+            <!-- 떡잎 (Lv.2 유지, 줄기 중간 높이) -->
+            <ellipse
+              cx="46" cy="90" rx="4" ry="1.8"
+              transform="rotate(-35 46 90)"
+              class="fill-emerald-500"
             />
-            <circle
-              :cx="50 + crownRadius * 0.35"
-              :cy="crownCenterY - crownRadius * 0.2"
-              r="1.8"
-              class="fill-rose-400"
+            <ellipse
+              cx="54" cy="90" rx="4" ry="1.8"
+              transform="rotate(35 54 90)"
+              class="fill-emerald-400"
             />
-            <circle
-              :cx="50"
-              :cy="crownCenterY + crownRadius * 0.45"
-              r="1.8"
-              class="fill-rose-400"
+            <!-- 본잎 (위쪽에 새로 자란 잎 2개, 약간 위로 펼침) -->
+            <ellipse
+              cx="45.5" cy="83.5" rx="4.5" ry="2.2"
+              transform="rotate(-25 45.5 83.5)"
+              class="fill-emerald-600"
             />
+            <ellipse
+              cx="54.5" cy="83.5" rx="4.5" ry="2.2"
+              transform="rotate(25 54.5 83.5)"
+              class="fill-emerald-500"
+            />
+            <!-- 중앙 새순 (가장 위쪽 성장점) -->
+            <circle cx="50" cy="81" r="1.1" class="fill-emerald-300" />
+          </template>
+
+          <!-- Lv.4 묘목: 트렁크 + V자 분지 + 잎 (위로 늘림 — Lv.3 → Lv.5 자연 연결) -->
+          <template v-if="stage === 4">
+            <!-- 흙더미 -->
+            <ellipse cx="50" cy="100" rx="13" ry="4" class="fill-amber-900" />
+            <ellipse cx="50" cy="99" rx="10" ry="2.5" class="fill-amber-800" />
+            <!-- 트렁크 (높이 26 으로 늘림) -->
+            <rect x="48.5" y="73.5" width="3" height="26" rx="1.2" class="fill-amber-800" />
+            <!-- 좌측 V자 가지 -->
+            <line
+              x1="50" y1="84" x2="42" y2="74"
+              stroke-width="1.4"
+              stroke-linecap="round"
+              class="stroke-amber-800"
+            />
+            <!-- 우측 V자 가지 -->
+            <line
+              x1="50" y1="84" x2="58" y2="74"
+              stroke-width="1.4"
+              stroke-linecap="round"
+              class="stroke-amber-800"
+            />
+            <!-- 좌측 가지 끝 잎 -->
+            <circle cx="41" cy="72" r="4.5" class="fill-emerald-500" />
+            <!-- 우측 가지 끝 잎 -->
+            <circle cx="59" cy="72" r="4.5" class="fill-emerald-400" />
+            <!-- 메인 잎 (위쪽 중앙, 가장 큰 덩어리) -->
+            <circle cx="50" cy="68" r="7" class="fill-emerald-600" />
+            <!-- 상단 작은 성장점 -->
+            <circle cx="50" cy="63" r="2.3" class="fill-emerald-300" />
+          </template>
+
+          <!-- Lv.5 청년 묘목: 자연 곡선 트렁크 + 곡선 가지 + 회전 타원 잎 (자연스러운 형태) -->
+          <template v-if="stage === 5">
+            <!-- 흙더미 -->
+            <ellipse cx="50" cy="100" rx="13" ry="4" class="fill-amber-900" />
+            <ellipse cx="50" cy="99" rx="10" ry="2.5" class="fill-amber-800" />
+
+            <!-- 트렁크 (아래는 굵고 위로 가늘어지는 자연 곡선) -->
+            <path
+              d="M 45.5 99.5 Q 45.5 75 46.3 55 Q 47 38 48 28 L 52 28 Q 53 38 53.7 55 Q 54.5 75 54.5 99.5 Z"
+              class="fill-amber-800"
+            />
+
+            <!-- 좌측 가지 (곡선, 자연스러운 휨) -->
+            <path
+              d="M 48 65 Q 40 60 32 53"
+              stroke-width="2.2"
+              stroke-linecap="round"
+              fill="none"
+              class="stroke-amber-800"
+            />
+            <!-- 우측 가지 (곡선) -->
+            <path
+              d="M 52 65 Q 60 60 68 53"
+              stroke-width="2.2"
+              stroke-linecap="round"
+              fill="none"
+              class="stroke-amber-800"
+            />
+
+            <!-- 잎 3개만 (좌/우/중앙) — 가장 큰 원만 남기고 보조 잎 모두 제거 -->
+            <!-- 좌측 큰 잎 -->
+            <ellipse cx="30" cy="50" rx="9" ry="6" transform="rotate(-25 30 50)" class="fill-emerald-700" />
+            <!-- 우측 큰 잎 -->
+            <ellipse cx="70" cy="50" rx="9" ry="6" transform="rotate(25 70 50)" class="fill-emerald-600" />
+            <!-- 메인 왕관 (중앙 위쪽 가장 큰 잎) -->
+            <ellipse cx="50" cy="33" rx="13" ry="11" class="fill-emerald-500" />
+          </template>
+
+          <!-- Lv.6 청년 나무: 곡선 트렁크 + 풍성한 잎 클러스터 + 가지 추가 + 트렁크 결무늬 -->
+          <template v-if="stage === 6">
+            <!-- 흙더미 -->
+            <ellipse cx="50" cy="100" rx="13" ry="4" class="fill-amber-900" />
+            <ellipse cx="50" cy="99" rx="10" ry="2.5" class="fill-amber-800" />
+
+            <!-- 트렁크 (곡선, 굵음→가늘어짐) -->
+            <path
+              d="M 44.5 99.5 Q 44.5 70 45.5 45 Q 46.5 28 48 18 L 52 18 Q 53.5 28 54.5 45 Q 55.5 70 55.5 99.5 Z"
+              class="fill-amber-800"
+            />
+            <!-- 트렁크 결무늬 (자연 디테일) -->
+            <path d="M 47.5 80 Q 48 65 47.5 50" stroke-width="0.5" fill="none" class="stroke-amber-950" opacity="0.5" />
+            <path d="M 52 78 Q 51.5 60 52.2 45" stroke-width="0.5" fill="none" class="stroke-amber-950" opacity="0.5" />
+
+            <!-- 좌측 메인 가지 -->
+            <path d="M 47 55 Q 38 50 28 42" stroke-width="2.5" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <!-- 우측 메인 가지 -->
+            <path d="M 53 55 Q 62 50 72 42" stroke-width="2.5" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <!-- 위쪽 좌 작은 가지 -->
+            <path d="M 48 38 Q 44 32 40 26" stroke-width="1.8" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <!-- 위쪽 우 작은 가지 -->
+            <path d="M 52 38 Q 56 32 60 26" stroke-width="1.8" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+
+            <!-- 좌측 잎 클러스터 (큰 + 보조 2개) -->
+            <ellipse cx="26" cy="40" rx="11" ry="7.5" transform="rotate(-22 26 40)" class="fill-emerald-700" />
+            <ellipse cx="34" cy="35" rx="7"  ry="5"   transform="rotate(-15 34 35)" class="fill-emerald-500" />
+            <ellipse cx="20" cy="36" rx="6"  ry="4.5" transform="rotate(-38 20 36)" class="fill-emerald-600" />
+
+            <!-- 우측 잎 클러스터 (큰 + 보조 2개) -->
+            <ellipse cx="74" cy="40" rx="11" ry="7.5" transform="rotate(22 74 40)" class="fill-emerald-600" />
+            <ellipse cx="66" cy="35" rx="7"  ry="5"   transform="rotate(15 66 35)" class="fill-emerald-400" />
+            <ellipse cx="80" cy="36" rx="6"  ry="4.5" transform="rotate(38 80 36)" class="fill-emerald-500" />
+
+            <!-- 메인 왕관 + 상단 보조 잎 (풍성한 윗부분) -->
+            <ellipse cx="50" cy="20" rx="17" ry="14" class="fill-emerald-500" />
+            <ellipse cx="41" cy="12" rx="7"  ry="6"  transform="rotate(-20 41 12)" class="fill-emerald-600" />
+            <ellipse cx="59" cy="12" rx="7"  ry="6"  transform="rotate(20 59 12)" class="fill-emerald-400" />
+            <ellipse cx="50" cy="6"  rx="6.5" ry="5" class="fill-emerald-300" />
+          </template>
+
+          <!-- Lv.7 풍성한 나무: Lv.6 의 곡선 트렁크 + 가지 1쌍 추가(총 3쌍) + 잎 클러스터 4개씩 -->
+          <template v-if="stage === 7">
+            <!-- 흙더미 -->
+            <ellipse cx="50" cy="100" rx="14" ry="4" class="fill-amber-900" />
+            <ellipse cx="50" cy="99" rx="11" ry="2.5" class="fill-amber-800" />
+
+            <!-- 트렁크 (Lv.6 보다 살짝 길고 굵음) -->
+            <path
+              d="M 44 99.5 Q 44 70 45 45 Q 46 25 47.5 10 L 52.5 10 Q 54 25 55 45 Q 56 70 56 99.5 Z"
+              class="fill-amber-800"
+            />
+            <!-- 트렁크 결무늬 -->
+            <path d="M 47 80 Q 47.5 60 47 40" stroke-width="0.5" fill="none" class="stroke-amber-950" opacity="0.5" />
+            <path d="M 52.5 78 Q 52 58 53 38" stroke-width="0.5" fill="none" class="stroke-amber-950" opacity="0.5" />
+
+            <!-- 하단 메인 가지 -->
+            <path d="M 46.5 60 Q 36 55 24 46" stroke-width="2.6" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 53.5 60 Q 64 55 76 46" stroke-width="2.6" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <!-- 중단 가지 (신규) -->
+            <path d="M 47 40 Q 40 33 30 26" stroke-width="2" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 53 40 Q 60 33 70 26" stroke-width="2" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <!-- 상단 작은 가지 -->
+            <path d="M 48 22 Q 44 14 40 6" stroke-width="1.6" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 52 22 Q 56 14 60 6" stroke-width="1.6" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+
+            <!-- 좌측 잎 클러스터 (4개) -->
+            <ellipse cx="22" cy="44" rx="12" ry="8" transform="rotate(-22 22 44)" class="fill-emerald-700" />
+            <ellipse cx="31" cy="38" rx="7.5" ry="5.5" transform="rotate(-15 31 38)" class="fill-emerald-500" />
+            <ellipse cx="16" cy="40" rx="6.5" ry="5" transform="rotate(-38 16 40)" class="fill-emerald-600" />
+            <ellipse cx="27" cy="24" rx="7" ry="5.5" transform="rotate(-18 27 24)" class="fill-emerald-500" />
+
+            <!-- 우측 잎 클러스터 (4개) -->
+            <ellipse cx="78" cy="44" rx="12" ry="8" transform="rotate(22 78 44)" class="fill-emerald-600" />
+            <ellipse cx="69" cy="38" rx="7.5" ry="5.5" transform="rotate(15 69 38)" class="fill-emerald-400" />
+            <ellipse cx="84" cy="40" rx="6.5" ry="5" transform="rotate(38 84 40)" class="fill-emerald-500" />
+            <ellipse cx="73" cy="24" rx="7" ry="5.5" transform="rotate(18 73 24)" class="fill-emerald-400" />
+
+            <!-- 메인 왕관 + 상단 보조 잎 -->
+            <ellipse cx="50" cy="12" rx="19" ry="15" class="fill-emerald-500" />
+            <ellipse cx="39" cy="3" rx="8" ry="6.5" transform="rotate(-20 39 3)" class="fill-emerald-600" />
+            <ellipse cx="61" cy="3" rx="8" ry="6.5" transform="rotate(20 61 3)" class="fill-emerald-400" />
+            <ellipse cx="50" cy="-4" rx="7.5" ry="6" class="fill-emerald-300" />
+          </template>
+
+          <!-- Lv.8 튼튼한 나무: Lv.7 + 가지 한 쌍 더 + 첫 열매 등장 + 트렁크 더 길게 -->
+          <template v-if="stage === 8">
+            <!-- 흙더미 -->
+            <ellipse cx="50" cy="100" rx="15" ry="4.5" class="fill-amber-900" />
+            <ellipse cx="50" cy="99" rx="12" ry="2.8" class="fill-amber-800" />
+
+            <!-- 트렁크 (더 길어 viewBox 위쪽까지) -->
+            <path
+              d="M 43.5 99.5 Q 43.5 68 44.5 42 Q 45.5 22 47 5 L 53 5 Q 54.5 22 55.5 42 Q 56.5 68 56.5 99.5 Z"
+              class="fill-amber-800"
+            />
+            <!-- 트렁크 결무늬 (2개) -->
+            <path d="M 46.5 82 Q 47 60 46.5 38" stroke-width="0.6" fill="none" class="stroke-amber-950" opacity="0.55" />
+            <path d="M 53 80 Q 52.5 58 53.3 35" stroke-width="0.6" fill="none" class="stroke-amber-950" opacity="0.55" />
+
+            <!-- 하단 메인 가지 -->
+            <path d="M 46 65 Q 35 60 22 50" stroke-width="2.8" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 54 65 Q 65 60 78 50" stroke-width="2.8" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <!-- 중단 가지 -->
+            <path d="M 46 45 Q 38 38 26 30" stroke-width="2.2" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 54 45 Q 62 38 74 30" stroke-width="2.2" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <!-- 상단 가지 -->
+            <path d="M 47 25 Q 42 18 36 10" stroke-width="1.8" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 53 25 Q 58 18 64 10" stroke-width="1.8" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+
+            <!-- 좌측 잎 클러스터 (5개) -->
+            <ellipse cx="20" cy="48" rx="13" ry="9" transform="rotate(-22 20 48)" class="fill-emerald-700" />
+            <ellipse cx="30" cy="42" rx="8" ry="6" transform="rotate(-15 30 42)" class="fill-emerald-500" />
+            <ellipse cx="13" cy="44" rx="7" ry="5.5" transform="rotate(-40 13 44)" class="fill-emerald-600" />
+            <ellipse cx="24" cy="28" rx="8" ry="6" transform="rotate(-20 24 28)" class="fill-emerald-500" />
+            <ellipse cx="34" cy="20" rx="6.5" ry="5" transform="rotate(-10 34 20)" class="fill-emerald-400" />
+
+            <!-- 우측 잎 클러스터 (5개) -->
+            <ellipse cx="80" cy="48" rx="13" ry="9" transform="rotate(22 80 48)" class="fill-emerald-600" />
+            <ellipse cx="70" cy="42" rx="8" ry="6" transform="rotate(15 70 42)" class="fill-emerald-400" />
+            <ellipse cx="87" cy="44" rx="7" ry="5.5" transform="rotate(40 87 44)" class="fill-emerald-500" />
+            <ellipse cx="76" cy="28" rx="8" ry="6" transform="rotate(20 76 28)" class="fill-emerald-400" />
+            <ellipse cx="66" cy="20" rx="6.5" ry="5" transform="rotate(10 66 20)" class="fill-emerald-500" />
+
+            <!-- 메인 왕관 + 상단 풍성 보조 잎 -->
+            <ellipse cx="50" cy="6" rx="21" ry="16" class="fill-emerald-500" />
+            <ellipse cx="37" cy="-3" rx="8.5" ry="7" transform="rotate(-22 37 -3)" class="fill-emerald-600" />
+            <ellipse cx="63" cy="-3" rx="8.5" ry="7" transform="rotate(22 63 -3)" class="fill-emerald-400" />
+            <ellipse cx="50" cy="-11" rx="9" ry="7" class="fill-emerald-300" />
+
+            <!-- 열매 3개 (Lv.8 부터 등장 — 작은 rose) -->
+            <circle cx="42" cy="14" r="2.1" class="fill-rose-400" />
+            <circle cx="58" cy="9" r="2.1" class="fill-rose-400" />
+            <circle cx="50" cy="20" r="2.1" class="fill-rose-400" />
+          </template>
+
+          <!-- Lv.9 거목: Lv.8 + 더 굵은 트렁크 + 가지 4쌍 + 풍성한 잎 + 열매 5개 -->
+          <template v-if="stage === 9">
+            <!-- 흙더미 (더 크게) -->
+            <ellipse cx="50" cy="100" rx="17" ry="5" class="fill-amber-900" />
+            <ellipse cx="50" cy="99" rx="13" ry="3" class="fill-amber-800" />
+
+            <!-- 트렁크 (가장 굵고 길어 viewBox 위쪽 활용) -->
+            <path
+              d="M 42 99.5 Q 42 65 43 38 Q 44 18 46 -2 L 54 -2 Q 56 18 57 38 Q 58 65 58 99.5 Z"
+              class="fill-amber-800"
+            />
+            <!-- 트렁크 결무늬 (3개로 풍성) -->
+            <path d="M 45.5 82 Q 46 58 45.5 32" stroke-width="0.6" fill="none" class="stroke-amber-950" opacity="0.6" />
+            <path d="M 50.5 80 Q 50 50 50.5 25" stroke-width="0.5" fill="none" class="stroke-amber-950" opacity="0.4" />
+            <path d="M 54 82 Q 53.5 56 54.5 28" stroke-width="0.6" fill="none" class="stroke-amber-950" opacity="0.6" />
+
+            <!-- 가지 4쌍 — 하단/중하단/중상단/상단 -->
+            <path d="M 45 70 Q 33 65 18 54" stroke-width="3" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 55 70 Q 67 65 82 54" stroke-width="3" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 45 50 Q 36 43 22 34" stroke-width="2.4" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 55 50 Q 64 43 78 34" stroke-width="2.4" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 46 30 Q 40 22 32 13" stroke-width="2" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 54 30 Q 60 22 68 13" stroke-width="2" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 47 10 Q 44 2 40 -6" stroke-width="1.6" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 53 10 Q 56 2 60 -6" stroke-width="1.6" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+
+            <!-- 좌측 잎 클러스터 (6개) -->
+            <ellipse cx="16" cy="52" rx="14" ry="10" transform="rotate(-22 16 52)" class="fill-emerald-700" />
+            <ellipse cx="28" cy="46" rx="9" ry="6.5" transform="rotate(-15 28 46)" class="fill-emerald-500" />
+            <ellipse cx="9" cy="48" rx="7.5" ry="6" transform="rotate(-40 9 48)" class="fill-emerald-600" />
+            <ellipse cx="20" cy="32" rx="9" ry="6.5" transform="rotate(-22 20 32)" class="fill-emerald-500" />
+            <ellipse cx="31" cy="22" rx="7.5" ry="5.5" transform="rotate(-12 31 22)" class="fill-emerald-400" />
+            <ellipse cx="24" cy="10" rx="7" ry="5" transform="rotate(-18 24 10)" class="fill-emerald-500" />
+
+            <!-- 우측 잎 클러스터 (6개) -->
+            <ellipse cx="84" cy="52" rx="14" ry="10" transform="rotate(22 84 52)" class="fill-emerald-600" />
+            <ellipse cx="72" cy="46" rx="9" ry="6.5" transform="rotate(15 72 46)" class="fill-emerald-400" />
+            <ellipse cx="91" cy="48" rx="7.5" ry="6" transform="rotate(40 91 48)" class="fill-emerald-500" />
+            <ellipse cx="80" cy="32" rx="9" ry="6.5" transform="rotate(22 80 32)" class="fill-emerald-400" />
+            <ellipse cx="69" cy="22" rx="7.5" ry="5.5" transform="rotate(12 69 22)" class="fill-emerald-500" />
+            <ellipse cx="76" cy="10" rx="7" ry="5" transform="rotate(18 76 10)" class="fill-emerald-400" />
+
+            <!-- 메인 왕관 (거대) + 상단 풍성 보조 잎 -->
+            <ellipse cx="50" cy="-2" rx="24" ry="18" class="fill-emerald-500" />
+            <ellipse cx="34" cy="-11" rx="9.5" ry="7.5" transform="rotate(-22 34 -11)" class="fill-emerald-600" />
+            <ellipse cx="66" cy="-11" rx="9.5" ry="7.5" transform="rotate(22 66 -11)" class="fill-emerald-400" />
+            <ellipse cx="50" cy="-20" rx="10" ry="8" class="fill-emerald-300" />
+            <ellipse cx="43" cy="-22" rx="6" ry="5" class="fill-emerald-400" />
+            <ellipse cx="57" cy="-22" rx="6" ry="5" class="fill-emerald-500" />
+
+            <!-- 열매 5개 (rose) -->
+            <circle cx="38" cy="18" r="2.3" class="fill-rose-400" />
+            <circle cx="62" cy="14" r="2.3" class="fill-rose-400" />
+            <circle cx="50" cy="22" r="2.3" class="fill-rose-400" />
+            <circle cx="45" cy="2" r="2.3" class="fill-rose-400" />
+            <circle cx="56" cy="-4" r="2.3" class="fill-rose-400" />
+          </template>
+
+          <!-- Lv.10 결실의 나무: 최대 풍성도 + 황금 열매 섞은 결실 + 트렁크 결무늬 다중 + 빛나는 광휘 -->
+          <template v-if="stage === 10">
+            <!-- 흙더미 (가장 크게) -->
+            <ellipse cx="50" cy="100" rx="19" ry="5.5" class="fill-amber-900" />
+            <ellipse cx="50" cy="99" rx="15" ry="3.5" class="fill-amber-800" />
+            <!-- 흙 위 풀잎 디테일 (결실의 나무 환경) -->
+            <line x1="38" y1="99" x2="36" y2="96" stroke-width="0.7" stroke-linecap="round" class="stroke-emerald-700" />
+            <line x1="62" y1="99" x2="64" y2="96" stroke-width="0.7" stroke-linecap="round" class="stroke-emerald-700" />
+            <line x1="33" y1="99.5" x2="32" y2="97" stroke-width="0.6" stroke-linecap="round" class="stroke-emerald-600" />
+            <line x1="67" y1="99.5" x2="68" y2="97" stroke-width="0.6" stroke-linecap="round" class="stroke-emerald-600" />
+
+            <!-- 광휘 — 메인 왕관 뒤쪽 부드러운 옅은 빛 (결실의 나무 특별 효과) -->
+            <ellipse cx="50" cy="-8" rx="34" ry="26" class="fill-amber-100" opacity="0.45" />
+
+            <!-- 트렁크 (가장 굵고 viewBox 상단까지) -->
+            <path
+              d="M 40.5 99.5 Q 40.5 63 41.5 35 Q 42.5 15 44.5 -8 L 55.5 -8 Q 57.5 15 58.5 35 Q 59.5 63 59.5 99.5 Z"
+              class="fill-amber-800"
+            />
+            <!-- 트렁크 결무늬 (다중 디테일 — 나이테 풍성) -->
+            <path d="M 44.5 84 Q 45 56 44.5 28" stroke-width="0.7" fill="none" class="stroke-amber-950" opacity="0.65" />
+            <path d="M 50 82 Q 49.5 48 50 18" stroke-width="0.5" fill="none" class="stroke-amber-950" opacity="0.4" />
+            <path d="M 55 84 Q 54.5 54 55.5 24" stroke-width="0.7" fill="none" class="stroke-amber-950" opacity="0.65" />
+            <!-- 트렁크 옹이 (결실 나무 디테일 — 시간의 흔적) -->
+            <ellipse cx="46" cy="70" rx="1.2" ry="2" class="fill-amber-950" opacity="0.4" />
+            <ellipse cx="54" cy="55" rx="1" ry="1.6" class="fill-amber-950" opacity="0.4" />
+
+            <!-- 가지 4쌍 (Lv.9 대비 더 길고 두꺼움) -->
+            <path d="M 43 72 Q 30 67 13 56" stroke-width="3.4" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 57 72 Q 70 67 87 56" stroke-width="3.4" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 43 52 Q 34 44 18 34" stroke-width="2.8" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 57 52 Q 66 44 82 34" stroke-width="2.8" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 44 32 Q 38 22 28 12" stroke-width="2.2" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 56 32 Q 62 22 72 12" stroke-width="2.2" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 45 10 Q 42 0 37 -10" stroke-width="1.8" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 55 10 Q 58 0 63 -10" stroke-width="1.8" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+
+            <!-- 좌측 잎 클러스터 (7개 — 그라데이션 톤) -->
+            <ellipse cx="12" cy="54" rx="15" ry="11" transform="rotate(-22 12 54)" class="fill-emerald-700" />
+            <ellipse cx="25" cy="48" rx="10" ry="7" transform="rotate(-15 25 48)" class="fill-emerald-500" />
+            <ellipse cx="5" cy="50" rx="8" ry="6.5" transform="rotate(-42 5 50)" class="fill-emerald-600" />
+            <ellipse cx="17" cy="32" rx="10" ry="7" transform="rotate(-22 17 32)" class="fill-emerald-500" />
+            <ellipse cx="28" cy="22" rx="8" ry="6" transform="rotate(-12 28 22)" class="fill-emerald-400" />
+            <ellipse cx="22" cy="8" rx="8" ry="6" transform="rotate(-18 22 8)" class="fill-emerald-500" />
+            <ellipse cx="32" cy="-2" rx="6.5" ry="5" transform="rotate(-10 32 -2)" class="fill-emerald-400" />
+
+            <!-- 우측 잎 클러스터 (7개 — 그라데이션 톤) -->
+            <ellipse cx="88" cy="54" rx="15" ry="11" transform="rotate(22 88 54)" class="fill-emerald-600" />
+            <ellipse cx="75" cy="48" rx="10" ry="7" transform="rotate(15 75 48)" class="fill-emerald-400" />
+            <ellipse cx="95" cy="50" rx="8" ry="6.5" transform="rotate(42 95 50)" class="fill-emerald-500" />
+            <ellipse cx="83" cy="32" rx="10" ry="7" transform="rotate(22 83 32)" class="fill-emerald-400" />
+            <ellipse cx="72" cy="22" rx="8" ry="6" transform="rotate(12 72 22)" class="fill-emerald-500" />
+            <ellipse cx="78" cy="8" rx="8" ry="6" transform="rotate(18 78 8)" class="fill-emerald-400" />
+            <ellipse cx="68" cy="-2" rx="6.5" ry="5" transform="rotate(10 68 -2)" class="fill-emerald-500" />
+
+            <!-- 메인 왕관 (최대) + 상단 풍성 보조 잎 -->
+            <ellipse cx="50" cy="-8" rx="27" ry="20" class="fill-emerald-500" />
+            <ellipse cx="32" cy="-18" rx="10" ry="8" transform="rotate(-22 32 -18)" class="fill-emerald-600" />
+            <ellipse cx="68" cy="-18" rx="10" ry="8" transform="rotate(22 68 -18)" class="fill-emerald-400" />
+            <ellipse cx="50" cy="-28" rx="11" ry="8" class="fill-emerald-300" />
+            <ellipse cx="40" cy="-29" rx="6.5" ry="5" class="fill-emerald-400" />
+            <ellipse cx="60" cy="-29" rx="6.5" ry="5" class="fill-emerald-500" />
+            <!-- 최상단 새순 (결실의 시작점) -->
+            <ellipse cx="50" cy="-31" rx="4.5" ry="3.5" class="fill-emerald-200" />
+
+            <!-- 열매 8개 — rose 5개 + amber(황금) 3개 섞어서 "결실" 표현 -->
+            <circle cx="35" cy="20" r="2.5" class="fill-rose-400" />
+            <circle cx="65" cy="16" r="2.5" class="fill-rose-400" />
+            <circle cx="50" cy="24" r="2.5" class="fill-rose-400" />
+            <circle cx="42" cy="0" r="2.5" class="fill-rose-400" />
+            <circle cx="58" cy="-4" r="2.5" class="fill-rose-400" />
+            <circle cx="30" cy="36" r="2.3" class="fill-amber-400" />
+            <circle cx="70" cy="36" r="2.3" class="fill-amber-400" />
+            <circle cx="50" cy="-13" r="2.3" class="fill-amber-400" />
+            <!-- 열매 하이라이트 (광택 점) — 결실의 나무 특유의 윤기 -->
+            <circle cx="34.3" cy="19.3" r="0.7" class="fill-white" opacity="0.7" />
+            <circle cx="64.3" cy="15.3" r="0.7" class="fill-white" opacity="0.7" />
+            <circle cx="29.3" cy="35.3" r="0.6" class="fill-white" opacity="0.7" />
+            <circle cx="69.3" cy="35.3" r="0.6" class="fill-white" opacity="0.7" />
           </template>
         </svg>
       </div>
@@ -131,9 +500,34 @@ const showFruits = computed(() => stage.value >= 8)
           ></div>
         </div>
         <p :class="expanded ? 'text-[10px] leading-tight text-gray-600' : 'text-[9px] leading-tight text-gray-500'">
-          <template v-if="stage >= maxStage">최고 단계 달성</template>
+          <template v-if="stage >= esg.maxStage">최고 단계 달성</template>
           <template v-else>다음 단계까지 {{ pointsToNext.toLocaleString() }}P</template>
         </p>
+
+        <!-- DEV 단계 미리보기 컨트롤 — 디자인 확인용. 빌드 시 자동 제거됨. -->
+        <div v-if="isDev" class="mt-2 flex items-center justify-center gap-2 border-t border-emerald-200/60 pt-2">
+          <button
+            type="button"
+            @click="prevStage"
+            :disabled="stage <= 1"
+            class="rounded border border-gray-300 bg-white/90 px-2 py-0.5 text-[10px] font-bold text-gray-700 hover:bg-emerald-50 disabled:cursor-not-allowed disabled:opacity-40"
+            aria-label="이전 단계 미리보기"
+          >
+            ◀
+          </button>
+          <span class="text-[9px] font-medium uppercase tracking-wider text-gray-500">
+            DEV Lv.{{ stage }}
+          </span>
+          <button
+            type="button"
+            @click="nextStage"
+            :disabled="stage >= esg.maxStage"
+            class="rounded border border-gray-300 bg-white/90 px-2 py-0.5 text-[10px] font-bold text-gray-700 hover:bg-emerald-50 disabled:cursor-not-allowed disabled:opacity-40"
+            aria-label="다음 단계 미리보기"
+          >
+            ▶
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/src/config/roleMenus.js
+++ b/src/config/roleMenus.js
@@ -34,6 +34,7 @@
         { label: '순환 재고 거래처 관리', path: '/hq/circular-inventory/buyers' },
         { label: '순환 재고 판매 등록', path: '/hq/circular-inventory/sales/register' },
         { label: '순환 재고 판매 내역', path: '/hq/circular-inventory/sales/history' },
+        { label: '순환 재고 판매 통계', path: '/hq/analytics/vendors' },
       ],
     },
     {
@@ -56,11 +57,11 @@
       icon: 'check',
     },
     {
-      label: 'ESG 대시보드',
+      label: 'ESG 탄소 성과 관리',
       path: '/hq/esg',
       icon: 'sprout',
       children: [
-        { label: '탄소배출권 관리', path: '/hq/esg' },
+        { label: '탄소 배출 관리', path: '/hq/esg' },
         { label: '친환경 나무 키우기 점수', path: '/hq/esg/tree-score' },
       ],
     },

--- a/src/stores/esg.js
+++ b/src/stores/esg.js
@@ -1,22 +1,34 @@
 import { ref, computed } from 'vue'
 import { defineStore } from 'pinia'
-import { carbonPriceApi, scoreEventsApi } from '@/api/hq/esg.js'
-import {
-  MOCK_DONATION_EVENTS,
-  computeTotalScore,
-  computeCarbonReductionKg,
-  computeMonthlyCarbonReduction,
-  normalizeSaleEvent,
-} from '@/utils/esgScore.js'
+import { carbonPriceApi, scoreEventsApi, materialFactorsApi } from '@/api/hq/esg.js'
+// Phase 3 B 이관 후: 점수 합산/카본 분포는 BE 응답을 그대로 사용 → 계산 함수 import 폐기.
+// MATERIAL_FACTORS 만 시드 fallback 용으로 유지.
+import { MATERIAL_FACTORS } from '@/utils/esgScore.js'
 
-const POINTS_PER_STAGE = 1500
-const MAX_STAGE = 10
+// ESG 나무 단계 임계값 (Curved 곡선, 게임화 자연스러움)
+//  - Lv.1 ~ Lv.10 까지 10단계
+//  - Lv.10 도달 = 1,500,000 pt (만점)
+//  - 초반엔 빠르게 진급 (동기부여), 후반엔 천천히 (도전감)
+//  - 산식: pts >= STAGE_THRESHOLDS[i] 인 가장 큰 i 가 (i+1) 단계
+const STAGE_THRESHOLDS = [
+  0,         // Lv.1 — 씨앗 (시작)
+  5000,      // Lv.2
+  20000,     // Lv.3
+  50000,     // Lv.4
+  100000,    // Lv.5
+  200000,    // Lv.6
+  350000,    // Lv.7
+  600000,    // Lv.8
+  1000000,   // Lv.9
+  1500000,   // Lv.10 — 결실의 나무 (만점)
+]
+const MAX_STAGE = STAGE_THRESHOLDS.length   // 10
 
 // BE 응답 실패 시 폴백 가격 (BE 의 esg.carbon-api.fallback-price 와 동기화: 9,200)
 const KAU_FALLBACK_PRICE = 9200
 
 export const useEsgStore = defineStore('esg', () => {
-  // 초기 0 → fetchTotalPoints() 호출 시 BE sale events + MOCK_DONATION_EVENTS 기반으로 자동 계산
+  // 초기 0 → fetchTotalPoints() 호출 시 BE sale events 기반으로 자동 계산
   const totalPoints = ref(0)
   const totalPointsLoading = ref(false)
   const totalPointsError = ref(null)
@@ -31,10 +43,25 @@ export const useEsgStore = defineStore('esg', () => {
   // 월별 탄소 절감량 (kg CO₂) 12개 — 전월 대비 변동률 계산용
   const carbonReductionMonthly = ref(Array(12).fill(0))
 
+  // 소재 그룹별 탄소 절감량 (kg CO₂)
+  const carbonReductionByGroupKg = ref({ NATURAL_SINGLE: 0, SYNTHETIC: 0, BLEND: 0 })
+
+  // 개별 소재별 탄소 절감량 (kg CO₂) — "순환 활동 탄소 감축 현황" 카드용
+  // 키: COTTON / WOOL / CASHMERE / SILK / LINEN / POLYESTER / ACRYLIC / NYLON / POLYAMIDE / ELASTANE / BLEND
+  const carbonReductionByMaterialKg = ref({})
+
   const kauPrice = ref(KAU_FALLBACK_PRICE)
   const kauPriceUpdatedAt = ref(null)
   const kauPriceLoading = ref(false)
   const kauPriceError = ref(null)
+
+  // Phase 1: 소재 환산 계수 마스터 (BE 응답 캐싱)
+  //  - shape: { COTTON: { label, group, factor }, ... } — FE esgScore.js 의 MATERIAL_FACTORS 와 동일 키 구조
+  //  - 초기값은 FE 상수로 시드 → BE 응답 도착 후 덮어씀 → 첫 페이지 로드 짧은 순간에도 산식 작동
+  const materialFactors = ref({ ...MATERIAL_FACTORS })
+  const materialFactorsLoaded = ref(false)
+  const materialFactorsLoading = ref(false)
+  const materialFactorsError = ref(null)
 
   // 탄소 배출 절감량 (tCO₂) — 보기 쉬운 단위
   const totalCarbonReductionTon = computed(() => totalCarbonReductionKg.value / 1000)
@@ -55,20 +82,29 @@ export const useEsgStore = defineStore('esg', () => {
     return Number((((curr - prev) / prev) * 100).toFixed(1))
   })
 
+  // 현재 단계 — STAGE_THRESHOLDS 배열에서 totalPoints 가 도달한 가장 큰 임계값의 인덱스+1
+  //  - Curved 곡선: 단계별 간격이 다름 (초반 5K→20K, 후반 1M→1.5M)
   const stage = computed(() => {
-    const s = Math.floor(totalPoints.value / POINTS_PER_STAGE) + 1
-    return Math.min(Math.max(s, 1), MAX_STAGE)
+    const pts = totalPoints.value
+    for (let i = STAGE_THRESHOLDS.length - 1; i >= 0; i--) {
+      if (pts >= STAGE_THRESHOLDS[i]) return i + 1
+    }
+    return 1
   })
 
+  // 현재 단계 내 진행률 (%) — 현재 임계값 ~ 다음 임계값 사이에서의 비율
   const stageProgress = computed(() => {
     if (stage.value >= MAX_STAGE) return 100
-    const stageStart = (stage.value - 1) * POINTS_PER_STAGE
-    return Math.min(100, ((totalPoints.value - stageStart) / POINTS_PER_STAGE) * 100)
+    const curr = STAGE_THRESHOLDS[stage.value - 1]
+    const next = STAGE_THRESHOLDS[stage.value]
+    if (next <= curr) return 100  // 안전 폴백 (배열 오류 대비)
+    return Math.min(100, ((totalPoints.value - curr) / (next - curr)) * 100)
   })
 
+  // 다음 단계까지 남은 점수
   const pointsToNext = computed(() => {
     if (stage.value >= MAX_STAGE) return 0
-    return stage.value * POINTS_PER_STAGE - totalPoints.value
+    return Math.max(0, STAGE_THRESHOLDS[stage.value] - totalPoints.value)
   })
 
   /**
@@ -99,22 +135,82 @@ export const useEsgStore = defineStore('esg', () => {
   }
 
   /**
-   * BE sale events + mock donation events 를 합쳐 누적 ESG 점수 계산 후 totalPoints 갱신.
-   *  - ESG 대시보드 헤더 / TreeScore 페이지가 같은 값 공유
-   *  - 점수 룰 변경 시 utils/esgScore.js 만 수정하면 양쪽 자동 반영
+   * 소재 환산 계수 마스터를 BE 에서 1회 조회 (Phase 1 BE 이관).
+   *  - 이미 로드되어 있으면 재요청 X (캐싱)
+   *  - 응답: { factors: [{ code, label, group, factor }, ...] }
+   *  - 내부 shape 으로 변환: { CODE: { label, group, factor } }
+   *
+   * @param {boolean} [force=false] true 이면 캐싱 무시하고 재조회
+   */
+  // BE material.material_group 어휘 → FE MATERIAL_FACTORS group 키 정규화 매핑.
+  //  - BE 는 ProductMasterService.MATERIAL_GROUP_NATURAL='NATURAL' 상수 호환을 위해 'NATURAL' 사용
+  //  - FE 는 'NATURAL_SINGLE' 키로 통일 (esgScore.js MATERIAL_FACTORS / computeCarbonReductionByGroup)
+  //  - 미매핑 그룹은 그대로 통과 (SYNTHETIC, BLEND)
+  const GROUP_NORMALIZATION = {
+    NATURAL: 'NATURAL_SINGLE',
+  }
+
+  async function fetchMaterialFactors(force = false) {
+    if (materialFactorsLoaded.value && !force) return materialFactors.value
+    materialFactorsLoading.value = true
+    materialFactorsError.value = null
+    try {
+      const res = await materialFactorsApi.get()
+      const map = {}
+      for (const it of res?.factors ?? []) {
+        if (!it?.code) continue
+        map[it.code] = {
+          label: it.label,
+          // BE 의 'NATURAL' 을 FE 의 'NATURAL_SINGLE' 로 정규화 (어휘 통일)
+          group: GROUP_NORMALIZATION[it.group] ?? it.group,
+          factor: Number(it.factor) || 0,
+        }
+      }
+      // BE 응답에 RAYON 이 있어도 FE 의 NYLON alias (POLYAMIDE 와 동일 label) 같은 호환성은 유지.
+      // 누락된 키는 FE 상수에서 보강해서 막대 그래프 등 다른 의존부 깨지지 않도록 함.
+      materialFactors.value = { ...MATERIAL_FACTORS, ...map }
+      materialFactorsLoaded.value = true
+      return materialFactors.value
+    } catch (e) {
+      materialFactorsError.value = e?.message ?? '소재 계수 조회 실패'
+      // 실패해도 FE 상수가 fallback 으로 작동
+      return materialFactors.value
+    } finally {
+      materialFactorsLoading.value = false
+    }
+  }
+
+  /**
+   * BE sale events + 통계 + 카본 분포를 한 번에 받아서 store 갱신 (Phase 3 B).
+   *  - 점수 산식 SSOT: BE (summary.totalScore)
+   *  - 카본 분포 SSOT: BE (carbonReduction.{byMaterial,byGroup,monthly,total}) — Phase 3 B 이관
+   *  - 페이지 슬라이스 (events) 는 store 에서 사용하지 않음. 통계/분포 묶음만 사용.
+   *  - 그래서 size=1 로 호출해서 events 페이로드 최소화 + 통계 그대로 받음.
+   *    (BE 가 통계는 "필터 적용 후 전체" 기준이라 페이지 size 와 무관하게 동일 값 반환)
    */
   async function fetchTotalPoints(year) {
     totalPointsLoading.value = true
     totalPointsError.value = null
     try {
       const targetYear = year ?? new Date().getFullYear()
-      const res = await scoreEventsApi.get(targetYear)
-      const saleEvents = (res?.events ?? []).map(normalizeSaleEvent)
-      const allEvents = [...saleEvents, ...MOCK_DONATION_EVENTS]
-      totalPoints.value = computeTotalScore(allEvents)
-      totalSalesKg.value = allEvents.reduce((s, e) => s + (Number(e.weightKg) || 0), 0)
-      totalCarbonReductionKg.value = computeCarbonReductionKg(allEvents)
-      carbonReductionMonthly.value = computeMonthlyCarbonReduction(allEvents)
+      // 소재 마스터 선로딩 (다른 화면에서 라벨/group 표시용으로도 사용)
+      await fetchMaterialFactors()
+      // size=1 → 통계는 받되 events 페이로드는 1건만 (대시보드는 events 불필요)
+      const res = await scoreEventsApi.get({ year: targetYear, size: 1 })
+
+      // 점수/판매량 — BE summary 직접 사용 (FE 자체 합산 폐기)
+      totalPoints.value  = Number(res?.summary?.totalScore || 0)
+      totalSalesKg.value = Number(res?.summary?.totalKg || 0)
+
+      // 카본 분포 — BE carbonReduction 직접 할당
+      const cr = res?.carbonReduction
+      carbonReductionByMaterialKg.value = cr?.byMaterial ?? {}
+      carbonReductionByGroupKg.value    = cr?.byGroup ?? { NATURAL_SINGLE: 0, SYNTHETIC: 0, BLEND: 0 }
+      carbonReductionMonthly.value      = Array.isArray(cr?.monthly) && cr.monthly.length === 12
+                                          ? cr.monthly
+                                          : Array(12).fill(0)
+      // "연간 총 탄소 감축량" = BE 가 직접 계산한 total (= Σ byMaterial 과 일치)
+      totalCarbonReductionKg.value      = Number(cr?.total || 0)
       return totalPoints.value
     } catch (e) {
       totalPointsError.value = e?.message ?? '점수 조회 실패'
@@ -145,11 +241,14 @@ export const useEsgStore = defineStore('esg', () => {
     totalCarbonReductionKg,
     totalCarbonReductionTon,
     carbonReductionMonthly,
+    carbonReductionByGroupKg,
+    carbonReductionByMaterialKg,
     carbonReductionDeltaPct,
     stage,
     stageProgress,
     pointsToNext,
-    pointsPerStage: POINTS_PER_STAGE,
+    // Curved 단계 정책 노출 — EsgTreeWidget 등에서 진척도 표시용
+    stageThresholds: STAGE_THRESHOLDS,
     maxStage: MAX_STAGE,
     kauPrice,
     kauPriceUpdatedAt,
@@ -160,5 +259,11 @@ export const useEsgStore = defineStore('esg', () => {
     fetchTotalPoints,
     setTotalPoints,
     setTotalSalesKg,
+    // Phase 1: 소재 환산 계수 마스터 (BE 응답 캐싱)
+    materialFactors,
+    materialFactorsLoaded,
+    materialFactorsLoading,
+    materialFactorsError,
+    fetchMaterialFactors,
   }
 })

--- a/src/utils/esgScore.js
+++ b/src/utils/esgScore.js
@@ -1,60 +1,76 @@
 /**
  * esgScore.js — ESG 점수 계산 공용 로직.
  *
+ * Phase 2 BE 이관 완료 후 구조:
+ *   - 점수 산식의 SSOT 는 BE (ScoreEventsService) — saleExecution / carbon / newBuyer / localPartner / total / scoreValid
+ *     모두 BE 응답값을 그대로 사용
+ *   - FE 의 carbon 절감량 계산 함수들 (computeCarbonReductionByMaterial 등) 은
+ *     ESG 대시보드 "순환 활동 탄소 감축 현황" 막대 그래프 / 월별 추이 표시용으로 유지
+ *     → effective factor 룩업은 store 의 materialFactors (BE 마스터) 우선, 폴백 FE 상수
+ *
  * 사용처:
- *   - EsgTreeScoreView : 친환경 나무 키우기 점수 상세 페이지 (5종 카테고리/이벤트 분해)
+ *   - EsgTreeScoreView : 친환경 나무 키우기 점수 상세 페이지 (4종 카테고리/이벤트 분해)
  *   - esgStore         : ESG 대시보드 헤더 누적 ESG 점수 동기화 (fetchTotalPoints)
  *
  * 데이터 소스:
- *   - sale events     : BE 연동 (GET /api/hq/esg/score-events)
- *   - donation events : BE 도메인 미구현 → MOCK_DONATION_EVENTS 머지
- *
- * 룰 마스터 (FE 단일 진실 원본):
- *   - 향후 BE 이관 시 GET /api/hq/esg/score-rules 로 fetch 가능
+ *   - sale events       : BE 연동 (GET /api/hq/esg/score-events) — 점수 4종 포함
+ *   - material factors  : BE 연동 (GET /api/hq/esg/material-factors) — Phase 1 이관 완료
  */
 
-// ─────────── 점수 룰 ───────────
+// ─────────── 점수 룰 (FE fallback / 디스플레이용 — BE 산식과 동일) ───────────
 export const SCORE_RULES = {
   saleBase: 100,              // 판매 1건 기본 점수
-  donationBase: 80,           // 기부 1건 기본 점수
   minWeightKg: 10,            // 최소 중량 (이하면 점수 부여 X)
   newBuyerBonus: 150,         // 신규 거래처 첫 거래 보너스
-  localPartnerBonus: 150,     // 지역 파트너 보너스 (월 3건 cap, FE 미적용)
+  localPartnerBonus: 150,     // 지역 파트너 보너스
 }
 
-// 탄소 점수 스케일링 (다른 점수 요소와의 비중 균형)
-export const CARBON_SCALE = 0.5
+// 탄소 점수 스케일링 — Phase 2: 0.5 → 0.1 (Higg MSI 표준값 적용에 따른 균형)
+export const CARBON_SCALE = 0.1
 
-// ─────────── 소재 계수 (kgCO₂/kg) ───────────
-//   - circular_material_price_policy 시드와 정합
-//   - 향후 BE GET /api/hq/esg/material-factors 로 교체 가능
+// ─────────── 소재 계수 (kgCO₂e/kg) — Phase 1 BE 이관 후 fallback ───────────
+//   - 정상 동작 시 esgStore.materialFactors (BE 응답) 사용
+//   - BE 응답 실패 / 신규 진입 직후 짧은 순간만 본 상수가 사용됨
+//   - 값은 Phase 1 옵션 B (Higg MSI v3 / EU PEF 표준 + cap) 와 동일하게 동기화
 export const MATERIAL_FACTORS = {
-  COTTON:     { label: '면',         group: 'NATURAL_SINGLE', factor: 1.8 },
-  WOOL:       { label: '울',         group: 'NATURAL_SINGLE', factor: 2.5 },
-  CASHMERE:   { label: '캐시미어',   group: 'NATURAL_SINGLE', factor: 5.8 },
-  SILK:       { label: '실크',       group: 'NATURAL_SINGLE', factor: 3.2 },
-  LINEN:      { label: '린넨',       group: 'NATURAL_SINGLE', factor: 1.1 },
-  POLYESTER:  { label: '폴리에스터', group: 'SYNTHETIC',      factor: 2.3 },
-  ACRYLIC:    { label: '아크릴',     group: 'SYNTHETIC',      factor: 2.2 },
-  POLYAMIDE:  { label: '나일론',     group: 'SYNTHETIC',      factor: 2.1 },
-  NYLON:      { label: '나일론',     group: 'SYNTHETIC',      factor: 2.1 },
-  ELASTANE:   { label: '스판덱스',   group: 'SYNTHETIC',      factor: 2.5 },
-  BLEND:      { label: '혼방',       group: 'BLEND',          factor: 2.0 },
+  COTTON:     { label: '면',         group: 'NATURAL_SINGLE', factor: 6.0 },
+  WOOL:       { label: '울',         group: 'NATURAL_SINGLE', factor: 5.0 },
+  CASHMERE:   { label: '캐시미어',   group: 'NATURAL_SINGLE', factor: 8.0 },
+  SILK:       { label: '실크',       group: 'NATURAL_SINGLE', factor: 5.0 },
+  LINEN:      { label: '린넨',       group: 'NATURAL_SINGLE', factor: 1.8 },
+  POLYESTER:  { label: '폴리에스터', group: 'SYNTHETIC',      factor: 6.5 },
+  ACRYLIC:    { label: '아크릴',     group: 'SYNTHETIC',      factor: 5.7 },
+  POLYAMIDE:  { label: '나일론',     group: 'SYNTHETIC',      factor: 8.0 },
+  NYLON:      { label: '나일론',     group: 'SYNTHETIC',      factor: 8.0 },
+  ELASTANE:   { label: '스판덱스',   group: 'SYNTHETIC',      factor: 12.0 },
+  RAYON:      { label: '레이온',     group: 'SYNTHETIC',      factor: 4.5 },
+  BLEND:      { label: '혼방',       group: 'BLEND',          factor: 5.5 },
 }
 
-// ─────────── Mock 기부 이벤트 (BE 도메인 미구현 — 향후 donation_history 테이블로 교체) ───────────
-export const MOCK_DONATION_EVENTS = [
-  { id: 'd-1', date: '2026-04-28', type: 'donation', buyer: '재해구호본부',  material: 'COTTON',    weightKg:  95, isNewBuyer: false, isLocalPartner: false, donationType: 'DISASTER',  method: null },
-  { id: 'd-2', date: '2026-04-22', type: 'donation', buyer: '사회복지시설',  material: 'COTTON',    weightKg:  80, isNewBuyer: false, isLocalPartner: false, donationType: 'VULNERABLE',method: null },
-  { id: 'd-3', date: '2026-04-14', type: 'donation', buyer: '해외구호단체',  material: 'POLYESTER', weightKg:  50, isNewBuyer: false, isLocalPartner: false, donationType: 'OVERSEAS',  method: null },
-  { id: 'd-4', date: '2026-04-05', type: 'donation', buyer: '직업학교',      material: 'BLEND',     weightKg:  30, isNewBuyer: false, isLocalPartner: false, donationType: 'EDU',       method: null },
-  { id: 'd-5', date: '2026-03-12', type: 'donation', buyer: '재해구호본부',  material: 'COTTON',    weightKg:  60, isNewBuyer: false, isLocalPartner: false, donationType: 'DISASTER',  method: null },
-  { id: 'd-6', date: '2026-01-12', type: 'donation', buyer: '직업학교',      material: 'BLEND',     weightKg:  40, isNewBuyer: false, isLocalPartner: false, donationType: 'EDU',       method: null },
-]
+// 소재별 고정 색 매핑 — ESG 대시보드 "순환 활동 탄소 감축 현황" 카드 +
+//   순환재고 판매 통계 페이지(HqAnalyticsVendorView)의 도넛/막대 차트 공유
+//   동일 소재가 두 페이지에서 항상 같은 색으로 표시되도록 보장
+export const MATERIAL_COLORS = {
+  COTTON:    '#059669',  // emerald-600  (면)
+  WOOL:      '#0ea5e9',  // sky-500      (울)
+  CASHMERE:  '#f59e0b',  // amber-500    (캐시미어)
+  SILK:      '#a855f7',  // purple-500   (실크)
+  LINEN:     '#ef4444',  // red-500      (린넨)
+  POLYESTER: '#10b981',  // emerald-500  (폴리에스터)
+  ACRYLIC:   '#3b82f6',  // blue-500     (아크릴)
+  POLYAMIDE: '#eab308',  // yellow-500   (나일론)
+  NYLON:     '#eab308',  // yellow-500   (나일론)
+  ELASTANE:  '#c084fc',  // purple-400   (스판덱스)
+  RAYON:     '#0d9488',  // teal-600     (레이온 — 셀룰로스 재생 섬유, 자연-인조 중간 톤)
+  BLEND:     '#f87171',  // red-400      (혼방)
+}
+export const MATERIAL_COLOR_FALLBACK = '#94a3b8'  // slate-400 (미매핑 소재용)
 
 /**
  * BE 응답 sale event 를 FE event 형태로 정규화.
  *   - Jackson+Lombok 직렬화 quirk 대응 (isNewBuyer → newBuyer)
+ *   - Phase 2: BE 가 계산한 점수 4종(saleExecution/carbon/newBuyer/localPartner/total/scoreValid)
+ *     + 혼방 메타(mainMaterialCode/mainMaterialRatio) 도 보존
  */
 export function normalizeSaleEvent(e) {
   return {
@@ -66,66 +82,134 @@ export function normalizeSaleEvent(e) {
     weightKg: e.weightKg,
     isNewBuyer: e.isNewBuyer ?? e.newBuyer ?? false,
     isLocalPartner: e.isLocalPartner ?? e.localPartner ?? false,
-    donationType: null,
-    method: null,
+    // Phase 2: 혼방 거래 70% 주 소재 메타 (단일 거래는 null)
+    mainMaterialCode: e.mainMaterialCode ?? null,
+    mainMaterialRatio: e.mainMaterialRatio != null ? Number(e.mainMaterialRatio) : null,
+    // Phase 2: BE 가 계산한 거래별 점수 4종 + total + scoreValid
+    //   BE 응답이 항상 채워지지만 fallback 으로 nullish 체크 후 0 사용
+    saleExecution: e.saleExecution ?? null,
+    carbon: e.carbon ?? null,
+    newBuyerScore: e.newBuyer ?? null,
+    localPartnerScore: e.localPartner ?? null,
+    total: e.total ?? null,
+    scoreValid: e.scoreValid ?? null,
   }
 }
 
 /**
- * 이벤트 1건 → 5종 점수 분해.
- *   - 무게 10kg 미만은 점수 부여 X (어뷰징 방지)
- *   - 탄소 점수 = weight × material_factor × CARBON_SCALE
+ * 거래의 effective carbon factor 산출 (kgCO₂e/kg).
+ *   - 혼방 (material='BLEND' + mainMaterialCode 존재): mainFactor × mainRatio (0.7)
+ *   - 단일 (또는 main 누락된 BLEND): 자기 material 의 factor
+ *
+ * @param {object} e          거래 이벤트 (normalizeSaleEvent 결과)
+ * @param {object} [factors]  factor 룩업 맵 (BE 응답 또는 FE 상수). { CODE: { factor, ... } }
  */
-export function calcEventScore(e) {
-  const valid = e.weightKg >= SCORE_RULES.minWeightKg
-  const factor = MATERIAL_FACTORS[e.material]?.factor ?? 0
-  if (e.type === 'sale') {
-    if (!valid) return { saleExecution: 0, carbon: 0, newBuyer: 0, localPartner: 0, donationExecution: 0, total: 0, valid: false }
-    const saleExecution = SCORE_RULES.saleBase
-    const carbon = Math.round(e.weightKg * factor * CARBON_SCALE)
-    const newBuyer = e.isNewBuyer ? SCORE_RULES.newBuyerBonus : 0
-    const localPartner = e.isLocalPartner ? SCORE_RULES.localPartnerBonus : 0
-    const total = saleExecution + carbon + newBuyer + localPartner
-    return { saleExecution, carbon, newBuyer, localPartner, donationExecution: 0, total, valid: true }
+export function resolveEffectiveFactor(e, factors = MATERIAL_FACTORS) {
+  if (!e) return 0
+  if (e.material === 'BLEND' && e.mainMaterialCode && e.mainMaterialRatio != null) {
+    const mainFactor = Number(factors?.[e.mainMaterialCode]?.factor) || 0
+    return mainFactor * Number(e.mainMaterialRatio)
   }
-  // donation
-  if (!valid) return { saleExecution: 0, carbon: 0, newBuyer: 0, localPartner: 0, donationExecution: 0, total: 0, valid: false }
-  const donationExecution = SCORE_RULES.donationBase
-  const carbon = Math.round(e.weightKg * factor * CARBON_SCALE)
-  return { saleExecution: 0, carbon, newBuyer: 0, localPartner: 0, donationExecution, total: donationExecution + carbon, valid: true }
+  return Number(factors?.[e.material]?.factor) || 0
 }
 
-/** events 배열 → 누적 ESG 점수 (5종 합산) */
-export function computeTotalScore(events) {
+/**
+ * 이벤트 1건 → 4종 점수 분해 (판매 전용).
+ *   - Phase 2: BE 응답 점수값을 우선 사용 (event.saleExecution / carbon / ... / total / scoreValid)
+ *   - BE 미응답 시 FE 자체 계산 (fallback)
+ */
+export function calcEventScore(e, factors = MATERIAL_FACTORS) {
+  // ── Phase 2 우선: BE 응답값 그대로 사용 ──
+  if (e?.total != null && e?.scoreValid != null) {
+    return {
+      saleExecution: e.saleExecution ?? 0,
+      carbon: e.carbon ?? 0,
+      newBuyer: e.newBuyerScore ?? 0,
+      localPartner: e.localPartnerScore ?? 0,
+      total: e.total ?? 0,
+      valid: e.scoreValid === true,
+    }
+  }
+  // ── Fallback: FE 자체 계산 (BE 산식과 동일 — Higg MSI factor × CARBON_SCALE 0.1) ──
+  const valid = e?.weightKg >= SCORE_RULES.minWeightKg
+  if (!valid) return { saleExecution: 0, carbon: 0, newBuyer: 0, localPartner: 0, total: 0, valid: false }
+  const factor = resolveEffectiveFactor(e, factors)
+  const saleExecution = SCORE_RULES.saleBase
+  const carbon = Math.round(e.weightKg * factor * CARBON_SCALE)
+  const newBuyer = e.isNewBuyer ? SCORE_RULES.newBuyerBonus : 0
+  const localPartner = e.isLocalPartner ? SCORE_RULES.localPartnerBonus : 0
+  const total = saleExecution + carbon + newBuyer + localPartner
+  return { saleExecution, carbon, newBuyer, localPartner, total, valid: true }
+}
+
+/** events 배열 → 누적 ESG 점수 (4종 합산) */
+export function computeTotalScore(events, factors = MATERIAL_FACTORS) {
   let total = 0
   for (const e of events ?? []) {
-    total += calcEventScore(e).total
+    total += calcEventScore(e, factors).total
   }
   return total
 }
 
 /**
  * 실제 탄소 배출 절감량 (kg CO₂) — 점수용 CARBON_SCALE 미적용.
- *   - 각 이벤트의 weight × material_factor 합산
+ *   - Phase 2: 혼방은 mainFactor × ratio 가중 적용
  *   - 의미: 폐기·소각되지 않고 순환재고로 회피한 실제 탄소량
  */
-export function computeCarbonReductionKg(events) {
+export function computeCarbonReductionKg(events, factors = MATERIAL_FACTORS) {
   let total = 0
   for (const e of events ?? []) {
-    const factor = MATERIAL_FACTORS[e.material]?.factor ?? 0
+    const factor = resolveEffectiveFactor(e, factors)
     total += Math.round((Number(e.weightKg) || 0) * factor)
   }
   return total
 }
 
+/**
+ * events 배열 → 개별 소재별 탄소 절감량 (kg CO₂) 버킷
+ *   - 모든 factors 키에 대해 합산
+ *   - 의미: ESG 대시보드 "순환 활동 탄소 감축 현황" 카드의 막대 게이지용 (소재 전체)
+ *   - Phase 2 정책: 혼방 거래의 weight 는 BLEND 막대에 누적 (별도 카테고리 유지)
+ *     단, factor 는 mainFactor × ratio 가중 적용 → 막대 길이가 합리적으로 표시됨
+ */
+export function computeCarbonReductionByMaterial(events, factors = MATERIAL_FACTORS) {
+  const buckets = {}
+  for (const key of Object.keys(factors)) buckets[key] = 0
+  for (const e of events ?? []) {
+    if (!factors[e?.material]) continue
+    const factor = resolveEffectiveFactor(e, factors)
+    const reduction = Math.round((Number(e.weightKg) || 0) * factor)
+    if (buckets[e.material] != null) buckets[e.material] += reduction
+  }
+  return buckets
+}
+
+/**
+ * events 배열 → 소재 그룹별 탄소 절감량 (kg CO₂) 버킷
+ *   - NATURAL_SINGLE: 면(COTTON), 울, 실크, 캐시미어, 린넨
+ *   - SYNTHETIC: 폴리에스터, 아크릴, 나일론, 스판덱스, 레이온
+ *   - BLEND: 혼방 (mainFactor × 0.7 가중치 적용된 effective factor 사용)
+ */
+export function computeCarbonReductionByGroup(events, factors = MATERIAL_FACTORS) {
+  const buckets = { NATURAL_SINGLE: 0, SYNTHETIC: 0, BLEND: 0 }
+  for (const e of events ?? []) {
+    const info = factors[e?.material]
+    if (!info) continue
+    const factor = resolveEffectiveFactor(e, factors)
+    const reduction = Math.round((Number(e.weightKg) || 0) * factor)
+    if (buckets[info.group] != null) buckets[info.group] += reduction
+  }
+  return buckets
+}
+
 /** events 배열 → 1~12월 탄소 절감량 (kg CO₂) 12개 버킷 */
-export function computeMonthlyCarbonReduction(events) {
+export function computeMonthlyCarbonReduction(events, factors = MATERIAL_FACTORS) {
   const buckets = Array(12).fill(0)
   for (const e of events ?? []) {
     const d = new Date(e.date)
     if (Number.isNaN(d.getTime())) continue
     const m = d.getMonth()
-    const factor = MATERIAL_FACTORS[e.material]?.factor ?? 0
+    const factor = resolveEffectiveFactor(e, factors)
     buckets[m] += Math.round((Number(e.weightKg) || 0) * factor)
   }
   return buckets

--- a/src/views/hq/account/AccountApprovalView.vue
+++ b/src/views/hq/account/AccountApprovalView.vue
@@ -204,8 +204,12 @@ function closeDetail() {
   modalMode.value = null
 }
 
+// 승인/거절 처리 중 중복 클릭 방지용 가드 (응답 지연 시 사용자가 여러 번 누르는 사고 방지)
+const isProcessing = ref(false)
+
 async function confirmApprove() {
-  if (!selectedRequest.value) return
+  if (!selectedRequest.value || isProcessing.value) return
+  isProcessing.value = true
   try {
     const result = await accountApi.approve(selectedRequest.value.id)
     alert(`승인 완료\n사원코드: ${result.employeeCode}`)
@@ -214,6 +218,8 @@ async function confirmApprove() {
     await Promise.all([loadAccounts(), loadPendingCount()])
   } catch (err) {
     alert(extractErrorMessage(err, '승인에 실패했습니다.'))
+  } finally {
+    isProcessing.value = false
   }
 }
 
@@ -222,13 +228,16 @@ async function confirmReject() {
     rejectReasonError.value = '거절 사유를 입력해주세요.'
     return
   }
-  if (!selectedRequest.value) return
+  if (!selectedRequest.value || isProcessing.value) return
+  isProcessing.value = true
   try {
     await accountApi.reject(selectedRequest.value.id)
     closeDetail()
     await Promise.all([loadAccounts(), loadPendingCount()])
   } catch (err) {
     alert(extractErrorMessage(err, '거절에 실패했습니다.'))
+  } finally {
+    isProcessing.value = false
   }
 }
 </script>
@@ -583,10 +592,10 @@ async function confirmReject() {
                 승인하면 계정이 즉시 생성됩니다. 계속하시겠습니까?
               </div>
               <div class="flex justify-end gap-2">
-                <button type="button" class="h-9 border border-gray-300 bg-white px-5 text-[13px] font-medium text-gray-600 transition hover:bg-gray-50" @click="modalMode = null">취소</button>
-                <button type="button" class="inline-flex h-9 items-center gap-1.5 bg-emerald-50 px-5 text-[13px] font-medium text-emerald-700 border border-emerald-200 transition hover:bg-emerald-100" @click="confirmApprove">
+                <button type="button" :disabled="isProcessing" class="h-9 border border-gray-300 bg-white px-5 text-[13px] font-medium text-gray-600 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50" @click="modalMode = null">취소</button>
+                <button type="button" :disabled="isProcessing" class="inline-flex h-9 items-center gap-1.5 bg-emerald-50 px-5 text-[13px] font-medium text-emerald-700 border border-emerald-200 transition hover:bg-emerald-100 disabled:cursor-not-allowed disabled:opacity-50" @click="confirmApprove">
                   <CheckCircle2 :size="14" />
-                  최종 승인
+                  {{ isProcessing ? '처리 중...' : '최종 승인' }}
                 </button>
               </div>
             </template>
@@ -594,10 +603,10 @@ async function confirmReject() {
             <!-- PENDING: 거절 확인 -->
             <template v-else-if="modalMode === 'reject'">
               <div class="flex justify-end gap-2">
-                <button type="button" class="h-9 border border-gray-300 bg-white px-5 text-[13px] font-medium text-gray-600 transition hover:bg-gray-50" @click="modalMode = null">취소</button>
-                <button type="button" class="inline-flex h-9 items-center gap-1.5 border border-red-200 bg-red-50 px-5 text-[13px] font-medium text-red-600 transition hover:bg-red-100" @click="confirmReject">
+                <button type="button" :disabled="isProcessing" class="h-9 border border-gray-300 bg-white px-5 text-[13px] font-medium text-gray-600 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50" @click="modalMode = null">취소</button>
+                <button type="button" :disabled="isProcessing" class="inline-flex h-9 items-center gap-1.5 border border-red-200 bg-red-50 px-5 text-[13px] font-medium text-red-600 transition hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-50" @click="confirmReject">
                   <XCircle :size="14" />
-                  거절 확정
+                  {{ isProcessing ? '처리 중...' : '거절 확정' }}
                 </button>
               </div>
             </template>

--- a/src/views/hq/analytics/HqAnalyticsVendorView.vue
+++ b/src/views/hq/analytics/HqAnalyticsVendorView.vue
@@ -13,14 +13,17 @@ import BarChart from '@/components/common/charts/BarChart.vue'
 import DoughnutChart from '@/components/common/charts/DoughnutChart.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
+import { useEsgStore } from '@/stores/esg.js'
 import { vendorAnalyticsApi } from '@/api/hq/analytics.js'
+import { MATERIAL_COLORS, MATERIAL_COLOR_FALLBACK } from '@/utils/esgScore.js'
 
 const auth = useAuthStore()
+const esgStore = useEsgStore()
 const hqMenus = roleMenus.hq
 const sideMenus = roleMenus.hq.find((m) => m.label === '정산/통계')?.children ?? []
 
 const activeTopMenu = computed(() => '정산/통계')
-const activeSideMenu = ref('순환재고 거래처 통계')
+const activeSideMenu = ref('순환재고 판매 통계')
 
 const dateLabel = computed(() =>
   new Intl.DateTimeFormat('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' }).format(new Date()),
@@ -85,7 +88,7 @@ async function fetchVendorStats() {
     })
   } catch (e) {
     console.error('[VendorView] fetch failed', e)
-    loadError.value = '순환재고 거래처 통계를 불러오지 못했습니다.'
+    loadError.value = '순환재고 판매 통계를 불러오지 못했습니다.'
     statsData.value = null
   } finally {
     loading.value = false
@@ -93,7 +96,10 @@ async function fetchVendorStats() {
 }
 
 watch([periodUnit, selectedMonth], fetchVendorStats)
-onMounted(fetchVendorStats)
+onMounted(() => {
+  fetchVendorStats()
+  esgStore.fetchTotalPoints(new Date().getFullYear())
+})
 
 // ─── BE 응답 → FE 데이터 ──────────────────────────────────────────────
 const vendors = computed(() => statsData.value?.vendors ?? [])
@@ -128,6 +134,13 @@ const kpiCards = computed(() => {
       unit: '곳',
       sub: `소재 ${activeMats}종`,
       icon: Handshake, valueCls: 'text-emerald-700', iconBg: 'bg-emerald-50', iconCls: 'text-emerald-600',
+    },
+    {
+      label: '연간 총 탄소 감축량',
+      value: (esgStore.totalCarbonReductionTon ?? 0).toFixed(2),
+      unit: 'tCO₂',
+      sub: '최근 1년 누적',
+      icon: Leaf, valueCls: 'text-teal-700', iconBg: 'bg-teal-50', iconCls: 'text-teal-600',
     },
     {
       label: '총 판매 금액',
@@ -267,13 +280,18 @@ const materialTypeBadge = (type) => {
   return 'bg-gray-100 text-gray-600'
 }
 
-// ─── 소재 매출 순위 막대 (순환재고 모드용) — 도넛과 동일한 소재별 컬러 매핑 ────
+// ─── 소재 매출 순위 막대 (순환재고 모드용) — ESG 카드와 동일한 소재별 컬러 매핑 ────
+function resolveMaterialColor(m) {
+  // BE materialCode 우선 (예: "COTTON" / "POLYESTER" 등), 없으면 fallback
+  return MATERIAL_COLORS[m?.materialCode] ?? MATERIAL_COLOR_FALLBACK
+}
+
 const materialSalesBarData = computed(() => ({
   labels: circularMaterialStats.value.map((m) => m.name),
   datasets: [{
     label: '매출',
     data: circularMaterialStats.value.map((m) => m.sales),
-    backgroundColor: circularMaterialStats.value.map((_, i) => MATERIAL_PALETTE[i % MATERIAL_PALETTE.length]),
+    backgroundColor: circularMaterialStats.value.map(resolveMaterialColor),
     borderRadius: 4,
   }],
 }))
@@ -296,18 +314,13 @@ const totalMaterialSales = computed(() =>
   circularMaterialStats.value.reduce((s, m) => s + m.sales, 0),
 )
 
-// ─── 소재 매출 비중 도넛 (순환재고 모드용) ────────────────────────────
-const MATERIAL_PALETTE = [
-  '#059669', '#0ea5e9', '#f59e0b', '#a855f7', '#ef4444',
-  '#10b981', '#3b82f6', '#eab308', '#c084fc', '#f87171',
-]
-
+// ─── 소재 매출 비중 도넛 (순환재고 모드용) — ESG 카드와 동일한 소재별 컬러 매핑 ────
 const materialShareList = computed(() =>
-  circularMaterialStats.value.map((m, i) => ({
+  circularMaterialStats.value.map((m) => ({
     name: m.name,
     sales: m.sales,
     share: m.sharePct,
-    color: MATERIAL_PALETTE[i % MATERIAL_PALETTE.length],
+    color: resolveMaterialColor(m),
   })),
 )
 
@@ -337,7 +350,7 @@ const materialDoughnutData = computed(() => ({
           <p class="text-[10px] font-bold uppercase tracking-[0.2em] text-gray-400">CIRCULAR INVENTORY · VENDOR ANALYTICS</p>
           <h2 class="mt-1 flex items-center gap-2 text-base font-black text-gray-900">
             <Handshake :size="18" class="text-[#004D3C]" />
-            순환재고 거래처 통계
+            순환재고 판매 통계
           </h2>
           <p class="mt-1 text-[11px] text-gray-500">
             기준일: {{ dateLabel }} · 거래처별 매출·의존도·소재 분포 분석
@@ -370,8 +383,8 @@ const materialDoughnutData = computed(() => ({
         </label>
       </section>
 
-      <!-- KPI 2개 -->
-      <section class="grid gap-3 grid-cols-1 sm:grid-cols-2">
+      <!-- KPI 3개 (활성 거래처 · 연간 총 탄소 감축량 · 총 판매 금액) -->
+      <section class="grid gap-3 grid-cols-1 sm:grid-cols-3">
         <article
           v-for="k in kpiCards"
           :key="k.label"

--- a/src/views/hq/esg/EsgCarbonPriceView.vue
+++ b/src/views/hq/esg/EsgCarbonPriceView.vue
@@ -25,7 +25,7 @@ const auth = useAuthStore()
 // ─────────── AppLayout props ───────────
 const topMenus = computed(() => roleMenus.hq ?? [])
 const sideMenus = computed(
-  () => (roleMenus.hq ?? []).find((menu) => menu.label === 'ESG 대시보드')?.children ?? [],
+  () => (roleMenus.hq ?? []).find((menu) => menu.label === 'ESG 탄소 성과 관리')?.children ?? [],
 )
 const activeSideMenu = ref('배출권 시장 가치')
 
@@ -37,8 +37,9 @@ const PERIOD_OPTIONS = [
 ]
 const selectedPeriod = ref('SEVEN_DAYS')
 
-// ─────────── 페이징 (일자별 상세 테이블) ───────────
+// ─────────── 페이징 (일자별 상세 테이블) — 알림/계정 관리와 동일한 5그룹 패턴 ───────────
 const PAGE_SIZE = 15
+const PAGES_PER_GROUP = 5
 const currentPage = ref(1)
 
 // 최신 → 과거 순 정렬된 전체 데이터 (테이블용)
@@ -55,30 +56,20 @@ const pagedRows = computed(() => {
   return sortedDesc.value.slice(start, start + PAGE_SIZE)
 })
 
-// 표시할 페이지 번호 목록 (현재 ±2, 양 끝 + 줄임표)
-const pageNumbers = computed(() => {
-  const total = totalPages.value
-  const cur = currentPage.value
-  if (total <= 7) return Array.from({ length: total }, (_, i) => i + 1)
-
-  const pages = new Set([1, 2, total - 1, total, cur - 1, cur, cur + 1])
-  const sorted = [...pages].filter(p => p >= 1 && p <= total).sort((a, b) => a - b)
-
-  // 사이에 끊김 있으면 ... 삽입
-  const result = []
-  let prev = 0
-  for (const p of sorted) {
-    if (prev && p - prev > 1) result.push('...')
-    result.push(p)
-    prev = p
-  }
-  return result
+// 페이지 그룹 (5개씩) — 계정 관리/알림 페이지와 동일 패턴
+const currentGroup = computed(() => Math.ceil(currentPage.value / PAGES_PER_GROUP))
+const totalGroups = computed(() => Math.max(1, Math.ceil(totalPages.value / PAGES_PER_GROUP)))
+const visiblePages = computed(() => {
+  const start = (currentGroup.value - 1) * PAGES_PER_GROUP + 1
+  const end = Math.min(start + PAGES_PER_GROUP - 1, totalPages.value)
+  return Array.from({ length: end - start + 1 }, (_, i) => start + i)
 })
 
-function goToPage(p) {
-  if (p === '...') return
-  if (p < 1 || p > totalPages.value) return
-  currentPage.value = p
+function goPrevGroup() {
+  currentPage.value = Math.max(1, (currentGroup.value - 2) * PAGES_PER_GROUP + 1)
+}
+function goNextGroup() {
+  currentPage.value = Math.min(totalPages.value, currentGroup.value * PAGES_PER_GROUP + 1)
 }
 
 // 기간 필터 변경 시 페이지 1로 리셋 (아래 watch 통합)
@@ -232,7 +223,7 @@ const chartOptions = {
 
 <template>
   <AppLayout
-    active-top-menu="ESG 대시보드"
+    active-top-menu="ESG 탄소 성과 관리"
     :top-menus="topMenus"
     :side-menus="sideMenus"
     v-model:active-side-menu="activeSideMenu"
@@ -450,44 +441,47 @@ const chartOptions = {
             </span>
 
             <div class="flex items-center gap-1">
-              <!-- 이전 -->
+              <!-- « 이전 5페이지 그룹 -->
               <button
                 type="button"
-                class="h-7 border border-gray-300 bg-white px-2.5 text-[11px] font-medium text-gray-600 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
+                :disabled="currentGroup === 1"
+                class="flex h-7 w-7 items-center justify-center border border-gray-300 bg-white text-[12px] text-gray-500 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
+                @click="goPrevGroup"
+                title="이전 5페이지"
+              >«</button>
+              <!-- ‹ 한 페이지 이전 -->
+              <button
+                type="button"
                 :disabled="currentPage === 1"
-                @click="goToPage(currentPage - 1)"
-              >
-                이전
-              </button>
-
-              <!-- 페이지 번호 -->
+                class="flex h-7 w-7 items-center justify-center border border-gray-300 bg-white text-[12px] text-gray-500 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
+                @click="currentPage--"
+                title="이전 페이지"
+              >‹</button>
+              <!-- 페이지 번호 (5개씩) -->
               <button
-                v-for="(p, idx) in pageNumbers"
-                :key="idx"
+                v-for="p in visiblePages"
+                :key="p"
                 type="button"
-                :disabled="p === '...'"
-                :class="[
-                  'h-7 min-w-[28px] px-2 text-[11px] font-medium transition',
-                  p === currentPage
-                    ? 'border border-[#004D3C] bg-[#004D3C] text-white'
-                    : p === '...'
-                      ? 'cursor-default text-gray-400'
-                      : 'border border-gray-300 bg-white text-gray-600 hover:bg-gray-100'
-                ]"
-                @click="goToPage(p)"
-              >
-                {{ p }}
-              </button>
-
-              <!-- 다음 -->
+                class="flex h-7 min-w-[28px] items-center justify-center border text-[12px] font-medium transition"
+                :class="p === currentPage ? 'border-[#004D3C] bg-[#004D3C] text-white' : 'border-gray-300 bg-white text-gray-500 hover:bg-gray-100'"
+                @click="currentPage = p"
+              >{{ p }}</button>
+              <!-- › 한 페이지 다음 -->
               <button
                 type="button"
-                class="h-7 border border-gray-300 bg-white px-2.5 text-[11px] font-medium text-gray-600 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
                 :disabled="currentPage === totalPages"
-                @click="goToPage(currentPage + 1)"
-              >
-                다음
-              </button>
+                class="flex h-7 w-7 items-center justify-center border border-gray-300 bg-white text-[12px] text-gray-500 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
+                @click="currentPage++"
+                title="다음 페이지"
+              >›</button>
+              <!-- » 다음 5페이지 그룹 -->
+              <button
+                type="button"
+                :disabled="currentGroup === totalGroups"
+                class="flex h-7 w-7 items-center justify-center border border-gray-300 bg-white text-[12px] text-gray-500 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
+                @click="goNextGroup"
+                title="다음 5페이지"
+              >»</button>
             </div>
           </div>
         </section>

--- a/src/views/hq/esg/EsgDashBoardView.vue
+++ b/src/views/hq/esg/EsgDashBoardView.vue
@@ -1,38 +1,32 @@
 <script setup>
-import { computed, ref, reactive, onMounted } from 'vue'
+import { computed, ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { storeToRefs } from 'pinia'
 import {
   Leaf,
   ShieldCheck,
   TrendingDown,
-  TrendingUp,
   Scale,
   Coins,
-  CheckCircle2,
   RefreshCw,
   Wallet,
-  X,
-  Save,
-  Edit3,
 } from 'lucide-vue-next'
 import AppLayout from '@/components/common/AppLayout.vue'
-import DoughnutChart from '@/components/common/charts/DoughnutChart.vue'
 import BarChart from '@/components/common/charts/BarChart.vue'
 import LineChart from '@/components/common/charts/LineChart.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useAuthStore } from '@/stores/auth.js'
 import { useEsgStore } from '@/stores/esg.js'
-import { useEmissionQuotaStore } from '@/stores/emissionQuota.js'
 import { carbonPriceApi, circularRevenueApi } from '@/api/hq/esg.js'
 import { extractErrorMessage } from '@/api/axios.js'
+import { MATERIAL_FACTORS, MATERIAL_COLORS, MATERIAL_COLOR_FALLBACK } from '@/utils/esgScore.js'
 const router = useRouter()
 const auth = useAuthStore()
 const hqMenus = roleMenus.hq
 
-const activeTopMenu = computed(() => 'ESG 대시보드')
-const activeSideMenu = ref('탄소배출권 관리')
-const esgSideMenus = (hqMenus.find((menu) => menu.label === 'ESG 대시보드')?.children ?? [])
+const activeTopMenu = computed(() => 'ESG 탄소 성과 관리')
+const activeSideMenu = ref('탄소 배출 관리')
+const esgSideMenus = (hqMenus.find((menu) => menu.label === 'ESG 탄소 성과 관리')?.children ?? [])
 
 const esgStore = useEsgStore()
 const {
@@ -40,10 +34,54 @@ const {
   totalSalesKg,
   totalCarbonReductionTon,
   carbonReductionDeltaPct,
+  carbonReductionByMaterialKg,
+  carbonReductionMonthly,
   kauPrice,
   kauPriceUpdatedAt,
   kauPriceLoading,
 } = storeToRefs(esgStore)
+
+// ─────────── 순환 활동 탄소 감축 현황 (소재 전체, 사용량 많은 순) ───────────
+//   - MATERIAL_FACTORS 의 모든 소재를 절감량(tCO₂e) 기준 내림차순 정렬
+//   - "한글 (English)" 형식으로 모든 소재 영문 병기
+const materialReductionRows = computed(() => {
+  const buckets = carbonReductionByMaterialKg.value ?? {}
+  // POLYAMIDE 와 NYLON 은 동일 label('나일론') 이라 중복 노출 방지: 절감량을 NYLON 으로 통합 후 POLYAMIDE 제외
+  const merged = { ...buckets }
+  if (merged.POLYAMIDE != null) {
+    merged.NYLON = (merged.NYLON ?? 0) + (merged.POLYAMIDE ?? 0)
+    delete merged.POLYAMIDE
+  }
+  // 한글명 옆에 영문명을 병기 — 회계/ESG 공시 문서 어휘와 정렬 (예: "면 (Cotton)")
+  const labelOverride = {
+    COTTON:    '면 (Cotton)',
+    WOOL:      '울 (Wool)',
+    CASHMERE:  '캐시미어 (Cashmere)',
+    SILK:      '실크 (Silk)',
+    LINEN:     '린넨 (Linen)',
+    POLYESTER: '폴리에스터 (Polyester)',
+    ACRYLIC:   '아크릴 (Acrylic)',
+    NYLON:     '나일론 (Nylon)',
+    POLYAMIDE: '나일론 (Nylon)',
+    ELASTANE:  '스판덱스 (Elastane)',
+    RAYON:     '레이온 (Rayon)',
+    BLEND:     '혼방 (Blend)',
+  }
+  const rows = Object.entries(merged).map(([key, kg]) => ({
+    key,
+    label: labelOverride[key] ?? MATERIAL_FACTORS[key]?.label ?? key,
+    kg: Number(kg) || 0,
+    color: MATERIAL_COLORS[key] ?? MATERIAL_COLOR_FALLBACK,
+  }))
+  // 사용량 많은 순 (kg 내림차순). 동률이면 라벨 가나다순.
+  rows.sort((a, b) => (b.kg - a.kg) || a.label.localeCompare(b.label, 'ko'))
+  const maxKg = Math.max(...rows.map(r => r.kg), 1)
+  return rows.map(r => ({
+    ...r,
+    ton: r.kg / 1000,
+    barPct: Math.min(100, (r.kg / maxKg) * 100),
+  }))
+})
 
 // ─────────── 배출권(KAU25) 실시간 시세 — BE 연동 ───────────
 const carbonLatest = ref(null)        // { pricePerTon, symbol, basDt, fltRt, fallback }
@@ -148,291 +186,16 @@ const formatBasDtShort = (yyyymmdd) => {
 
 onMounted(loadCarbonPrice)
 
-// 헤더 누적 ESG 점수 — BE sale events + mock donation 으로 자동 계산
+// 헤더 누적 ESG 점수 — BE sale events 기반 자동 계산
 onMounted(() => {
   esgStore.fetchTotalPoints().catch(err => {
     console.error('[EsgDashBoardView] fetchTotalPoints failed:', err)
   })
 })
 
-// 배출 한도 vs 실적 데이터 — emissionQuota 스토어와 연동
-// 대시보드 진입 시 BE 에서 저장된 할당량/월별 실적을 불러와 새로고침/재로그인 후에도 동일하게 유지
-const quotaStore = useEmissionQuotaStore()
-onMounted(async () => {
-  try {
-    await quotaStore.fetchQuota()
-  } catch (err) {
-    console.error('[EsgDashBoardView] quota fetch failed:', err)
-  }
-})
-const {
-  fiscalYear,
-  yearlyAllocation,
-  warnThresholdPct,
-  monthlyEmissions,
-} = storeToRefs(quotaStore)
-
-const MONTH_LABELS = ['1월','2월','3월','4월','5월','6월','7월','8월','9월','10월','11월','12월']
-
-// 정부 할당량 입력 모달
-const showQuotaModal = ref(false)
-const quotaDraft = reactive({
-  yearlyAllocation: 0,
-  warnThresholdPct: 75,
-  monthly: ['', '', '', '', '', '', '', '', '', '', '', ''],
-})
-
-function openQuotaModal() {
-  quotaDraft.yearlyAllocation = yearlyAllocation.value
-  quotaDraft.warnThresholdPct = warnThresholdPct.value
-  quotaDraft.monthly = (monthlyEmissions.value ?? []).map(v => v == null ? '' : String(v))
-  while (quotaDraft.monthly.length < 12) quotaDraft.monthly.push('')
-  showQuotaModal.value = true
-}
-function closeQuotaModal() {
-  showQuotaModal.value = false
-}
-function quarterSum(q) {
-  const start = (q - 1) * 3
-  let sum = 0
-  for (let i = 0; i < 3; i++) {
-    const v = Number(quotaDraft.monthly[start + i])
-    if (!isNaN(v)) sum += v
-  }
-  return sum
-}
-async function saveQuotaModal() {
-  try {
-    const monthly = quotaDraft.monthly.map(v =>
-      v === '' || v === null || isNaN(Number(v)) ? null : Number(v),
-    )
-    await quotaStore.saveQuota({
-      allocation: Number(quotaDraft.yearlyAllocation) || 0,
-      warnPct:    Number(warnThresholdPct.value) || 75,
-      monthly,
-    })
-    showQuotaModal.value = false
-  } catch (err) {
-    alert('저장에 실패했습니다. 잠시 후 다시 시도해 주세요.')
-  }
-}
-
-const emissionCompliance = computed(() => ({
-  allocation:     quotaStore.yearlyAllocation,
-  ytdNet:         Number(quotaStore.ytdEmissions.toFixed(2)),
-  ytdAvoided:     Number(quotaStore.ytdAvoided.toFixed(2)),
-  netEmissions:   Number(quotaStore.netEmissions.toFixed(2)),
-  costSavingsWon: Math.round(quotaStore.costSavingsWon),
-  utilizationPct: Number(quotaStore.utilizationPct.toFixed(1)),
-  expectedSurplus: Number(quotaStore.remaining.toFixed(2)),
-  warnPct:        quotaStore.warnThresholdPct,
-  quarterly: quotaStore.quarterly.map(q => ({
-    q: q.q,
-    period: q.period,
-    actual: Number(q.emissions.toFixed(2)),
-    status: q.status,
-  })),
-}))
-
-const marketVolume = {
-  reducedTons: 285,
-  surplusTons: 1595,
-  yearlyTonsProjected: 855,
-  yoyPct: 47,
-  monthlyTons: [
-    { m: '1월', tons: 76.4 },
-    { m: '2월', tons: 95.0 },
-    { m: '3월', tons: 86.4 },
-    { m: '4월', tons: 27.2 },
-    { m: '5월', tons: 55.0 },
-    { m: '6월', tons: 68.0 },
-    { m: '7월', tons: 82.0 },
-    { m: '8월', tons: 74.0 },
-    { m: '9월', tons: 62.0 },
-    { m: '10월', tons: 78.0 },
-    { m: '11월', tons: 92.0 },
-    { m: '12월', tons: 88.0 },
-  ],
-}
-
-// 배출 한도 vs 사용한 탄소배출권 도넛
-const emissionRemaining = computed(
-  () => emissionCompliance.value.allocation - emissionCompliance.value.ytdNet,
-)
-
-const emissionDoughnutData = computed(() => ({
-  labels: ['사용한 탄소배출권', '잔여 한도'],
-  datasets: [
-    {
-      data: [emissionCompliance.value.ytdNet, emissionRemaining.value],
-      backgroundColor: ['#2563eb', '#e5e7eb'],
-      borderColor: ['#1d4ed8', '#d1d5db'],
-      borderWidth: 1,
-      hoverBackgroundColor: ['#1d4ed8', '#9ca3af'],
-    },
-  ],
-}))
-
-const emissionDoughnutOptions = {
-  responsive: true,
-  maintainAspectRatio: false,
-  cutout: '70%',
-  plugins: {
-    legend: {
-      display: true,
-      position: 'bottom',
-      labels: { font: { size: 11 }, boxWidth: 10, usePointStyle: true, padding: 12 },
-    },
-    tooltip: {
-      backgroundColor: 'rgba(17, 24, 39, 0.95)',
-      titleColor: '#93c5fd',
-      titleFont: { size: 11, weight: 'bold' },
-      bodyColor: '#fff',
-      padding: 10,
-      cornerRadius: 6,
-      displayColors: false,
-      callbacks: {
-        label: (ctx) => {
-          const total = emissionCompliance.value.allocation
-          const pct = total > 0 ? ((ctx.parsed / total) * 100).toFixed(1) : '0.0'
-          return `${ctx.parsed.toLocaleString()} tCO₂ (${pct}%)`
-        },
-      },
-    },
-  },
-}
-
-// 분기별 배출 진행 BarChart (Q1~Q2 실적만, Q3~Q4 라벨만)
-const quarterlyChartData = computed(() => ({
-  labels: emissionCompliance.value.quarterly.map((q) => q.period),
-  datasets: [
-    {
-      label: '분기별 실적',
-      data: emissionCompliance.value.quarterly.map((q) => (q.actual > 0 ? q.actual : null)),
-      backgroundColor: 'rgba(59, 130, 246, 0.9)',
-      borderColor: '#1d4ed8',
-      borderWidth: 1,
-      borderRadius: 6,
-      borderSkipped: false,
-      maxBarThickness: 32,
-      hoverBackgroundColor: '#1d4ed8',
-    },
-  ],
-}))
-
-const quarterlyChartOptions = computed(() => ({
-  responsive: true,
-  maintainAspectRatio: false,
-  plugins: {
-    legend: { display: false },
-    tooltip: {
-      backgroundColor: 'rgba(17, 24, 39, 0.95)',
-      titleColor: '#93c5fd',
-      titleFont: { size: 11, weight: 'bold' },
-      bodyColor: '#fff',
-      padding: 10,
-      cornerRadius: 6,
-      displayColors: false,
-      callbacks: {
-        title: (items) => {
-          const q = emissionCompliance.value.quarterly[items[0].dataIndex]
-          return `${q.q} · ${q.period}`
-        },
-        label: (ctx) => {
-          const q = emissionCompliance.value.quarterly[ctx.dataIndex]
-          return `실적 ${q.actual.toLocaleString()} tCO₂`
-        },
-      },
-    },
-  },
-  scales: {
-    x: {
-      grid: { display: false },
-      ticks: { font: { size: 10 }, color: '#6b7280', maxRotation: 0, minRotation: 0 },
-    },
-    y: {
-      grid: { color: '#f3f4f6', drawBorder: false },
-      ticks: {
-        font: { size: 9 },
-        color: '#9ca3af',
-        callback: (v) => v + 't',
-      },
-      beginAtZero: true,
-    },
-  },
-}))
+// (정부 할당량 / 분기 배출 등 emissionQuota 관련 코드 제거됨 — UI 에서도 모두 사용 안 함)
 
 // 월별 환산 가치 추이 BarChart (1~4월 실적만 표시, 5~12월은 라벨만)
-const monthlyChartData = computed(() => ({
-  labels: marketVolume.monthlyTons.map((m) => m.m),
-  datasets: [
-    {
-      label: '월별 환산 가치',
-      data: marketVolume.monthlyTons.map((m, i) =>
-        i < 4 ? m.tons * kauPrice.value : null,
-      ),
-      backgroundColor: 'rgba(245, 158, 11, 0.9)',
-      borderColor: '#d97706',
-      borderWidth: 1,
-      borderRadius: 6,
-      borderSkipped: false,
-      maxBarThickness: 24,
-      hoverBackgroundColor: '#d97706',
-    },
-  ],
-}))
-
-const monthlyChartOptions = computed(() => ({
-  responsive: true,
-  maintainAspectRatio: false,
-  plugins: {
-    legend: { display: false },
-    tooltip: {
-      backgroundColor: 'rgba(17, 24, 39, 0.95)',
-      titleColor: '#fcd34d',
-      titleFont: { size: 11, weight: 'bold' },
-      bodyColor: '#fff',
-      padding: 10,
-      cornerRadius: 6,
-      displayColors: false,
-      callbacks: {
-        title: (items) => items[0].label,
-        label: (ctx) => {
-          const m = marketVolume.monthlyTons[ctx.dataIndex]
-          return [
-            `감축량 ${m.tons.toFixed(1)} tCO₂`,
-            `KAU ₩${kauPrice.value.toLocaleString()}/t`,
-            `환산 가치 ₩${Math.round(m.tons * kauPrice.value).toLocaleString()}`,
-            '✓ 실적',
-          ]
-        },
-      },
-    },
-  },
-  scales: {
-    x: {
-      grid: { display: false },
-      ticks: { font: { size: 10 }, color: '#6b7280', maxRotation: 0, minRotation: 0 },
-    },
-    y: {
-      grid: { color: '#f3f4f6', drawBorder: false },
-      min: 0,
-      max: 5000000,
-      ticks: {
-        font: { size: 9 },
-        color: '#9ca3af',
-        stepSize: 500000,
-        callback: (v) => '₩' + Math.round(v / 10000).toLocaleString() + '만',
-      },
-      beginAtZero: true,
-    },
-  },
-}))
-
-const reducedKrw = computed(() => marketVolume.reducedTons * kauPrice.value)
-const surplusKrw = computed(() => marketVolume.surplusTons * kauPrice.value)
-const yearlyKrw = computed(() => marketVolume.yearlyTonsProjected * kauPrice.value)
-
 const kauUpdatedLabel = computed(() => {
   if (!kauPriceUpdatedAt.value) return '시세 미조회'
   const d = new Date(kauPriceUpdatedAt.value)
@@ -465,26 +228,27 @@ const carbonDeltaLabel = computed(() => {
   return `전월 대비 ${sign}${pct}%`
 })
 const kpiMetrics = computed(() => [
-  { label: '탄소 배출 절감',   value: (totalCarbonReductionTon.value ?? 0).toFixed(2),    unit: 'tCO₂', sub: carbonDeltaLabel.value, icon: TrendingDown, valueCls: 'text-emerald-700', iconBg: 'bg-emerald-50', iconCls: 'text-emerald-600' },
-  { label: '순환재고 판매량', value: (totalSalesKg.value ?? 0).toLocaleString('ko-KR'), unit: 'kg',   sub: '불법폐기 0건',         icon: ShieldCheck,  valueCls: 'text-teal-700',     iconBg: 'bg-teal-50',     iconCls: 'text-teal-600' },
+  { label: '연간 총 탄소 감축량',   value: (totalCarbonReductionTon.value ?? 0).toFixed(2),    unit: 'tCO₂', sub: carbonDeltaLabel.value, icon: TrendingDown, valueCls: 'text-emerald-700', iconBg: 'bg-emerald-50', iconCls: 'text-emerald-600' },
+  { label: '순환재고 판매량', value: (totalSalesKg.value ?? 0).toLocaleString('ko-KR'), unit: 'kg',   sub: '판매 내역 보기 →',     icon: ShieldCheck,  valueCls: 'text-teal-700',     iconBg: 'bg-teal-50',     iconCls: 'text-teal-600', to: '/hq/circular-inventory/sales/history' },
 ])
 
-// ─────────── 거래 가능 탄소 배출권 (자산 포트폴리오 스타일) ───────────
-//   잔여 한도 × KAU25 시세 = 보유 자산 가치
-//   향후 KOC offset 도입 시 carbonAssetBreakdown 에 항목 추가
+// ─────────── 배출권 시장 가치 환산 (자산 포트폴리오 스타일) ───────────
+//   순환 활동 탄소 감축량 (tCO₂e) × KAU25 시세 = 절감 가치 (환산 가치)
+//   - 의미: 우리가 순환재고 활동으로 회피한 탄소량을 배출권으로 환산했을 때의 시장 가치
+//   - 데이터: esgStore.totalCarbonReductionTon (= "순환 활동 탄소 감축 현황" 막대 합계)
 const carbonAssetValue = computed(() =>
-  Math.round(emissionCompliance.value.expectedSurplus * (kauPrice.value || 0)),
+  Math.round((totalCarbonReductionTon.value || 0) * (kauPrice.value || 0)),
 )
 
 // 변동률 (7거래일 첫째 날 대비) — carbonTrend 의 첫째 날 종가를 baseline 으로 동적 산정
 const carbonAssetTrend = computed(() => {
-  const surplus = emissionCompliance.value.expectedSurplus
+  const reductionTon = totalCarbonReductionTon.value || 0
   const trend = carbonTrend.value ?? []
   if (trend.length === 0) {
     return { up: false, down: false, label: '시세 미조회', detail: '기준값 없음' }
   }
   const firstPrice = Number(trend[0]?.pricePerTon) || 0
-  const baseline = Math.round(surplus * firstPrice)
+  const baseline = Math.round(reductionTon * firstPrice)
   const current = carbonAssetValue.value
   if (baseline === 0) return { up: false, down: false, label: '0%', detail: '기준값 없음' }
   const diff = current - baseline
@@ -494,32 +258,29 @@ const carbonAssetTrend = computed(() => {
   return {
     up: diff > 0, down: diff < 0,
     label: `${formattedPct} (vs 7거래일 첫날)`,
-    detail: `${formattedDiff} · 잔여 ${surplus.toLocaleString()} tCO₂ × ₩${(kauPrice.value || 0).toLocaleString()}`,
+    detail: `${formattedDiff} · 절감량 ${reductionTon.toFixed(1)} tCO₂e × ₩${(kauPrice.value || 0).toLocaleString()}`,
   }
 })
 
-// 일별 자산 가치 추이 — 잔여 한도(현재) × 일별 KAU25 종가 (carbonTrend, BE 연동)
+// 월별 환산 가치 추이 — 월별 탄소 절감량(kg → tCO₂e) × 현재 KAU25 시세
+//   - esgStore.carbonReductionMonthly: 1~12월 kg CO₂ (computeMonthlyCarbonReduction 결과)
+//   - 의미: 각 월에 회피한 탄소량을 배출권 시장 가치로 환산 (막대 그래프 표시)
 const carbonAssetMonthlyData = computed(() => {
-  const trend = carbonTrend.value ?? []
-  const surplus = emissionCompliance.value.expectedSurplus
+  const monthly = carbonReductionMonthly.value ?? Array(12).fill(0)
+  const price = Number(kauPrice.value) || 0
+  const labels = Array.from({ length: 12 }, (_, i) => `${i + 1}월`)
+  const data = monthly.map(kg => Math.round(((Number(kg) || 0) / 1000) * price))
   return {
-    labels: trend.map(d => {
-      const s = d?.basDt ?? ''
-      return s.length === 8 ? `${s.slice(4,6)}/${s.slice(6,8)}` : s
-    }),
+    labels,
     datasets: [{
-      label: '자산 가치',
-      data: trend.map(d => Math.round(surplus * (Number(d?.pricePerTon) || 0))),
+      label: '월별 환산 가치',
+      data,
+      backgroundColor: 'rgba(245, 158, 11, 0.85)',
+      hoverBackgroundColor: '#d97706',
       borderColor: '#d97706',
-      backgroundColor: 'rgba(245, 158, 11, 0.12)',
-      pointBackgroundColor: '#d97706',
-      pointBorderColor: '#fff',
-      pointBorderWidth: 1.5,
-      pointRadius: 3.5,
-      pointHoverRadius: 5,
-      borderWidth: 2,
-      tension: 0.3,
-      fill: true,
+      borderWidth: 1,
+      borderRadius: 3,
+      maxBarThickness: 28,
     }],
   }
 })
@@ -535,10 +296,14 @@ const carbonAssetMonthlyOptions = {
   },
   scales: {
     y: {
-      beginAtZero: false,
+      beginAtZero: true,
       ticks: {
         font: { size: 9 }, maxTicksLimit: 5,
-        callback: (v) => '₩' + Math.round(v / 1000000) + 'M',
+        callback: (v) => {
+          if (v >= 1_000_000) return '₩' + Math.round(v / 1_000_000) + 'M'
+          if (v >= 1_000) return '₩' + Math.round(v / 1_000) + 'K'
+          return '₩' + v
+        },
       },
       grid: { color: 'rgba(0,0,0,0.05)' },
     },
@@ -558,7 +323,6 @@ const carbonAssetMonthlyOptions = {
 // ─────────── 순환 재고 판매 수익 — BE 연동 ───────────
 //   GET /api/hq/esg/circular-revenue?year=YYYY
 //   응답: { year, monthly:[{month,revenue,count}], totalRevenue, totalCount, monthsWithData, avgMonthly }
-const revenuePeriod = ref('YEAR')   // M | Q | YEAR (토글 — totalRevenue 계산 범위만 영향)
 const revenueData = ref(null)        // BE 응답 원본
 const revenueLoading = ref(false)
 const revenueError = ref('')
@@ -588,16 +352,9 @@ const revenueMonthly = computed(() => {
   return arr
 })
 
-// 토글 (월/분기/연) 에 따른 합계 — BE 의 12개월 데이터를 FE 에서 슬라이싱
+// 12개월 누적 합계 — BE 의 totalRevenue 우선, 없으면 월별 데이터 합산
 const totalRevenue = computed(() => {
   const arr = revenueMonthly.value
-  const now = new Date()
-  const m = now.getMonth()
-  if (revenuePeriod.value === 'M') return arr[m] ?? 0
-  if (revenuePeriod.value === 'Q') {
-    const start = Math.max(0, m - 2)
-    return arr.slice(start, m + 1).reduce((s, v) => s + v, 0)
-  }
   return revenueData.value?.totalRevenue ?? arr.reduce((s, v) => s + v, 0)
 })
 
@@ -670,7 +427,7 @@ const dateLabel = computed(() =>
         <div class="flex flex-wrap items-center gap-3">
           <h2 class="inline-flex items-center gap-2 text-[15px] font-semibold text-gray-900">
             <Leaf :size="18" class="text-emerald-600" />
-            탄소배출권 관리
+            탄소 배출 관리
           </h2>
           <span class="border border-gray-200 bg-gray-50 px-2 py-1 text-[11px] font-medium text-gray-500">
             기준: {{ dateLabel }}
@@ -693,6 +450,8 @@ const dateLabel = computed(() =>
           v-for="m in kpiMetrics"
           :key="m.label"
           class="flex h-[90px] flex-col justify-between border border-gray-300 bg-white px-4 py-3 shadow-sm"
+          :class="m.to ? 'cursor-pointer transition hover:border-gray-400 hover:shadow' : ''"
+          @click="m.to && router.push(m.to)"
         >
           <div class="flex items-center justify-between">
             <p class="text-[11px] font-medium text-gray-500">{{ m.label }}</p>
@@ -710,113 +469,65 @@ const dateLabel = computed(() =>
         </article>
       </section>
 
-      <!-- 배출 한도 vs 실적 + 거래 가능 탄소 배출권 -->
+      <!-- 배출 한도 vs 실적 + 배출권 시장 가치 환산 -->
       <section class="grid gap-3 xl:grid-cols-2">
 
-        <!-- 탄소중립 관리 (emissionQuota 스토어 연동) -->
+        <!-- 순환 활동 탄소 감축 현황 (소재 그룹별 막대 게이지) -->
         <article class="flex flex-col border border-gray-300 bg-white shadow-sm">
           <div class="flex items-center justify-between border-b border-gray-200 px-3 py-2.5">
             <h3 class="inline-flex items-center gap-2 text-sm font-medium text-gray-800">
-              <Scale :size="15" class="text-blue-600" />
-              탄소중립 관리
-              <span class="text-[10px] font-normal text-gray-400">SBTi 자발적 모델</span>
+              <Scale :size="15" class="text-emerald-600" />
+              순환 활동 탄소 감축 현황
             </h3>
-            <button
-              type="button"
-              class="inline-flex items-center gap-1 border border-blue-300 bg-blue-50 px-2 py-1 text-[11px] font-medium text-blue-700 transition hover:bg-blue-100"
-              @click="openQuotaModal"
-            >
-              <Edit3 :size="12" />
-              할당량 입력
-            </button>
           </div>
 
-          <div class="flex flex-1 flex-col gap-3 px-3 pt-3 pb-0">
-            <!-- 배출 한도 vs 사용한 탄소배출권 도넛 -->
-            <div>
-              <div class="mb-1.5 flex items-baseline justify-between">
-                <span class="text-[11px] font-medium text-gray-500">정부 할당량 대비 사용률</span>
-                <span class="inline-flex items-center gap-1 border border-blue-200 bg-blue-50 px-2 py-0.5 text-[10px] font-bold text-blue-700">
-                  실효 {{ emissionCompliance.ytdNet.toLocaleString() }} / 할당 {{ emissionCompliance.allocation.toLocaleString() }} tCO₂
-                </span>
-              </div>
-              <div class="relative">
-                <DoughnutChart :data="emissionDoughnutData" :options="emissionDoughnutOptions" :height="220" />
-                <div class="pointer-events-none absolute inset-x-0 top-[28%] flex flex-col items-center">
-                  <span class="text-[10px] font-medium text-gray-500">사용률</span>
-                  <span class="text-[26px] font-black text-blue-700 leading-none">{{ emissionCompliance.utilizationPct }}%</span>
-                  <span class="mt-1 text-[10px] text-gray-400">{{ emissionCompliance.ytdNet.toLocaleString() }} / {{ emissionCompliance.allocation.toLocaleString() }} tCO₂</span>
+          <div class="flex flex-1 flex-col gap-4 px-4 py-4">
+            <!-- 소재 그룹별 막대 게이지 -->
+            <div class="flex flex-col gap-3">
+              <div
+                v-for="row in materialReductionRows"
+                :key="row.key"
+                class="flex flex-col gap-1.5"
+              >
+                <div class="flex items-baseline justify-between">
+                  <span class="text-[12px] font-medium text-gray-700">{{ row.label }}</span>
+                  <span class="text-[12px] font-bold text-gray-800">
+                    {{ row.ton.toFixed(1) }}
+                    <span class="text-[10px] font-medium text-gray-500">tCO₂e</span>
+                  </span>
+                </div>
+                <div class="h-1.5 w-full bg-gray-100">
+                  <div
+                    class="h-full transition-all"
+                    :style="{ width: `${row.barPct}%`, backgroundColor: row.color }"
+                  ></div>
                 </div>
               </div>
-            </div>
-
-            <!-- 4개 메트릭: 정부 할당량 / 사용한 탄소 배출량 / 잔여 한도 / 절감한 탄소 배출량 -->
-            <div class="grid grid-cols-4 gap-2">
-              <div class="border border-gray-200 bg-gray-50 px-2 py-2">
-                <p class="text-[10px] text-gray-500">정부 할당량</p>
-                <div class="mt-0.5 flex items-baseline gap-0.5">
-                  <span class="text-[14px] font-bold text-gray-800">{{ emissionCompliance.allocation.toLocaleString() }}</span>
-                  <span class="text-[9px] text-gray-400">tCO₂</span>
-                </div>
-              </div>
-              <div class="border border-gray-200 bg-gray-50 px-2 py-2">
-                <p class="text-[10px] text-gray-500">사용한 탄소 배출량</p>
-                <div class="mt-0.5 flex items-baseline gap-0.5">
-                  <span class="text-[14px] font-bold text-blue-700">{{ emissionCompliance.ytdNet.toLocaleString() }}</span>
-                  <span class="text-[9px] text-gray-400">tCO₂</span>
-                </div>
-              </div>
-              <div class="border border-amber-200 bg-amber-50 px-2 py-2">
-                <p class="text-[10px] text-amber-700">잔여 한도</p>
-                <div class="mt-0.5 flex items-baseline gap-0.5">
-                  <span class="text-[14px] font-bold text-amber-700">{{ emissionCompliance.expectedSurplus.toLocaleString() }}</span>
-                  <span class="text-[9px] text-amber-600">tCO₂</span>
-                </div>
-              </div>
-              <div class="border border-emerald-200 bg-emerald-50 px-2 py-2">
-                <p class="text-[10px] text-emerald-700">절감한 탄소 배출량</p>
-                <div class="mt-0.5 flex items-baseline gap-0.5">
-                  <!-- KPI "탄소 배출 절감" 카드와 동일한 값 (esgStore.totalCarbonReductionKg / 1000) -->
-                  <span class="text-[14px] font-bold text-emerald-700">{{ totalCarbonReductionTon.toFixed(2) }}</span>
-                  <span class="text-[9px] text-emerald-600">tCO₂</span>
-                </div>
-              </div>
-            </div>
-
-            <!-- 분기별 진행 (BarChart, 카드 최하단) -->
-            <div class="mt-auto">
-              <div class="mb-1.5 flex items-center justify-between">
-                <p class="text-[10px] font-medium text-gray-500">분기별 배출 진행 (YTD 실적)</p>
-                <span class="inline-flex items-center gap-1 text-[9px] text-gray-500">
-                  <span class="inline-block h-2 w-2 rounded-sm bg-blue-500"></span>
-                  실적
-                </span>
-              </div>
-              <BarChart :data="quarterlyChartData" :options="quarterlyChartOptions" :height="140" />
             </div>
 
           </div>
         </article>
 
-        <!-- 거래 가능 탄소 배출권 (자산 포트폴리오 스타일) -->
+        <!-- 배출권 시장 가치 환산 (자산 포트폴리오 스타일) -->
         <article class="flex min-w-0 flex-col border border-gray-300 bg-white shadow-sm">
           <div class="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 border-b border-gray-200 px-3 py-2.5">
             <h3 class="inline-flex flex-wrap items-center gap-x-2 gap-y-0.5 text-sm font-medium text-gray-800">
               <span class="inline-flex items-center gap-2">
                 <Coins :size="15" class="text-amber-600" />
-                거래 가능 탄소 배출권
-                <span class="text-[10px] font-normal text-gray-400">자산 포트폴리오</span>
+                순환재고 판매 시장 가치 환산
               </span>
               <span class="text-[10.5px] font-normal text-amber-700/80">
-                ⓘ 잔여 한도 × KAU25 시세 · KRX 매도 가능 (평일 10:00~12:00)
+                ⓘ 순환 활동 탄소 감축량 × KAU25 시세
               </span>
             </h3>
             <span class="shrink-0 text-[10px] text-gray-400">기준: {{ dateLabel }}</span>
           </div>
 
-          <!-- 보유 자산 가치 (메인 메트릭) -->
+          <!-- 순환재고 판매 누적 환산 가치 (메인 메트릭) -->
+          <!--   = 연간 누적 탄소 감축량(tCO₂) × KAU25 현재 시세(원/톤) -->
+          <!--   "보유 자산" 이 아니라 "탄소 감축 효과를 KAU 시세로 환산한 누적 가치" 라는 의미 -->
           <div class="border-b border-amber-100 bg-gradient-to-br from-amber-50 to-yellow-50 px-3 py-3">
-            <p class="text-[10px] font-medium text-amber-700/80">보유 자산 가치</p>
+            <p class="text-[10px] font-medium text-amber-700/80">순환재고 판매 누적 환산 가치</p>
             <div class="mt-1 flex items-baseline gap-1.5">
               <span class="text-[24px] font-black text-amber-700">
                 ₩{{ carbonAssetValue.toLocaleString('ko-KR') }}
@@ -836,9 +547,9 @@ const dateLabel = computed(() =>
 
           <!-- 월별 가치 추이 (막대 차트) -->
           <div class="flex min-w-0 flex-1 flex-col px-3 py-2.5">
-            <p class="mb-1.5 text-[10px] font-medium uppercase tracking-widest text-gray-500">최근 7거래일 자산 가치 추이</p>
+            <p class="mb-1.5 text-[10px] font-medium uppercase tracking-widest text-gray-500">월별 환산 가치 추이</p>
             <div class="relative w-full flex-1" style="min-height: 220px;">
-              <LineChart :data="carbonAssetMonthlyData" :options="carbonAssetMonthlyOptions" fill-height />
+              <BarChart :data="carbonAssetMonthlyData" :options="carbonAssetMonthlyOptions" fill-height />
             </div>
           </div>
         </article>
@@ -859,16 +570,6 @@ const dateLabel = computed(() =>
                 ⓘ 판매 단가 × 무게 합산 · 월말 마감 후 자동 갱신
               </span>
             </h3>
-            <div class="inline-flex shrink-0 items-center gap-0.5 border border-gray-300 bg-white p-0.5">
-              <button
-                v-for="p in [{v:'M',l:'월'},{v:'Q',l:'분기'},{v:'YEAR',l:'년'}]"
-                :key="p.v"
-                type="button"
-                class="px-2 py-0.5 text-[10px] font-medium transition"
-                :class="revenuePeriod === p.v ? 'bg-emerald-700 text-white' : 'text-gray-600 hover:bg-gray-50'"
-                @click="revenuePeriod = p.v"
-              >{{ p.l }}</button>
-            </div>
           </div>
 
           <!-- 월별 판매 수익 (메인) -->
@@ -983,105 +684,5 @@ const dateLabel = computed(() =>
       </section>
 
     </div>
-
-    <!-- 정부 할당량 관리 모달 -->
-    <Teleport to="body">
-      <div
-        v-if="showQuotaModal"
-        class="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50 p-4"
-        @click.self="closeQuotaModal"
-      >
-        <div class="flex max-h-[90vh] w-full max-w-2xl flex-col border border-gray-300 bg-white shadow-2xl">
-          <!-- 헤더 -->
-          <div class="flex items-center justify-between border-b border-gray-200 bg-gradient-to-r from-blue-50 to-emerald-50 px-5 py-3">
-            <h3 class="inline-flex items-center gap-2 text-[15px] font-bold text-gray-900">
-              <Scale :size="18" class="text-blue-600" />
-              {{ fiscalYear }} 정부 할당량 관리
-            </h3>
-            <button
-              type="button"
-              class="flex h-7 w-7 items-center justify-center text-gray-500 hover:bg-gray-100 hover:text-gray-700"
-              @click="closeQuotaModal"
-            >
-              <X :size="16" />
-            </button>
-          </div>
-
-          <!-- 본문 -->
-          <div class="flex-1 overflow-y-auto px-5 py-4">
-            <!-- 연간 할당량 -->
-            <div class="mb-4">
-              <label class="flex flex-col gap-1">
-                <span class="text-[11px] font-semibold text-gray-700">연간 할당량 (tCO₂)</span>
-                <input
-                  v-model.number="quotaDraft.yearlyAllocation"
-                  type="number"
-                  min="0"
-                  class="border border-gray-300 bg-white px-2.5 py-1.5 text-sm text-gray-900 focus:border-blue-500 focus:outline-none"
-                  placeholder="예: 1000"
-                />
-              </label>
-            </div>
-
-            <!-- 월별 입력 (분기별 4행) -->
-            <div class="mb-6">
-              <p class="mb-1.5 text-[11px] font-semibold text-gray-700">월별 실적 (tCO₂)</p>
-              <div class="flex flex-col gap-1.5">
-                <div
-                  v-for="q in 4"
-                  :key="q"
-                  class="grid grid-cols-4 gap-2"
-                >
-                  <label
-                    v-for="m in 3"
-                    :key="m"
-                    class="flex flex-col gap-0.5 border border-gray-200 bg-gray-50 px-2 py-1.5"
-                  >
-                    <span class="text-[10px] font-medium text-gray-500">{{ MONTH_LABELS[(q - 1) * 3 + (m - 1)] }}</span>
-                    <input
-                      v-model="quotaDraft.monthly[(q - 1) * 3 + (m - 1)]"
-                      type="number"
-                      min="0"
-                      class="w-full border-0 bg-transparent p-0 text-[12px] font-semibold text-gray-900 focus:outline-none focus:ring-0"
-                      placeholder="-"
-                    />
-                  </label>
-                  <div class="flex flex-col gap-0.5 border border-blue-200 bg-blue-50 px-2 py-1.5">
-                    <span class="text-[10px] font-semibold text-blue-700">Q{{ q }}</span>
-                    <span class="text-[12px] font-bold text-blue-700">
-                      {{ quarterSum(q).toLocaleString() }}
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <!-- 안내 -->
-            <p class="text-[11px] text-gray-500">
-              매월 활동량 입력 시 tCO₂로 자동 환산됩니다. YTD는 누적, 분기 차트는 3개월씩 합산.
-            </p>
-          </div>
-
-          <!-- 푸터 -->
-          <div class="flex items-center justify-end gap-2 border-t border-gray-200 bg-gray-50 px-5 py-3">
-            <button
-              type="button"
-              class="border border-gray-300 bg-white px-3 py-1.5 text-[12px] font-semibold text-gray-700 transition hover:bg-gray-100"
-              @click="closeQuotaModal"
-            >
-              취소
-            </button>
-            <button
-              type="button"
-              class="inline-flex items-center gap-1 border border-blue-600 bg-blue-600 px-3 py-1.5 text-[12px] font-semibold text-white transition hover:bg-blue-700"
-              @click="saveQuotaModal"
-            >
-              <Save :size="13" />
-              저장
-            </button>
-          </div>
-        </div>
-      </div>
-    </Teleport>
   </AppLayout>
 </template>

--- a/src/views/hq/esg/EsgTreeScoreView.vue
+++ b/src/views/hq/esg/EsgTreeScoreView.vue
@@ -2,7 +2,7 @@
 import { ref, computed, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import {
-  ArrowLeft, RefreshCw, Leaf, Recycle, ShieldCheck, Heart,
+  ArrowLeft, RefreshCw, Leaf, Recycle, ShieldCheck,
   TrendingUp, Award, Filter, Sprout, Calendar,
   Info, X,
 } from 'lucide-vue-next'
@@ -19,33 +19,26 @@ const router = useRouter()
 const auth = useAuthStore()
 const topMenus = computed(() => roleMenus.hq ?? [])
 const sideMenus = computed(
-  () => (roleMenus.hq ?? []).find((menu) => menu.label === 'ESG 대시보드')?.children ?? [],
+  () => (roleMenus.hq ?? []).find((menu) => menu.label === 'ESG 탄소 성과 관리')?.children ?? [],
 )
 const activeSideMenu = ref('친환경 나무 키우기 점수')
 
-// ─────────── 점수 룰 마스터 ───────────
-const SCORE_RULES = {
-  saleBase: 100,             // 판매 1건 기본 점수
-  donationBase: 80,          // 기부 1건 기본 점수
-  minWeightKg: 10,           // 최소 중량
-  newBuyerBonus: 150,
-  localPartnerBonus: 150,
-  localPartnerMonthlyCap: 3, // 거래처당 월 한도
-}
-// circular_material_price_policy 시드와 동일한 10종.
-// factor: kgCO₂/kg (LCA 기준 표준치 mock — 향후 BE GET /api/hq/esg/material-factors 로 교체)
+// Phase 1 BE 이관 후: 산식·factor 모두 BE 에서 처리. 본 객체는 화면 표시용
+// (테이블 소재명 라벨 + 안내 모달의 factor/note 표) 로만 사용.
+// note 는 BE 응답에 없는 보조 텍스트라 FE 에만 유지.
 const MATERIAL_FACTORS = {
-  COTTON:     { label: '면',         group: 'NATURAL_SINGLE', factor: 1.8, note: '—' },
-  WOOL:       { label: '울',         group: 'NATURAL_SINGLE', factor: 2.5, note: '—' },
-  CASHMERE:   { label: '캐시미어',   group: 'NATURAL_SINGLE', factor: 5.8, note: '방목 토지 사용으로 계수 높음' },
-  SILK:       { label: '실크',       group: 'NATURAL_SINGLE', factor: 3.2, note: '—' },
-  LINEN:      { label: '린넨',       group: 'NATURAL_SINGLE', factor: 1.1, note: '재배 단계 배출 적음' },
-  POLYESTER:  { label: '폴리에스터', group: 'SYNTHETIC',      factor: 2.3, note: '—' },
-  ACRYLIC:    { label: '아크릴',     group: 'SYNTHETIC',      factor: 2.2, note: '—' },
-  POLYAMIDE:  { label: '나일론',     group: 'SYNTHETIC',      factor: 2.1, note: 'POLYAMIDE' },
-  NYLON:      { label: '나일론',     group: 'SYNTHETIC',      factor: 2.1, note: 'POLYAMIDE 별칭' },
-  ELASTANE:   { label: '스판덱스',   group: 'SYNTHETIC',      factor: 2.5, note: '—' },
-  BLEND:      { label: '혼방',       group: 'BLEND',          factor: 2.0, note: '구성 비율 분해 평균' },
+  COTTON:     { label: '면',         group: 'NATURAL_SINGLE', factor: 6.0, note: 'Higg MSI v3 중앙값' },
+  WOOL:       { label: '울',         group: 'NATURAL_SINGLE', factor: 5.0, note: 'Higg MSI cap (방목 메탄 보정)' },
+  CASHMERE:   { label: '캐시미어',   group: 'NATURAL_SINGLE', factor: 8.0, note: 'Higg MSI cap (방목 토지 사용)' },
+  SILK:       { label: '실크',       group: 'NATURAL_SINGLE', factor: 5.0, note: 'Higg MSI cap' },
+  LINEN:      { label: '린넨',       group: 'NATURAL_SINGLE', factor: 1.8, note: '재배 단계 배출 적음' },
+  POLYESTER:  { label: '폴리에스터', group: 'SYNTHETIC',      factor: 6.5, note: 'Higg MSI / EU PEF' },
+  ACRYLIC:    { label: '아크릴',     group: 'SYNTHETIC',      factor: 5.7, note: 'Higg MSI' },
+  POLYAMIDE:  { label: '나일론',     group: 'SYNTHETIC',      factor: 8.0, note: 'Higg MSI Nylon 6' },
+  NYLON:      { label: '나일론',     group: 'SYNTHETIC',      factor: 8.0, note: 'POLYAMIDE 별칭' },
+  ELASTANE:   { label: '스판덱스',   group: 'SYNTHETIC',      factor: 12.0, note: 'Higg MSI 10~14' },
+  RAYON:      { label: '레이온',     group: 'SYNTHETIC',      factor: 4.5, note: 'Higg MSI Viscose' },
+  BLEND:      { label: '혼방',       group: 'BLEND',          factor: 5.5, note: '70% 주 소재 × 0.7 가중 적용' },
 }
 
 // 소재 계수 안내 모달
@@ -71,9 +64,9 @@ const SCORE_RULE_ROWS = [
   {
     id: 'carbon',
     label: '탄소 감축 기여',
-    base: '무게(kg) × 소재 계수 × 0.5',
-    cond: '판매 + 기부 합산',
-    detail: '폐기·소각되지 않고 판매·기부된 재고에 대한 실제 탄소 감축량 환산 점수. 혼방 소재는 구성 비율 분해 평균 적용. ×0.5는 다른 점수 요소와의 비중 균형용 스케일링.',
+    base: '무게(kg) × 소재 계수 × 0.1',
+    cond: '판매 활동',
+    detail: '폐기·소각되지 않고 판매된 재고에 대한 실제 탄소 감축량 환산 점수. 혼방 소재는 70% 주 소재 factor × 0.7 가중 적용. ×0.1는 Higg MSI 표준 factor 적용에 따른 다른 점수 요소와의 비중 균형.',
     barCls: 'bg-teal-500',
   },
   {
@@ -92,17 +85,9 @@ const SCORE_RULE_ROWS = [
     detail: '지역 기반 소규모 파트너 / 사회적 기업과의 거래에 부여 (ESG-S). 거래처당 월 3건 상한으로 어뷰징 방지.',
     barCls: 'bg-amber-500',
   },
-  {
-    id: 'donationExecution',
-    label: '기부 활동 실행',
-    base: '기부 1건 = 80점',
-    cond: '최소 10kg 이상 기부 시',
-    detail: '기부 행동 자체에 부여되는 기본 점수. 탄소 감축 점수는 별도 합산.',
-    barCls: 'bg-pink-500',
-  },
 ]
 
-// 모달 표시용 소재 리스트 — BE circular_material_price_policy 시드 순서와 동일 (NYLON 은 POLYAMIDE 의 FE 별칭이라 제외)
+// 모달 표시용 소재 리스트 — BE material 시드 (Phase 1) 와 동일 (NYLON 은 POLYAMIDE 의 FE 별칭이라 제외)
 const MATERIAL_FACTOR_ROWS = [
   { code: 'COTTON',     ...MATERIAL_FACTORS.COTTON },
   { code: 'WOOL',       ...MATERIAL_FACTORS.WOOL },
@@ -113,6 +98,7 @@ const MATERIAL_FACTOR_ROWS = [
   { code: 'ACRYLIC',    ...MATERIAL_FACTORS.ACRYLIC },
   { code: 'POLYAMIDE',  ...MATERIAL_FACTORS.POLYAMIDE },
   { code: 'ELASTANE',   ...MATERIAL_FACTORS.ELASTANE },
+  { code: 'RAYON',      ...MATERIAL_FACTORS.RAYON },
   { code: 'BLEND',      ...MATERIAL_FACTORS.BLEND },
 ]
 const MATERIAL_GROUP_LABEL = {
@@ -121,28 +107,32 @@ const MATERIAL_GROUP_LABEL = {
   BLEND:          '혼방',
 }
 
-// ─────────── 이벤트 데이터 ───────────
-//   sale: BE 연동 (GET /api/hq/esg/score-events)
-//   donation: BE 도메인 미구현 → mock 유지 (향후 BE 추가 시 같은 형태로 머지)
-const MOCK_DONATION_EVENTS = [
-  // 4월 기부 4건
-  { id: 'd-1', date: '2026-04-28', type: 'donation', buyer: '재해구호본부',  material: 'COTTON',    weightKg:  95, isNewBuyer: false, isLocalPartner: false, donationType: 'DISASTER',  method: null },
-  { id: 'd-2', date: '2026-04-22', type: 'donation', buyer: '사회복지시설',  material: 'COTTON',    weightKg:  80, isNewBuyer: false, isLocalPartner: false, donationType: 'VULNERABLE',method: null },
-  { id: 'd-3', date: '2026-04-14', type: 'donation', buyer: '해외구호단체',  material: 'POLYESTER', weightKg:  50, isNewBuyer: false, isLocalPartner: false, donationType: 'OVERSEAS',  method: null },
-  { id: 'd-4', date: '2026-04-05', type: 'donation', buyer: '직업학교',      material: 'BLEND',     weightKg:  30, isNewBuyer: false, isLocalPartner: false, donationType: 'EDU',       method: null },
-  // 3월 기부 1건
-  { id: 'd-5', date: '2026-03-12', type: 'donation', buyer: '재해구호본부',  material: 'COTTON',    weightKg:  60, isNewBuyer: false, isLocalPartner: false, donationType: 'DISASTER',  method: null },
-  // 1월 기부 1건
-  { id: 'd-6', date: '2026-01-12', type: 'donation', buyer: '직업학교',      material: 'BLEND',     weightKg:  40, isNewBuyer: false, isLocalPartner: false, donationType: 'EDU',       method: null },
-]
+// ─────────── 활동 이력 카테고리 필터 ───────────
+// ALL | saleExecution | carbon | newBuyer | localPartner — BE 동일 enum
+const filterCategory = ref('ALL')
 
-const saleEvents = ref([])
+// 카테고리 필터 메타 (라벨/색상)
+const LOG_FILTERS = [
+  { v: 'ALL',               l: '전체',          dot: '#6b7280' },
+  { v: 'saleExecution',     l: '판매 실행',     dot: '#10b981' },
+  { v: 'carbon',            l: '탄소 감축',     dot: '#14b8a6' },
+  { v: 'newBuyer',          l: '신규 확산',     dot: '#3b82f6' },
+  { v: 'localPartner',      l: '지역 상생',     dot: '#f59e0b' },
+]
+// 단일 카테고리 필터 시 점수 분해/총점 컬럼 라벨 & 텍스트 색상
+const FILTER_BREAKDOWN_META = {
+  saleExecution:     { label: '판매 실행', cls: 'text-emerald-700' },
+  carbon:            { label: '탄소 감축', cls: 'text-teal-700' },
+  newBuyer:          { label: '신규 확산', cls: 'text-blue-700' },
+  localPartner:      { label: '지역 상생', cls: 'text-amber-700' },
+}
+
+// ─────────── BE 응답 통째 보관 (Phase 3 — A''-1 서버 페이징/통계) ───────────
+//   응답: { year, events(페이지 슬라이스), summary, monthlyBreakdown, categoryBreakdown, page, size, totalElements, totalPages }
+const responseData = ref(null)
 const loadEventsError = ref('')
 
-/** BE 응답 sale events 를 FE event 형태로 정규화
- *  - Jackson+Lombok 직렬화 quirk: isNewBuyer → "newBuyer" 로 직렬화됨
- *  - 양쪽 필드명 모두 수용해서 BE/FE 직렬화 컨벤션 변경에 견고
- */
+/** BE event row 1건을 FE 표시용으로 정규화 (필드명 quirk 흡수) */
 function normalizeSaleEvent(e) {
   return {
     id: e.id,
@@ -151,173 +141,84 @@ function normalizeSaleEvent(e) {
     buyer: e.buyer,
     material: e.material,
     weightKg: e.weightKg,
+    // Jackson+Lombok 직렬화 quirk: isXxx → "xxx" 로 직렬화될 수 있음. 양쪽 모두 수용.
     isNewBuyer: e.isNewBuyer ?? e.newBuyer ?? false,
     isLocalPartner: e.isLocalPartner ?? e.localPartner ?? false,
-    donationType: null,
-    method: null,
+    mainMaterialCode: e.mainMaterialCode ?? null,
+    mainMaterialRatio: e.mainMaterialRatio != null ? Number(e.mainMaterialRatio) : null,
+    // BE 가 계산한 거래별 점수 4종 (그대로 사용 — FE 자체 산식 폐기)
+    saleExecution: e.saleExecution ?? 0,
+    carbon:        e.carbon        ?? 0,
+    newBuyer:      e.newBuyer      ?? 0,
+    localPartner:  e.localPartner  ?? 0,
+    total:         e.total         ?? 0,
+    scoreValid:    e.scoreValid    === true,
   }
 }
 
-async function loadEvents(year) {
-  loadEventsError.value = ''
-  try {
-    const targetYear = year ?? new Date().getFullYear()
-    const res = await scoreEventsApi.get(targetYear)
-    saleEvents.value = (res?.events ?? []).map(normalizeSaleEvent)
-  } catch (err) {
-    loadEventsError.value = extractErrorMessage(err, '점수 이벤트를 불러오지 못했습니다.')
-    saleEvents.value = []
-  }
-}
-
-// sale (BE) + donation (mock) 머지 → 기존 events 변수와 동일 인터페이스
-const events = computed(() => [...saleEvents.value, ...MOCK_DONATION_EVENTS])
-
-// ─────────── 점수 계산 함수 (이벤트 1건 → 분해 점수) ───────────
-//   탄소 점수 = 무게(kg) × 소재 계수 × 0.5
-//   (×0.5 스케일링 — 거래량 누적에 따른 점수 폭주 방지 / 다른 점수 요소와 비중 균형)
-const CARBON_SCALE = 0.5
-function calcEventScore(e) {
-  const valid = e.weightKg >= SCORE_RULES.minWeightKg
-  const factor = MATERIAL_FACTORS[e.material]?.factor ?? 0
-  if (e.type === 'sale') {
-    if (!valid) return { saleExecution: 0, carbon: 0, newBuyer: 0, localPartner: 0, donationExecution: 0, total: 0, valid: false }
-    const saleExecution = SCORE_RULES.saleBase
-    const carbon = Math.round(e.weightKg * factor * CARBON_SCALE)
-    const newBuyer = e.isNewBuyer ? SCORE_RULES.newBuyerBonus : 0
-    const localPartner = e.isLocalPartner ? SCORE_RULES.localPartnerBonus : 0
-    const total = saleExecution + carbon + newBuyer + localPartner
-    return { saleExecution, carbon, newBuyer, localPartner, donationExecution: 0, total, valid: true }
-  }
-  // donation
-  if (!valid) return { saleExecution: 0, carbon: 0, newBuyer: 0, localPartner: 0, donationExecution: 0, total: 0, valid: false }
-  const donationExecution = SCORE_RULES.donationBase
-  const carbon = Math.round(e.weightKg * factor * CARBON_SCALE)
-  return { saleExecution: 0, carbon, newBuyer: 0, localPartner: 0, donationExecution, total: donationExecution + carbon, valid: true }
-}
-
-// ─────────── 필터 ───────────
-//   기간 필터: 페이지 전체 (통계/차트/카테고리 합산) 에 영향
-//   카테고리 필터: 활동 이력 섹션에만 적용 (5개 점수 요소 + 전체)
-const filterPeriod = ref('YEAR')        // YEAR | Q | M
-const filterCategory = ref('ALL')       // ALL | saleExecution | carbon | newBuyer | localPartner | donationExecution
-
-// 기간만 적용한 이벤트 (통계/차트/카테고리 합산용)
-const filteredEvents = computed(() => {
-  const now = new Date()
-  const ym = now.getFullYear() * 12 + now.getMonth()
-  return events.value.filter(e => {
-    const d = new Date(e.date)
-    const eYm = d.getFullYear() * 12 + d.getMonth()
-    if (filterPeriod.value === 'M') return eYm === ym
-    if (filterPeriod.value === 'Q') return eYm >= ym - 2
-    return d.getFullYear() === now.getFullYear()  // YEAR
-  })
-})
-
-// 카테고리 필터까지 적용 — 활동 이력 섹션 전용
-const logEvents = computed(() => {
-  if (filterCategory.value === 'ALL') return filteredEvents.value
-  const key = filterCategory.value
-  return filteredEvents.value.filter(e => {
-    const s = calcEventScore(e)
-    return s[key] > 0
-  })
-})
-
-// 활동 이력 카테고리 필터 메타 (라벨/색상)
-const LOG_FILTERS = [
-  { v: 'ALL',               l: '전체',          dot: '#6b7280' },
-  { v: 'saleExecution',     l: '판매 실행',     dot: '#10b981' },
-  { v: 'carbon',            l: '탄소 감축',     dot: '#14b8a6' },
-  { v: 'newBuyer',          l: '신규 확산',     dot: '#3b82f6' },
-  { v: 'localPartner',      l: '지역 상생',     dot: '#f59e0b' },
-  { v: 'donationExecution', l: '기부 실행',     dot: '#ec4899' },
-]
-// 단일 카테고리 필터 시 점수 분해/총점 컬럼 라벨 & 텍스트 색상
-const FILTER_BREAKDOWN_META = {
-  saleExecution:     { label: '판매 실행', cls: 'text-emerald-700' },
-  carbon:            { label: '탄소 감축', cls: 'text-teal-700' },
-  newBuyer:          { label: '신규 확산', cls: 'text-blue-700' },
-  localPartner:      { label: '지역 상생', cls: 'text-amber-700' },
-  donationExecution: { label: '기부 실행', cls: 'text-pink-700' },
-}
-
-// ─────────── 카테고리 누적 ───────────
-const categoryTotals = computed(() => {
-  const t = { saleExecution: 0, carbon: 0, newBuyer: 0, localPartner: 0, donationExecution: 0 }
-  for (const e of filteredEvents.value) {
-    const s = calcEventScore(e)
-    t.saleExecution    += s.saleExecution
-    t.carbon           += s.carbon
-    t.newBuyer         += s.newBuyer
-    t.localPartner     += s.localPartner
-    t.donationExecution+= s.donationExecution
-  }
-  return t
-})
-const totalScore = computed(() =>
-  Object.values(categoryTotals.value).reduce((a, b) => a + b, 0),
+// 화면에 보여줄 이벤트 = BE 응답의 페이지 슬라이스 (정렬도 BE 가 id DESC 로 처리)
+const pagedEvents = computed(() =>
+  (responseData.value?.events ?? []).map(normalizeSaleEvent)
 )
 
-// ESG 대시보드 헤더와 누적 점수 동기화 — totalScore 변할 때마다 esgStore 갱신
-const esgStore = useEsgStore()
-watch(totalScore, (n) => esgStore.setTotalPoints(n), { immediate: true })
+// BE summary — KPI/통계
+const summary = computed(() => responseData.value?.summary ?? {
+  totalScore: 0, saleExecutionSum: 0, carbonSum: 0, newBuyerSum: 0, localPartnerSum: 0,
+  totalEventCount: 0, validEventCount: 0, totalKg: 0, avgScore: 0,
+})
 
+// BE categoryBreakdown — 도넛 차트 & 점수 요소 리스트
+const categoryBreakdown = computed(() => responseData.value?.categoryBreakdown ?? {
+  saleExecution: 0, carbon: 0, newBuyer: 0, localPartner: 0,
+})
+
+// 총점 (도넛/헤더에서 사용)
+const totalScore = computed(() => Number(summary.value.totalScore || 0))
+
+// ESG 대시보드 헤더와 누적 점수/판매량 동기화
+const esgStore = useEsgStore()
+watch(totalScore,            (n) => esgStore.setTotalPoints(n),  { immediate: true })
+watch(() => summary.value.totalKg, (n) => esgStore.setTotalSalesKg(Number(n || 0)), { immediate: true })
+
+// 점수 요소 4종 (BE 응답을 표시용 메타와 합쳐서)
 const scoreCategories = computed(() => {
-  const t = categoryTotals.value
+  const t = categoryBreakdown.value
   const total = totalScore.value || 1
   return [
-    { id: 'saleExecution',     label: '순환재고 판매 실행', icon: RefreshCw,   color: '#10b981', barCls: 'bg-emerald-500', points: t.saleExecution,    desc: '판매 1건당 100점 (10kg 이상)' },
-    { id: 'carbon',            label: '탄소 감축 기여',     icon: Leaf,        color: '#14b8a6', barCls: 'bg-teal-500',    points: t.carbon,           desc: '무게 × 소재 계수 (판매 + 기부 합산)' },
-    { id: 'newBuyer',          label: '순환 거래 확산',     icon: Recycle,     color: '#3b82f6', barCls: 'bg-blue-500',    points: t.newBuyer,         desc: '신규 거래처 첫 거래 +150 (ESG-S)' },
-    { id: 'localPartner',      label: '지역 상생',          icon: ShieldCheck, color: '#f59e0b', barCls: 'bg-amber-500',   points: t.localPartner,     desc: '사회적기업/지역 파트너 +150 (월 3건)' },
-    { id: 'donationExecution', label: '기부 활동 실행',     icon: Heart,       color: '#ec4899', barCls: 'bg-pink-500',    points: t.donationExecution, desc: '기부 1건당 80점 (10kg 이상)' },
+    { id: 'saleExecution', label: '순환재고 판매 실행', icon: RefreshCw,   color: '#10b981', barCls: 'bg-emerald-500', points: t.saleExecution, desc: '판매 1건당 100점 (10kg 이상)' },
+    { id: 'carbon',        label: '탄소 감축 기여',     icon: Leaf,        color: '#14b8a6', barCls: 'bg-teal-500',    points: t.carbon,        desc: '무게 × 소재 계수 (판매 활동)' },
+    { id: 'newBuyer',      label: '순환 거래 확산',     icon: Recycle,     color: '#3b82f6', barCls: 'bg-blue-500',    points: t.newBuyer,      desc: '신규 거래처 첫 거래 +150 (ESG-S)' },
+    { id: 'localPartner',  label: '지역 상생',          icon: ShieldCheck, color: '#f59e0b', barCls: 'bg-amber-500',   points: t.localPartner,  desc: '사회적기업/지역 파트너 +150 (월 3건)' },
   ].map(c => ({ ...c, pct: total > 0 ? +((c.points / total) * 100).toFixed(1) : 0 }))
 })
 
-// ─────────── 통계 ───────────
-const stats = computed(() => {
-  const evs = filteredEvents.value
-  const sales = evs.filter(e => e.type === 'sale')
-  const dons = evs.filter(e => e.type === 'donation')
-  const totalKg = evs.reduce((s, e) => s + e.weightKg, 0)
-  const validEvents = evs.filter(e => e.weightKg >= SCORE_RULES.minWeightKg)
-  const invalidEvents = evs.length - validEvents.length
-  return {
-    saleCount: sales.length,
-    donationCount: dons.length,
-    totalKg,
-    validEvents: validEvents.length,
-    invalidEvents,
-    avgScore: validEvents.length > 0 ? Math.round(totalScore.value / validEvents.length) : 0,
-  }
-})
+// stats — 상단 KPI 카드 표시용 (BE summary 직접 사용)
+const stats = computed(() => ({
+  saleCount: Number(summary.value.totalEventCount || 0),
+  totalKg:   Number(summary.value.totalKg || 0),
+  validEvents:   Number(summary.value.validEventCount || 0),
+  invalidEvents: Number(summary.value.totalEventCount || 0) - Number(summary.value.validEventCount || 0),
+  avgScore:  Number(summary.value.avgScore || 0),
+}))
 
-// ESG 대시보드 KPI "순환재고 판매량" 카드와 동기화
-watch(() => stats.value.totalKg, (n) => esgStore.setTotalSalesKg(n), { immediate: true })
-
-// ─────────── 월별 추이 차트 ───────────
+// ─────────── 월별 추이 차트 — BE monthlyBreakdown 사용 ───────────
 const monthLabels = ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월', '9월', '10월', '11월', '12월']
 const monthlyScoresData = computed(() => {
+  // BE 응답 [{month:1, score:n}, ... 12개]. 누락 대비 12-bucket 안전 채움.
   const buckets = Array(12).fill(0)
-  for (const e of events.value) {
-    const d = new Date(e.date)
-    if (d.getFullYear() !== 2026) continue
-    const m = d.getMonth()
-    buckets[m] += calcEventScore(e).total
+  for (const row of (responseData.value?.monthlyBreakdown ?? [])) {
+    const m = Number(row.month)
+    if (m >= 1 && m <= 12) buckets[m - 1] = Number(row.score || 0)
   }
   return {
     labels: monthLabels,
-    datasets: [
-      {
-        label: '월별 점수',
-        data: buckets,
-        backgroundColor: 'rgba(16, 185, 129, 0.85)',
-        borderColor: '#059669',
-        borderWidth: 1.5, borderRadius: 4, maxBarThickness: 18,
-      },
-    ],
+    datasets: [{
+      label: '월별 점수',
+      data: buckets,
+      backgroundColor: 'rgba(16, 185, 129, 0.85)',
+      borderColor: '#059669',
+      borderWidth: 1.5, borderRadius: 4, maxBarThickness: 18,
+    }],
   }
 })
 const monthlyScoresOptions = {
@@ -358,18 +259,11 @@ const categoryDoughnutOptions = {
   },
 }
 
-// ─────────── 활동 이력 (페이지네이션) ───────────
-//   logEvents (기간 + 카테고리 필터) 를 정렬·페이징
-const sortedEvents = computed(() =>
-  [...logEvents.value].sort((a, b) => new Date(b.date) - new Date(a.date)),
-)
+// ─────────── 활동 이력 페이지네이션 (서버 페이징) ───────────
 const pageSize = ref(20)
-const page = ref(1)
-const totalPages = computed(() => Math.max(1, Math.ceil(sortedEvents.value.length / pageSize.value)))
-const pagedEvents = computed(() => {
-  const start = (page.value - 1) * pageSize.value
-  return sortedEvents.value.slice(start, start + pageSize.value)
-})
+const page = ref(1)        // UI 는 1-based 유지. BE 호출 시 -1 변환.
+const totalElements = computed(() => Number(responseData.value?.totalElements || 0))
+const totalPages    = computed(() => Math.max(1, Number(responseData.value?.totalPages || 1)))
 
 /**
  * 화살표 페이지네이션 — 현재 페이지를 중심으로 최대 5개 번호만 표시.
@@ -398,7 +292,9 @@ const pageNumbers = computed(() => {
 
 const PAGE_JUMP = 5
 function changePage(p) {
+  // 서버 totalPages 기반으로 클램프. 동일 페이지면 재호출 방지.
   const clamped = Math.max(1, Math.min(totalPages.value, p))
+  if (clamped === page.value) return
   page.value = clamped
 }
 function goJumpBack()    { changePage(page.value - PAGE_JUMP) }
@@ -406,81 +302,100 @@ function goPrev()        { changePage(page.value - 1) }
 function goNext()        { changePage(page.value + 1) }
 function goJumpForward() { changePage(page.value + PAGE_JUMP) }
 
-
 // ─────────── 포맷터 ───────────
 const formatNum = (n) => Number(n ?? 0).toLocaleString('ko-KR')
 const formatDate = (s) => s.slice(5).replace('-', '.')
-const typeLabel = (t) => t === 'sale' ? '판매' : '기부'
-const typeCls = (t) => t === 'sale' ? 'bg-emerald-50 text-emerald-700 border-emerald-200' : 'bg-pink-50 text-pink-700 border-pink-200'
+const typeLabel = () => '판매'
+const typeCls = () => 'bg-emerald-50 text-emerald-700 border-emerald-200'
 
-// 페이지 로드 — BE sale events 호출
+// ─────────── BE 호출 ───────────
 const loading = ref(false)
-async function reload() {
-  loading.value = true
+
+/** 현재 page/filterCategory 기준으로 BE 호출. 카테고리 변경 시엔 page=1 로 리셋해서 호출. */
+async function loadEvents() {
+  loadEventsError.value = ''
   try {
-    await loadEvents()
-  } finally {
-    loading.value = false
+    const targetYear = new Date().getFullYear()
+    const res = await scoreEventsApi.get({
+      year: targetYear,
+      page: page.value - 1,        // FE 1-based → BE 0-based 변환
+      size: pageSize.value,
+      category: filterCategory.value,
+    })
+    responseData.value = res
+    // BE 가 page 를 clamp 했을 수 있어 (요청 page 가 totalPages 초과) FE 도 보정.
+    const beTotalPages = Math.max(1, Number(res?.totalPages || 1))
+    if (page.value > beTotalPages) page.value = beTotalPages
+  } catch (err) {
+    loadEventsError.value = extractErrorMessage(err, '점수 이벤트를 불러오지 못했습니다.')
+    responseData.value = null
   }
 }
+
+async function reload() {
+  loading.value = true
+  try { await loadEvents() } finally { loading.value = false }
+}
+
+// 페이지 이동 / 카테고리 변경 시 BE 재호출
+watch(page, () => { loadEvents() })
+watch(filterCategory, () => {
+  // 필터 변경 시 첫 페이지로 — page watch 가 안 트리거되면 직접 loadEvents 호출
+  if (page.value !== 1) page.value = 1
+  else loadEvents()
+})
+
 onMounted(reload)
 </script>
 
 <template>
   <AppLayout
-    active-top-menu="ESG 대시보드"
+    active-top-menu="ESG 탄소 성과 관리"
     :top-menus="topMenus"
     :side-menus="sideMenus"
     v-model:active-side-menu="activeSideMenu"
   >
     <div class="flex flex-col gap-4">
-      <!-- ───────── 헤더 ───────── -->
-      <div class="flex items-end justify-between">
-        <div>
-          <button
-            type="button"
-            class="mb-2 inline-flex items-center gap-1.5 border border-[#004D3C]/30 bg-[#eef7f4] px-3 py-1.5 text-[12px] font-bold text-[#004D3C] transition hover:bg-[#004D3C] hover:text-white"
-            @click="router.push('/hq/esg')"
-          >
-            <ArrowLeft :size="14" />
-            ESG 대시보드로 돌아가기
-          </button>
-          <h1 class="inline-flex items-center gap-2 text-[20px] font-bold text-gray-900">
-            <Sprout :size="22" class="text-emerald-600" />
-            친환경 나무 키우기 점수
-          </h1>
-          <p class="mt-0.5 text-[12px] text-gray-500">
-            순환재고 판매·기부 활동 1건마다 적립되는 ESG 점수 — 5종 점수 요소 합산
-          </p>
-        </div>
-        <div class="flex items-center gap-2">
-          <!-- 필터 -->
-          <div class="inline-flex items-center gap-1 border border-gray-300 bg-white p-0.5">
+      <!-- ───────── 헤더 (돌아가기 버튼 + 제목 가로 배치, 그라데이션 카드) ───────── -->
+      <div class="overflow-hidden rounded-xl border border-emerald-200/70 bg-gradient-to-r from-emerald-50 via-white to-sky-50 shadow-sm">
+        <div class="flex items-center justify-between gap-4 px-4 py-3">
+          <!-- 좌측: 돌아가기 버튼 + 구분선 + 제목 가로 정렬 -->
+          <div class="flex items-center gap-3 min-w-0">
             <button
-              v-for="f in [{v:'M',l:'이번 달'},{v:'Q',l:'최근 3개월'},{v:'YEAR',l:'올해'}]"
-              :key="f.v"
               type="button"
-              class="px-2.5 py-1 text-[11px] font-medium transition"
-              :class="filterPeriod === f.v ? 'bg-[#004D3C] text-white' : 'text-gray-600 hover:bg-gray-50'"
-              @click="filterPeriod = f.v"
+              class="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-[#004D3C]/30 bg-white/80 px-3 py-1.5 text-[12px] font-bold text-[#004D3C] backdrop-blur transition hover:bg-[#004D3C] hover:text-white"
+              @click="router.push('/hq/esg')"
             >
-              {{ f.l }}
+              <ArrowLeft :size="14" />
+              ESG 대시보드로 돌아가기
             </button>
+            <!-- 세로 구분선 -->
+            <div class="h-9 w-px shrink-0 bg-emerald-300/60"></div>
+            <!-- 둥근 아이콘 + 제목 + 부제 -->
+            <div class="flex items-center gap-2.5 min-w-0">
+              <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-emerald-100 to-emerald-200 ring-1 ring-emerald-300/50">
+                <Sprout :size="22" class="text-emerald-700" />
+              </div>
+              <div class="min-w-0">
+                <h1 class="text-[18px] font-bold leading-tight text-gray-900">
+                  친환경 나무 키우기 점수
+                </h1>
+                <p class="mt-0.5 truncate text-[11px] text-gray-500">
+                  순환재고 판매 활동 1건마다 적립되는 ESG 점수 — 4종 점수 요소 합산
+                </p>
+              </div>
+            </div>
           </div>
-          <button
-            type="button"
-            class="inline-flex items-center gap-1.5 border border-gray-300 bg-white px-3 py-1.5 text-[12px] font-medium text-gray-600 transition hover:bg-gray-50"
-            @click="reload"
-            :disabled="loading"
-          >
-            <RefreshCw :size="13" :class="{ 'animate-spin': loading }" />
-            새로고침
-          </button>
+          <!-- 우측: ESG 활동 뱃지 (md 이상에서만 표시) -->
+          <div class="hidden shrink-0 items-center gap-1.5 rounded-full bg-emerald-600/10 px-3 py-1.5 ring-1 ring-emerald-600/20 md:inline-flex">
+            <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-500"></span>
+            <span class="text-[10px] font-bold uppercase tracking-wider text-emerald-700">ESG 누적</span>
+          </div>
         </div>
       </div>
 
       <!-- ───────── 1. 총점 + 통계 ───────── -->
-      <section class="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-5">
+      <section class="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
         <div class="border-2 border-emerald-300 bg-gradient-to-br from-emerald-50 to-white p-5 shadow-sm xl:col-span-2">
           <div class="inline-flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-widest text-emerald-700/70">
             <Award :size="13" /> 누적 ESG 점수
@@ -501,11 +416,6 @@ onMounted(reload)
           <p class="mt-0.5 text-[10px] text-gray-500">건 (≥10kg)</p>
         </div>
         <div class="border border-gray-300 bg-white p-4 shadow-sm">
-          <p class="text-[10px] font-bold uppercase tracking-widest text-gray-400">순환재고 기부 건수</p>
-          <p class="mt-1 text-[22px] font-black text-pink-700">{{ stats.donationCount }}</p>
-          <p class="mt-0.5 text-[10px] text-gray-500">건 (≥10kg)</p>
-        </div>
-        <div class="border border-gray-300 bg-white p-4 shadow-sm">
           <p class="text-[10px] font-bold uppercase tracking-widest text-gray-400">총 순환재고 판매량</p>
           <p class="mt-1 flex items-baseline gap-1">
             <span class="text-[22px] font-black text-gray-800">{{ formatNum(stats.totalKg) }}</span>
@@ -520,7 +430,7 @@ onMounted(reload)
         <article class="flex flex-col border border-gray-300 bg-white shadow-sm">
           <div class="border-b border-gray-200 px-4 py-3">
             <h2 class="text-[14px] font-bold text-gray-800">카테고리별 비중</h2>
-            <p class="text-[10px] text-gray-500">5종 점수 요소 — {{ filterPeriod === 'M' ? '이번 달' : filterPeriod === 'Q' ? '최근 3개월' : '올해' }}</p>
+            <p class="text-[10px] text-gray-500">4종 점수 요소 — 올해</p>
           </div>
           <div class="min-h-[240px] flex-1 p-4">
             <DoughnutChart :data="categoryDoughnutData" :options="categoryDoughnutOptions" />
@@ -531,7 +441,7 @@ onMounted(reload)
         <article class="flex flex-col border border-gray-300 bg-white shadow-sm">
           <div class="border-b border-gray-200 px-4 py-3">
             <h2 class="text-[14px] font-bold text-gray-800">월별 점수 추이</h2>
-            <p class="text-[10px] text-gray-500">판매 / 기부 누적 (스택)</p>
+            <p class="text-[10px] text-gray-500">판매 점수 누적</p>
           </div>
           <div class="min-h-[240px] flex-1 p-4">
             <BarChart :data="monthlyScoresData" :options="monthlyScoresOptions" />
@@ -611,10 +521,10 @@ onMounted(reload)
           </div>
           <div class="inline-flex items-center gap-2">
             <Filter :size="13" class="text-gray-500" />
+            <!-- 카테고리 변경은 watch(filterCategory) 가 page=1 로 리셋하면서 BE 재호출 -->
             <select
               v-model="filterCategory"
               class="border border-gray-300 bg-white px-2.5 py-1 pr-7 text-[12px] font-medium text-gray-700 focus:border-[#004D3C] focus:outline-none"
-              @change="page = 1"
             >
               <option v-for="f in LOG_FILTERS" :key="f.v" :value="f.v">{{ f.l }}</option>
             </select>
@@ -634,7 +544,9 @@ onMounted(reload)
               </tr>
             </thead>
             <tbody>
-              <tr v-for="e in pagedEvents" :key="e.id" class="border-b border-gray-100 last:border-0" :class="{ 'opacity-50': !calcEventScore(e).valid }">
+              <!-- Phase 3 — BE 가 점수 4종/total/scoreValid 를 직접 계산해 응답에 포함.
+                   FE 는 e.scoreValid, e.saleExecution, e.carbon, e.newBuyer, e.localPartner, e.total 을 그대로 사용. -->
+              <tr v-for="e in pagedEvents" :key="e.id" class="border-b border-gray-100 last:border-0" :class="{ 'opacity-50': !e.scoreValid }">
                 <td class="px-3 py-2 font-mono text-gray-700">{{ formatDate(e.date) }}</td>
                 <td class="px-3 py-2 text-center">
                   <span class="inline-flex items-center border px-2 py-0.5 text-[10px] font-bold" :class="typeCls(e.type)">
@@ -647,30 +559,19 @@ onMounted(reload)
                 </td>
                 <td class="px-3 py-2 text-right font-mono text-gray-700">{{ formatNum(e.weightKg) }} kg</td>
                 <td class="px-3 py-2 text-[10.5px] text-gray-500">
-                  <template v-if="calcEventScore(e).valid">
+                  <template v-if="e.scoreValid">
                     <!-- 전체 필터: 모든 점수 요소 분해 표시 -->
                     <template v-if="filterCategory === 'ALL'">
-                      <span v-if="calcEventScore(e).saleExecution">
-                        실행 {{ calcEventScore(e).saleExecution }}
-                      </span>
-                      <span v-if="calcEventScore(e).donationExecution">
-                        실행 {{ calcEventScore(e).donationExecution }}
-                      </span>
-                      <span v-if="calcEventScore(e).carbon">
-                        + 탄소 {{ formatNum(calcEventScore(e).carbon) }}
-                      </span>
-                      <span v-if="calcEventScore(e).newBuyer" class="text-blue-600">
-                        + 신규 {{ calcEventScore(e).newBuyer }}
-                      </span>
-                      <span v-if="calcEventScore(e).localPartner" class="text-amber-600">
-                        + 지역 {{ calcEventScore(e).localPartner }}
-                      </span>
+                      <span v-if="e.saleExecution">실행 {{ e.saleExecution }}</span>
+                      <span v-if="e.carbon">+ 탄소 {{ formatNum(e.carbon) }}</span>
+                      <span v-if="e.newBuyer" class="text-blue-600">+ 신규 {{ e.newBuyer }}</span>
+                      <span v-if="e.localPartner" class="text-amber-600">+ 지역 {{ e.localPartner }}</span>
                     </template>
                     <!-- 단일 카테고리 필터: 해당 점수 요소 1개만 표시 -->
                     <template v-else>
                       <span class="font-black" :class="FILTER_BREAKDOWN_META[filterCategory]?.cls">
                         {{ FILTER_BREAKDOWN_META[filterCategory]?.label }}
-                        +{{ formatNum(calcEventScore(e)[filterCategory] || 0) }}
+                        +{{ formatNum(e[filterCategory] || 0) }}
                       </span>
                     </template>
                   </template>
@@ -678,12 +579,10 @@ onMounted(reload)
                 </td>
                 <td class="px-3 py-2 text-right">
                   <div class="font-black"
-                       :class="calcEventScore(e).valid
+                       :class="e.scoreValid
                          ? (filterCategory === 'ALL' ? 'text-emerald-700' : FILTER_BREAKDOWN_META[filterCategory]?.cls)
                          : 'text-gray-400'">
-                    +{{ formatNum(filterCategory === 'ALL'
-                      ? calcEventScore(e).total
-                      : (calcEventScore(e)[filterCategory] || 0)) }}
+                    +{{ formatNum(filterCategory === 'ALL' ? e.total : (e[filterCategory] || 0)) }}
                   </div>
                 </td>
               </tr>
@@ -696,13 +595,16 @@ onMounted(reload)
 
         <!-- 페이지네이션 -->
         <div class="flex flex-wrap items-center justify-between gap-2 border-t border-gray-200 bg-gray-50 px-4 py-2.5 text-[11px]">
+          <!-- 서버 페이징 — 카운트는 BE summary 의 totalElements 사용 -->
           <span class="text-gray-500">
             <template v-if="filterCategory !== 'ALL'">
               <span class="font-bold text-[#004D3C]">
                 {{ LOG_FILTERS.find(f => f.v === filterCategory)?.l }}
               </span>
-              에 기여한 이벤트 <strong>{{ sortedEvents.length }}</strong>건 표시 중
-              <span class="text-gray-400">(기간 내 전체 {{ filteredEvents.length }}건)</span>
+              에 기여한 이벤트 <strong>{{ formatNum(totalElements) }}</strong>건 표시 중
+            </template>
+            <template v-else>
+              전체 활동 <strong>{{ formatNum(totalElements) }}</strong>건 — {{ page }} / {{ totalPages }} 페이지
             </template>
           </span>
           <div v-if="totalPages > 1" class="inline-flex items-center gap-1">
@@ -789,7 +691,7 @@ onMounted(reload)
           <!-- 본문 -->
           <div class="flex-1 overflow-y-auto px-5 py-4">
             <p class="mb-3 text-[11px] leading-relaxed text-gray-500">
-              순환재고 판매·기부 활동 1건마다 아래 5개 점수 요소가 산정되어 합산됩니다.
+              순환재고 판매 활동 1건마다 아래 4개 점수 요소가 산정되어 합산됩니다.
               <span class="font-bold text-gray-700">최소 10kg 미만</span> 활동은 점수 부여 대상이 아닙니다 (어뷰징 방지).
             </p>
 

--- a/src/views/hq/notification/HqNotificationView.vue
+++ b/src/views/hq/notification/HqNotificationView.vue
@@ -1,35 +1,134 @@
 <script setup>
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
+import { storeToRefs } from 'pinia'
 import { Bell, Filter, RefreshCw } from 'lucide-vue-next'
 import AppLayout from '@/components/common/AppLayout.vue'
 import { roleMenus } from '@/config/roleMenus.js'
 import { useNotificationStore } from '@/stores/notification.js'
+import { notificationApi } from '@/api/notification.js'
 
 const topMenus = roleMenus.hq
 const activeTopMenu = computed(() => '알림')
 
+// 헤더 종 아이콘과 공유되는 store (미확인 카운트 표시용)
 const notifStore = useNotificationStore()
-const filterMode = ref('all')
+// SSE 로 새 알림 수신 시 store 변화 감지용 reactive refs.
+// totalElements 는 store 내부에서 SSE onNotification 시 +1 (ref 기반이라 watch trigger 안정적).
+const { totalElements: storeTotal, unreadCount: storeUnread } = storeToRefs(notifStore)
 
-const filteredNotifications = computed(() => {
-  if (filterMode.value === 'unread') {
-    return notifStore.notifications.filter((n) => !n.read)
-  }
-  return notifStore.notifications
+// ── 알림 페이지 전용 페이징 상태 (store 와 별도 — 서버 페이징)
+const PAGE_SIZE = 15
+const PAGES_PER_GROUP = 5
+
+const filterMode = ref('all')         // 'all' | 'unread'
+const pageItems = ref([])             // 현재 페이지의 알림
+const totalElements = ref(0)
+const totalPages = ref(1)
+const currentPage = ref(1)            // 1-based
+const loading = ref(false)
+const error = ref('')
+
+// 헤더 미확인 뱃지는 store 의 unreadCount 를 그대로 사용 (앱 전역 최신값)
+const unreadCount = computed(() => notifStore.unreadCount)
+
+// ── 페이지 그룹 (5개씩) — 계정 관리 페이지와 동일 패턴
+const currentGroup = computed(() => Math.ceil(currentPage.value / PAGES_PER_GROUP))
+const totalGroups = computed(() => Math.max(1, Math.ceil(totalPages.value / PAGES_PER_GROUP)))
+const visiblePages = computed(() => {
+  const start = (currentGroup.value - 1) * PAGES_PER_GROUP + 1
+  const end = Math.min(start + PAGES_PER_GROUP - 1, totalPages.value)
+  return Array.from({ length: end - start + 1 }, (_, i) => start + i)
 })
 
-const unreadCount = computed(() => notifStore.unreadCount)
-const loading = computed(() => notifStore.loading)
-const error = computed(() => notifStore.error)
+function goPrevGroup() {
+  currentPage.value = Math.max(1, (currentGroup.value - 2) * PAGES_PER_GROUP + 1)
+}
+function goNextGroup() {
+  currentPage.value = Math.min(totalPages.value, currentGroup.value * PAGES_PER_GROUP + 1)
+}
 
-async function reload() { await notifStore.refresh() }
-async function handleClick(n) {
-  if (!n.read) {
-    try { await notifStore.markAsRead(n.id) } catch { /* ignore */ }
+// ── BE 호출 — 현재 페이지/필터로 조회
+async function loadPage() {
+  loading.value = true
+  error.value = ''
+  try {
+    const data = await notificationApi.list({
+      page: currentPage.value - 1,    // BE 는 0-based
+      size: PAGE_SIZE,
+      unreadOnly: filterMode.value === 'unread' ? true : undefined,
+    })
+    pageItems.value = data?.items ?? []
+    totalElements.value = data?.totalElements ?? 0
+    totalPages.value = Math.max(1, data?.totalPages ?? 1)
+    // 현재 페이지가 총 페이지 수보다 크면 마지막 페이지로 보정 (필터 변경 등으로 항목이 줄어든 경우)
+    if (currentPage.value > totalPages.value) {
+      currentPage.value = totalPages.value
+    }
+  } catch (e) {
+    error.value = e?.message ?? '알림을 불러오지 못했습니다.'
+    console.error('[HqNotificationView.loadPage]', e)
+  } finally {
+    loading.value = false
   }
 }
+
+// 필터 변경 시 — 첫 페이지로 + 재호출
+watch(filterMode, () => {
+  currentPage.value = 1
+  loadPage()
+})
+
+// 페이지 변경 시 — 재호출
+watch(currentPage, () => loadPage())
+
+// SSE 로 새 알림 수신 시 (store.totalElements +1) — 1페이지에 있으면 자동 갱신.
+// 다른 페이지 (2, 3, ...) 에 있을 때는 사용자가 보던 위치 유지 (혼란 방지).
+// store.totalElements 는 ref 라서 watch trigger 가 안정적 (storeToRefs 로 unwrap).
+watch(storeTotal, (newVal, oldVal) => {
+  console.log('[HqNotificationView] store.totalElements 변화:', oldVal, '→', newVal)  // 디버그
+  if (newVal > oldVal && currentPage.value === 1) {
+    loadPage()
+  }
+})
+// 백업: 미확인 카운트도 함께 감시 (store.unreadCount 가 변하면 새 알림 도달 신호로 간주)
+watch(storeUnread, (newVal, oldVal) => {
+  if (newVal > oldVal && currentPage.value === 1) {
+    loadPage()
+  }
+})
+
+// ── 사용자 액션
+async function reload() {
+  // store 도 함께 새로고침 (헤더 카운트 최신화)
+  await Promise.all([notifStore.refresh(), loadPage()])
+}
+
+async function handleClick(n) {
+  if (n.read) return
+  try {
+    await notifStore.markAsRead(n.id)
+    // 페이지 콘텐츠 갱신 — 미확인만 모드면 목록에서 빠져야 하므로 서버 재조회, 전체 모드면 로컬 read=true 만
+    if (filterMode.value === 'unread') {
+      await loadPage()
+    } else {
+      const idx = pageItems.value.findIndex((it) => it.id === n.id)
+      if (idx >= 0) {
+        pageItems.value[idx] = { ...pageItems.value[idx], read: true, readAt: new Date().toISOString() }
+      }
+    }
+  } catch {
+    /* ignore — store 가 콘솔 로그 처리 */
+  }
+}
+
 async function handleReadAll() {
-  try { await notifStore.markAllAsRead() } catch { /* ignore */ }
+  try {
+    await notifStore.markAllAsRead()
+    // 페이지 콘텐츠 일괄 read=true 처리 (미확인 모드면 비워짐)
+    await loadPage()
+  } catch {
+    /* ignore */
+  }
 }
 
 function severityBadgeCls(severity) {
@@ -57,7 +156,10 @@ function formatDateTime(value) {
   } catch { return String(value) }
 }
 
-onMounted(() => { notifStore.init() })
+onMounted(() => {
+  notifStore.init()   // 헤더 종 아이콘용 store 초기화 (이미 init 됐으면 no-op)
+  loadPage()          // 알림 페이지는 독립적으로 첫 페이지 조회
+})
 </script>
 
 <template>
@@ -123,13 +225,13 @@ onMounted(() => { notifStore.init() })
       </div>
 
       <div class="rounded-lg border border-gray-200 bg-white shadow-sm">
-        <div v-if="loading && filteredNotifications.length === 0" class="p-6 text-center text-xs text-gray-500">
+        <div v-if="loading && pageItems.length === 0" class="p-6 text-center text-xs text-gray-500">
           불러오는 중…
         </div>
 
-        <ul v-else-if="filteredNotifications.length > 0" class="divide-y divide-gray-100">
+        <ul v-else-if="pageItems.length > 0" class="divide-y divide-gray-100">
           <li
-            v-for="n in filteredNotifications"
+            v-for="n in pageItems"
             :key="n.id"
             class="flex cursor-pointer items-start gap-3 px-4 py-3 transition-colors hover:bg-gray-50"
             :class="{ 'bg-emerald-50/40': !n.read }"
@@ -157,6 +259,62 @@ onMounted(() => { notifStore.init() })
           <p class="text-xs text-gray-500">
             {{ filterMode === 'unread' ? '미확인 알림이 없습니다.' : '표시할 알림이 없습니다.' }}
           </p>
+        </div>
+
+        <!-- 페이지네이션 — 계정 관리와 동일 패턴 (<< < 1 2 3 4 5 > >>) -->
+        <div
+          v-if="pageItems.length > 0"
+          class="flex items-center justify-between border-t border-gray-200 bg-gray-50 px-3 py-2"
+        >
+          <span class="text-[11px] font-medium text-gray-400">
+            <template v-if="totalElements > 0">
+              {{ (currentPage - 1) * PAGE_SIZE + 1 }}–{{ Math.min(currentPage * PAGE_SIZE, totalElements) }} / 전체 {{ totalElements }}건
+            </template>
+            <template v-else>0건</template>
+          </span>
+          <div class="flex items-center gap-1">
+            <!-- << 이전 5페이지 그룹 -->
+            <button
+              type="button"
+              :disabled="currentGroup === 1"
+              class="flex h-7 w-7 items-center justify-center border border-gray-300 bg-white text-[12px] text-gray-500 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
+              @click="goPrevGroup"
+              title="이전 5페이지"
+            >«</button>
+            <!-- < 한 페이지 이전 -->
+            <button
+              type="button"
+              :disabled="currentPage === 1"
+              class="flex h-7 w-7 items-center justify-center border border-gray-300 bg-white text-[12px] text-gray-500 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
+              @click="currentPage--"
+              title="이전 페이지"
+            >‹</button>
+            <!-- 페이지 번호 (5개씩) -->
+            <button
+              v-for="p in visiblePages"
+              :key="p"
+              type="button"
+              class="flex h-7 min-w-[28px] items-center justify-center border text-[12px] font-medium transition"
+              :class="p === currentPage ? 'border-[#004D3C] bg-[#004D3C] text-white' : 'border-gray-300 bg-white text-gray-500 hover:bg-gray-100'"
+              @click="currentPage = p"
+            >{{ p }}</button>
+            <!-- > 한 페이지 다음 -->
+            <button
+              type="button"
+              :disabled="currentPage === totalPages"
+              class="flex h-7 w-7 items-center justify-center border border-gray-300 bg-white text-[12px] text-gray-500 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
+              @click="currentPage++"
+              title="다음 페이지"
+            >›</button>
+            <!-- >> 다음 5페이지 그룹 -->
+            <button
+              type="button"
+              :disabled="currentGroup === totalGroups"
+              class="flex h-7 w-7 items-center justify-center border border-gray-300 bg-white text-[12px] text-gray-500 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
+              @click="goNextGroup"
+              title="다음 5페이지"
+            >»</button>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 📌 요약
- BE 의 산식/통계 SSOT 이관 + 페이징 풀세트에 맞춰 ESG 점수 페이지의 클라이언트 계산을 BE 응답 사용으로 전환
- 알림 페이지 5-그룹 페이지네이션 도입 + SSE 실시간 갱신 + 헤더 bell 아이콘 9+ 캡 처리
- ESG 나무 위젯 Lv.7~10 디자인 신규 (Lv.6 무드 유지하면서 길이/풍성도 점진 성장 + Lv.10 결실 표현)
- 다중 페이지 페이지네이션 UI 를 5-그룹 패턴으로 통일

<br><br>

## 🎯 작업 내용

### 1. fix(notification): HqNotificationView 페이징 + SSE 자동 갱신 + bell 9+ 캡
- 15-row 페이지네이션 + 5-그룹 UI (« ‹ 1 2 3 4 5 › ») 적용
- `storeToRefs` + `watch(storeTotal)` 로 SSE push 도착 시 페이지 자동 갱신
- `AppLayout.vue` 헤더 알림 아이콘 9+ 캡 표시 (10건 이상 시 "9+")

### 2. fix(hq/account): 중복 승인 방지 — 처리 중 버튼 비활성화
- `isProcessing` 상태 도입 → 승인/반려 버튼 클릭 직후 비활성화
- BE 의 `USER_CONCURRENT_MODIFICATION(4805)` 응답과 매칭되는 사용자 친화 메시지 처리

### 3. feat(esg/carbon-price): 5-그룹 페이지네이션 UI 통일
- `PAGES_PER_GROUP=5`, `visiblePages`, `goPrevGroup/goNextGroup` 패턴 적용
- 다른 페이지(알림/계정 등) 와 동일한 UX 일관성 확보

### 4. feat(esg): 점수 페이지 서버 페이징/통계 BE 응답 사용 + 트리 위젯 Lv.7~10 디자인 + 카본 분포 BE 이관
- **EsgTreeScoreView 서버 페이징 풀세트 (Phase 3 A''-1)**
  - `scoreEventsApi.get()` 시그니처 객체화 (`{ year, page, size, dateFrom, dateTo, category }`)
  - FE 자체 산식/필터/통계 모두 폐기 → BE `summary` / `monthlyBreakdown` / `categoryBreakdown` 응답 사용
  - `watch(page) / watch(filterCategory)` 로 변경 시 BE 재호출, 필터 변경 시 page=1 자동 리셋
  - 클라이언트 slice 페이징 제거 → `totalElements` / `totalPages` BE 메타 사용
- **카본 분포 BE 이관 (Phase 3 B)**
  - `esg.js` store 의 `fetchTotalPoints()` 가 `size=1` 로 호출해서 events 페이로드 최소화하면서 `carbonReduction.byMaterial/byGroup/monthly/total` 4종 BE 응답 사용
  - `computeCarbonReductionByMaterial/Group/Monthly` 호출 제거 (FE 자체 계산 폐기, 산식 함수는 fallback 으로 유지)
- **EsgTreeWidget Lv.7~10 디자인 신규**
  - Lv.6 의 곡선 트렁크/잎 클러스터 무드 유지, 레벨 올라갈수록 길이/풍성도 점진 성장
  - Lv.8 부터 열매(rose) 등장, Lv.9 부터 가지 4쌍 + 트렁크 결무늬 다중
  - Lv.10 (결실의 나무): 7개 잎 클러스터 + 8개 열매(rose 5 + 황금 amber 3) + 광휘 후광 + 트렁크 옹이 디테일
- **EsgDashBoardView**: `totalCarbonReductionTon`, `carbonReductionByMaterialKg`, `carbonReductionMonthly` 모두 BE 응답 기반

### 5. chore: 기타 도메인 변경
- `analytics.js` / `HqAnalyticsVendorView.vue` 분석 페이지 미세 조정
- `roleMenus.js` 메뉴 구조 정리

<br><br>

## ✔️ 참고 사항

### BE 의존성
- 본 PR 은 BE 의 다음 작업과 함께 배포되어야 함:
  - `ScoreEventsService` Phase 3 (페이징/필터/통계/카본 분포 풀세트 응답)
  - `MaterialFactor` API
  - `notification_read` 매핑 분리 (B3)
  - `User @Version` 낙관적 락 + `USER_CONCURRENT_MODIFICATION(4805)`
- BE 미배포 상태에서 본 PR 만 배포 시 ESG 점수 페이지/대시보드 카본 분포가 망가짐 → 동시 배포 권장

### 동작 보장 포인트
- `EsgTreeScoreView` 필터 변경 시 BE 재호출 → KPI/도넛/막대 차트도 새 필터 기준으로 일관성 유지
- 페이지 이동 시 통계 묶음은 동일 (필터 기준 변경 없음) → 차트는 그대로, 테이블만 새 행
- ESG 나무 위젯 `isDev` 환경에서 ◀ ▶ 버튼으로 Lv.1~10 미리보기 가능 (빌드 시 자동 제거)

### 회귀 주의
- `utils/esgScore.js` 의 `computeCarbonReduction*` 함수들은 dead code 상태로 남아 있음 (BE 미응답 시 fallback 보조). 후속 작업에서 제거 가능
- `EsgDashBoardView` 의 dashboard KPI 카드와 트리 위젯 모두 `fetchTotalPoints()` 응답에 의존 → BE 응답 실패 시 0 으로 표시됨 (기존 동작 유지)

<br><br>

## ✔️ 관련 이슈

- Close #511
