### PR TITLE
517 refactor 나무 디자인 리팩토링

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { onMounted, watch } from 'vue'
+import { onBeforeUnmount, onMounted, watch } from 'vue'
 import { RouterView } from 'vue-router'
 import { useAuthStore } from '@/stores/auth.js'
 import { useNotificationStore } from '@/stores/notification.js'
@@ -9,8 +9,27 @@ import { useNotificationStore } from '@/stores/notification.js'
 const auth = useAuthStore()
 const notif = useNotificationStore()
 
+// 페이지 unload (탭 닫기 / 창 닫기 / F5 / 다른 도메인 이동) 시 SSE 명시적 close.
+// 없으면 BE NotificationSseService 의 emitters Map 에 stale entry 가 30초(heartbeat) 동안 살아있음.
+// 운영 로그에서 userId=1 의 20+ 누적 emitter 가 한꺼번에 정리되던 현상의 근본 원인.
+// pagehide 가 beforeunload 보다 모바일 호환성 + BFCache 친화적.
+// event.persisted === true 면 BFCache 로 캐시되는 것이라 곧 살아날 수 있으므로 dispose 생략.
+const handlePageHide = (event) => {
+  if (event && event.persisted) return
+  try { notif.dispose() } catch { /* ignore */ }
+}
+
 onMounted(() => {
   if (auth.isAuthenticated) notif.init()
+  if (typeof window !== 'undefined') {
+    window.addEventListener('pagehide', handlePageHide)
+  }
+})
+
+onBeforeUnmount(() => {
+  if (typeof window !== 'undefined') {
+    window.removeEventListener('pagehide', handlePageHide)
+  }
 })
 
 watch(

--- a/src/api/notification.js
+++ b/src/api/notification.js
@@ -38,8 +38,11 @@ export const notificationApi = {
  * SSE 구독 — EventSource 는 axios 와 별도. 쿠키 자동 전송을 위해 withCredentials.
  * 호출 측에서 반환된 EventSource 의 close() 를 책임진다 (언마운트/로그아웃 시).
  *
+ * BE 의 connect 이벤트 payload 는 sessionId (UUID) — handlers.onConnect 으로 그대로 전달.
+ * notificationStore 가 이 sessionId 를 보관해두었다가 페이지 unload 시 closeNotificationStreamBeacon 으로 BE 에 명시적 종료 요청.
+ *
  * @param {{
- *   onConnect?: (data: string) => void,
+ *   onConnect?: (sessionId: string) => void,
  *   onNotification?: (payload: object) => void,
  *   onError?: (event: Event) => void,
  * }} handlers
@@ -66,4 +69,34 @@ export function subscribeNotificationStream(handlers = {}) {
     es.onerror = handlers.onError
   }
   return es
+}
+
+/**
+ * SSE 명시적 종료 (sendBeacon) — 페이지 unload (탭 닫기/F5/창 닫기) 시 호출.
+ *
+ * 왜 sendBeacon 인가:
+ *  - 일반 fetch/axios 는 페이지 unload 중에 브라우저가 취소시킬 수 있음.
+ *  - sendBeacon 은 spec 상 unload 중에도 백그라운드 전송 보장.
+ *  - 단, POST 만 지원 + Content-Type 제한적 → BE 엔드포인트도 POST 로 설계.
+ *
+ * BE: POST /api/notifications/stream/{sessionId}/close
+ *  - 쿠키 자동 전송 (same-origin) → JwtAuthFilter 통과
+ *  - BE 가 sessionId 의 owner(userId) 검증 후 emitter 즉시 정리.
+ *
+ * @param {string} sessionId — BE 가 connect 이벤트로 전달한 UUID
+ * @returns {boolean} sendBeacon 큐잉 성공 여부
+ */
+export function closeNotificationStreamBeacon(sessionId) {
+  if (!sessionId) return false
+  if (typeof navigator === 'undefined' || typeof navigator.sendBeacon !== 'function') {
+    return false                                                       // 구형 브라우저 — pagehide close() 만 의존
+  }
+  const base = import.meta.env.VITE_API_BASE ?? ''
+  const url = `${base}/api/notifications/stream/${encodeURIComponent(sessionId)}/close`
+  try {
+    // body 없이도 OK — BE 는 path variable 만 사용. Blob 으로 명시적 빈 body.
+    return navigator.sendBeacon(url, new Blob([], { type: 'text/plain' }))
+  } catch {
+    return false
+  }
 }

--- a/src/components/common/EsgTreeWidget.vue
+++ b/src/components/common/EsgTreeWidget.vue
@@ -10,23 +10,7 @@ defineProps({
 const esg = useEsgStore()
 // stage / stageProgress / pointsToNext 는 computed → storeToRefs 로 ref 추출 가능.
 // maxStage / stageThresholds 는 store 내부 상수 (ref 아님) → esg 객체로 직접 접근.
-const { totalPoints, stage, stageProgress, pointsToNext } = storeToRefs(esg)
-
-// ─────────── DEV 단계 미리보기 (디자인 확인용 임시 컨트롤) ───────────
-// import.meta.env.DEV 가 true 인 환경(npm run dev)에서만 노출, 빌드 결과물에는 미포함.
-// 테스트 완료 후 이 블록과 템플릿의 v-if="isDev" 영역만 삭제하면 됨.
-const isDev = import.meta.env.DEV
-
-function prevStage() {
-  if (stage.value <= 1) return
-  // 한 단계 아래의 임계값 시작점으로 totalPoints 강제 세팅
-  esg.setTotalPoints(esg.stageThresholds[stage.value - 2])
-}
-function nextStage() {
-  if (stage.value >= esg.maxStage) return
-  // 다음 단계 임계값 시작점으로 강제 세팅
-  esg.setTotalPoints(esg.stageThresholds[stage.value])
-}
+const { totalPoints, stage, stageProgress, pointsToNext, treeCount } = storeToRefs(esg)
 
 const stageLabels = [
   '씨앗',
@@ -44,6 +28,12 @@ const stageLabel = computed(() => stageLabels[stage.value - 1])
 
 // Lv.7~10 은 Lv.6 의 곡선 트렁크/잎 클러스터 무드를 따라 각 레벨별 별도 SVG 로 손그림.
 // 이전 버전의 trunkHeight/crownRadius 자동 계산 로직은 폐기 — 동일 톤의 풍성한 성장 표현을 위해 손튜닝 채택.
+
+// viewBox 동적 — Lv.7+ 는 위쪽으로 확장 (지면 cy=100 기준 Lv.6 의 2배 이상 길이 확보).
+//   Lv.1~6: 기존 viewBox (위쪽 -32 까지)
+//   Lv.7+ : 위쪽 -130 까지 확장 → 트렁크 상단/잎 클러스터/메인 왕관 다 들어옴
+// preserveAspectRatio="xMidYMax meet" 라 지면이 항상 화면 하단 정렬 → 위로만 늘어남.
+const svgViewBox = computed(() => (stage.value >= 7 ? '0 -130 100 268' : '0 -32 100 170'))
 </script>
 
 <template>
@@ -53,19 +43,25 @@ const stageLabel = computed(() => stageLabels[stage.value - 1])
         ? 'flex flex-1 flex-col overflow-hidden rounded-2xl bg-gradient-to-br from-sky-50 via-emerald-50 to-emerald-100 p-4 ring-1 ring-emerald-100/80'
         : 'overflow-hidden rounded-2xl bg-gradient-to-br from-sky-50 via-emerald-50 to-emerald-100 p-3 ring-1 ring-emerald-100/80'"
     >
-      <div class="mb-2 flex items-center justify-between">
-        <span class="text-[10px] font-bold uppercase tracking-[0.16em] text-emerald-700">
-          ESG 나무
-        </span>
+      <div class="mb-2 flex items-start justify-between">
+        <div class="min-w-0">
+          <span class="text-[10px] font-bold uppercase tracking-[0.16em] text-emerald-700">
+            ESG 나무
+          </span>
+          <!-- 키운 나무 누적 그루 — 1,500,000pt(Lv.10 만점) 도달 시마다 +1, 사이클은 Lv.1 부터 다시 -->
+          <p v-if="treeCount > 0" class="mt-0.5 text-[10px] font-semibold leading-tight text-emerald-700">
+            🌳 {{ treeCount.toLocaleString() }}그루의 나무를 키웠습니다!
+          </p>
+        </div>
         <span
-          class="rounded-full bg-emerald-600 px-1.5 py-0.5 text-[9px] font-bold leading-none text-white"
+          class="shrink-0 rounded-full bg-emerald-600 px-1.5 py-0.5 text-[9px] font-bold leading-none text-white"
         >
           Lv.{{ stage }}
         </span>
       </div>
 
       <div :class="expanded ? 'flex min-h-0 flex-1 items-end justify-center' : 'flex h-36 items-end justify-center'">
-        <svg viewBox="0 -32 100 170" preserveAspectRatio="xMidYMax meet" class="h-full w-auto" aria-hidden="true">
+        <svg :viewBox="svgViewBox" preserveAspectRatio="xMidYMax meet" class="h-full w-auto" aria-hidden="true">
           <ellipse cx="50" cy="100" rx="30" ry="2" class="fill-emerald-200/70" />
 
           <!-- Lv.1 씨앗: 흙더미 + 흙에 더 깊이 묻힌 씨앗 (트렁크/왕관 미표시) -->
@@ -250,160 +246,157 @@ const stageLabel = computed(() => stageLabels[stage.value - 1])
             <ellipse cx="50" cy="6"  rx="6.5" ry="5" class="fill-emerald-300" />
           </template>
 
-          <!-- Lv.7 풍성한 나무: Lv.6 의 곡선 트렁크 + 가지 1쌍 추가(총 3쌍) + 잎 클러스터 4개씩 -->
+          <!-- Lv.7 풍성한 나무: Lv.6 의 정확히 2배 길이 (지면 cy=100 기준 위쪽 거리 ×2) -->
+          <!-- 변환 공식: y_new = 100 - (100 - y_old) * 2 = -100 + 2*y_old -->
           <template v-if="stage === 7">
-            <!-- 흙더미 -->
+            <!-- 흙더미 (지면 — 그대로) -->
             <ellipse cx="50" cy="100" rx="14" ry="4" class="fill-amber-900" />
             <ellipse cx="50" cy="99" rx="11" ry="2.5" class="fill-amber-800" />
 
-            <!-- 트렁크 (Lv.6 보다 살짝 길고 굵음) -->
+            <!-- 트렁크 (Lv.6 상단 y=18 → -64, 정확히 2배 위로 자람) -->
             <path
-              d="M 44 99.5 Q 44 70 45 45 Q 46 25 47.5 10 L 52.5 10 Q 54 25 55 45 Q 56 70 56 99.5 Z"
+              d="M 44 99.5 Q 44 40 45 -10 Q 46 -44 47.5 -64 L 52.5 -64 Q 54 -44 55 -10 Q 56 40 56 99.5 Z"
               class="fill-amber-800"
             />
             <!-- 트렁크 결무늬 -->
-            <path d="M 47 80 Q 47.5 60 47 40" stroke-width="0.5" fill="none" class="stroke-amber-950" opacity="0.5" />
-            <path d="M 52.5 78 Q 52 58 53 38" stroke-width="0.5" fill="none" class="stroke-amber-950" opacity="0.5" />
+            <path d="M 47 60 Q 48 30 47 0" stroke-width="0.5" fill="none" class="stroke-amber-950" opacity="0.5" />
+            <path d="M 52 56 Q 51 20 52 -10" stroke-width="0.5" fill="none" class="stroke-amber-950" opacity="0.5" />
 
-            <!-- 하단 메인 가지 -->
-            <path d="M 46.5 60 Q 36 55 24 46" stroke-width="2.6" stroke-linecap="round" fill="none" class="stroke-amber-800" />
-            <path d="M 53.5 60 Q 64 55 76 46" stroke-width="2.6" stroke-linecap="round" fill="none" class="stroke-amber-800" />
-            <!-- 중단 가지 (신규) -->
-            <path d="M 47 40 Q 40 33 30 26" stroke-width="2" stroke-linecap="round" fill="none" class="stroke-amber-800" />
-            <path d="M 53 40 Q 60 33 70 26" stroke-width="2" stroke-linecap="round" fill="none" class="stroke-amber-800" />
-            <!-- 상단 작은 가지 -->
-            <path d="M 48 22 Q 44 14 40 6" stroke-width="1.6" stroke-linecap="round" fill="none" class="stroke-amber-800" />
-            <path d="M 52 22 Q 56 14 60 6" stroke-width="1.6" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <!-- 하단 메인 가지 (Lv.6 y=55→10, y=42→-16) -->
+            <path d="M 47 10 Q 36 0 24 -16" stroke-width="2.6" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 53 10 Q 64 0 76 -16" stroke-width="2.6" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <!-- 중단 가지 (Lv.6 y=38→-24, y=26→-48) -->
+            <path d="M 48 -24 Q 44 -36 40 -48" stroke-width="2" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 52 -24 Q 56 -36 60 -48" stroke-width="2" stroke-linecap="round" fill="none" class="stroke-amber-800" />
 
-            <!-- 좌측 잎 클러스터 (4개) -->
-            <ellipse cx="22" cy="44" rx="12" ry="8" transform="rotate(-22 22 44)" class="fill-emerald-700" />
-            <ellipse cx="31" cy="38" rx="7.5" ry="5.5" transform="rotate(-15 31 38)" class="fill-emerald-500" />
-            <ellipse cx="16" cy="40" rx="6.5" ry="5" transform="rotate(-38 16 40)" class="fill-emerald-600" />
-            <ellipse cx="27" cy="24" rx="7" ry="5.5" transform="rotate(-18 27 24)" class="fill-emerald-500" />
+            <!-- 좌측 잎 클러스터 (Lv.6 cy=40,35,36 → -20,-30,-28) -->
+            <ellipse cx="26" cy="-20" rx="11" ry="7.5" transform="rotate(-22 26 -20)" class="fill-emerald-700" />
+            <ellipse cx="34" cy="-30" rx="7" ry="5" transform="rotate(-15 34 -30)" class="fill-emerald-500" />
+            <ellipse cx="20" cy="-28" rx="6" ry="4.5" transform="rotate(-38 20 -28)" class="fill-emerald-600" />
 
-            <!-- 우측 잎 클러스터 (4개) -->
-            <ellipse cx="78" cy="44" rx="12" ry="8" transform="rotate(22 78 44)" class="fill-emerald-600" />
-            <ellipse cx="69" cy="38" rx="7.5" ry="5.5" transform="rotate(15 69 38)" class="fill-emerald-400" />
-            <ellipse cx="84" cy="40" rx="6.5" ry="5" transform="rotate(38 84 40)" class="fill-emerald-500" />
-            <ellipse cx="73" cy="24" rx="7" ry="5.5" transform="rotate(18 73 24)" class="fill-emerald-400" />
+            <!-- 우측 잎 클러스터 -->
+            <ellipse cx="74" cy="-20" rx="11" ry="7.5" transform="rotate(22 74 -20)" class="fill-emerald-600" />
+            <ellipse cx="66" cy="-30" rx="7" ry="5" transform="rotate(15 66 -30)" class="fill-emerald-400" />
+            <ellipse cx="80" cy="-28" rx="6" ry="4.5" transform="rotate(38 80 -28)" class="fill-emerald-500" />
 
-            <!-- 메인 왕관 + 상단 보조 잎 -->
-            <ellipse cx="50" cy="12" rx="19" ry="15" class="fill-emerald-500" />
-            <ellipse cx="39" cy="3" rx="8" ry="6.5" transform="rotate(-20 39 3)" class="fill-emerald-600" />
-            <ellipse cx="61" cy="3" rx="8" ry="6.5" transform="rotate(20 61 3)" class="fill-emerald-400" />
-            <ellipse cx="50" cy="-4" rx="7.5" ry="6" class="fill-emerald-300" />
+            <!-- 메인 왕관 + 상단 보조 잎 (Lv.6 cy=20,12,12,6 → -60,-76,-76,-88) -->
+            <ellipse cx="50" cy="-60" rx="17" ry="14" class="fill-emerald-500" />
+            <ellipse cx="41" cy="-76" rx="7" ry="6" transform="rotate(-20 41 -76)" class="fill-emerald-600" />
+            <ellipse cx="59" cy="-76" rx="7" ry="6" transform="rotate(20 59 -76)" class="fill-emerald-400" />
+            <ellipse cx="50" cy="-88" rx="6.5" ry="5" class="fill-emerald-300" />
           </template>
 
-          <!-- Lv.8 튼튼한 나무: Lv.7 + 가지 한 쌍 더 + 첫 열매 등장 + 트렁크 더 길게 -->
+          <!-- Lv.8 튼튼한 나무: Lv.7 + 약간 더 길게 + 가지 1쌍 추가 + 잎 클러스터 1개씩 + 열매 등장 -->
+          <!-- scale ≈ 2.15 (Lv.7 의 2.0 + 점진 성장) -->
           <template v-if="stage === 8">
             <!-- 흙더미 -->
             <ellipse cx="50" cy="100" rx="15" ry="4.5" class="fill-amber-900" />
             <ellipse cx="50" cy="99" rx="12" ry="2.8" class="fill-amber-800" />
 
-            <!-- 트렁크 (더 길어 viewBox 위쪽까지) -->
+            <!-- 트렁크 (상단 y=-76, Lv.7 보다 길게) -->
             <path
-              d="M 43.5 99.5 Q 43.5 68 44.5 42 Q 45.5 22 47 5 L 53 5 Q 54.5 22 55.5 42 Q 56.5 68 56.5 99.5 Z"
+              d="M 43.5 99.5 Q 43.5 36 44.5 -16 Q 45.5 -53 47 -76 L 53 -76 Q 54.5 -53 55.5 -16 Q 56.5 36 56.5 99.5 Z"
               class="fill-amber-800"
             />
-            <!-- 트렁크 결무늬 (2개) -->
-            <path d="M 46.5 82 Q 47 60 46.5 38" stroke-width="0.6" fill="none" class="stroke-amber-950" opacity="0.55" />
-            <path d="M 53 80 Q 52.5 58 53.3 35" stroke-width="0.6" fill="none" class="stroke-amber-950" opacity="0.55" />
+            <!-- 트렁크 결무늬 -->
+            <path d="M 46.5 64 Q 47 20 46.5 -24" stroke-width="0.6" fill="none" class="stroke-amber-950" opacity="0.55" />
+            <path d="M 53 60 Q 52.5 16 53 -30" stroke-width="0.6" fill="none" class="stroke-amber-950" opacity="0.55" />
 
             <!-- 하단 메인 가지 -->
-            <path d="M 46 65 Q 35 60 22 50" stroke-width="2.8" stroke-linecap="round" fill="none" class="stroke-amber-800" />
-            <path d="M 54 65 Q 65 60 78 50" stroke-width="2.8" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 46 30 Q 35 20 22 7" stroke-width="2.8" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 54 30 Q 65 20 78 7" stroke-width="2.8" stroke-linecap="round" fill="none" class="stroke-amber-800" />
             <!-- 중단 가지 -->
-            <path d="M 46 45 Q 38 38 26 30" stroke-width="2.2" stroke-linecap="round" fill="none" class="stroke-amber-800" />
-            <path d="M 54 45 Q 62 38 74 30" stroke-width="2.2" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 46 -10 Q 38 -25 26 -42" stroke-width="2.2" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 54 -10 Q 62 -25 74 -42" stroke-width="2.2" stroke-linecap="round" fill="none" class="stroke-amber-800" />
             <!-- 상단 가지 -->
-            <path d="M 47 25 Q 42 18 36 10" stroke-width="1.8" stroke-linecap="round" fill="none" class="stroke-amber-800" />
-            <path d="M 53 25 Q 58 18 64 10" stroke-width="1.8" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 47 -45 Q 42 -58 36 -72" stroke-width="1.8" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 53 -45 Q 58 -58 64 -72" stroke-width="1.8" stroke-linecap="round" fill="none" class="stroke-amber-800" />
 
             <!-- 좌측 잎 클러스터 (5개) -->
-            <ellipse cx="20" cy="48" rx="13" ry="9" transform="rotate(-22 20 48)" class="fill-emerald-700" />
-            <ellipse cx="30" cy="42" rx="8" ry="6" transform="rotate(-15 30 42)" class="fill-emerald-500" />
-            <ellipse cx="13" cy="44" rx="7" ry="5.5" transform="rotate(-40 13 44)" class="fill-emerald-600" />
-            <ellipse cx="24" cy="28" rx="8" ry="6" transform="rotate(-20 24 28)" class="fill-emerald-500" />
-            <ellipse cx="34" cy="20" rx="6.5" ry="5" transform="rotate(-10 34 20)" class="fill-emerald-400" />
+            <ellipse cx="20" cy="-30" rx="13" ry="9" transform="rotate(-22 20 -30)" class="fill-emerald-700" />
+            <ellipse cx="30" cy="-40" rx="8" ry="6" transform="rotate(-15 30 -40)" class="fill-emerald-500" />
+            <ellipse cx="13" cy="-35" rx="7" ry="5.5" transform="rotate(-40 13 -35)" class="fill-emerald-600" />
+            <ellipse cx="24" cy="-55" rx="8" ry="6" transform="rotate(-20 24 -55)" class="fill-emerald-500" />
+            <ellipse cx="34" cy="-68" rx="6.5" ry="5" transform="rotate(-10 34 -68)" class="fill-emerald-400" />
 
             <!-- 우측 잎 클러스터 (5개) -->
-            <ellipse cx="80" cy="48" rx="13" ry="9" transform="rotate(22 80 48)" class="fill-emerald-600" />
-            <ellipse cx="70" cy="42" rx="8" ry="6" transform="rotate(15 70 42)" class="fill-emerald-400" />
-            <ellipse cx="87" cy="44" rx="7" ry="5.5" transform="rotate(40 87 44)" class="fill-emerald-500" />
-            <ellipse cx="76" cy="28" rx="8" ry="6" transform="rotate(20 76 28)" class="fill-emerald-400" />
-            <ellipse cx="66" cy="20" rx="6.5" ry="5" transform="rotate(10 66 20)" class="fill-emerald-500" />
+            <ellipse cx="80" cy="-30" rx="13" ry="9" transform="rotate(22 80 -30)" class="fill-emerald-600" />
+            <ellipse cx="70" cy="-40" rx="8" ry="6" transform="rotate(15 70 -40)" class="fill-emerald-400" />
+            <ellipse cx="87" cy="-35" rx="7" ry="5.5" transform="rotate(40 87 -35)" class="fill-emerald-500" />
+            <ellipse cx="76" cy="-55" rx="8" ry="6" transform="rotate(20 76 -55)" class="fill-emerald-400" />
+            <ellipse cx="66" cy="-68" rx="6.5" ry="5" transform="rotate(10 66 -68)" class="fill-emerald-500" />
 
             <!-- 메인 왕관 + 상단 풍성 보조 잎 -->
-            <ellipse cx="50" cy="6" rx="21" ry="16" class="fill-emerald-500" />
-            <ellipse cx="37" cy="-3" rx="8.5" ry="7" transform="rotate(-22 37 -3)" class="fill-emerald-600" />
-            <ellipse cx="63" cy="-3" rx="8.5" ry="7" transform="rotate(22 63 -3)" class="fill-emerald-400" />
-            <ellipse cx="50" cy="-11" rx="9" ry="7" class="fill-emerald-300" />
+            <ellipse cx="50" cy="-80" rx="21" ry="16" class="fill-emerald-500" />
+            <ellipse cx="37" cy="-95" rx="8.5" ry="7" transform="rotate(-22 37 -95)" class="fill-emerald-600" />
+            <ellipse cx="63" cy="-95" rx="8.5" ry="7" transform="rotate(22 63 -95)" class="fill-emerald-400" />
+            <ellipse cx="50" cy="-105" rx="9" ry="7" class="fill-emerald-300" />
 
             <!-- 열매 3개 (Lv.8 부터 등장 — 작은 rose) -->
-            <circle cx="42" cy="14" r="2.1" class="fill-rose-400" />
-            <circle cx="58" cy="9" r="2.1" class="fill-rose-400" />
-            <circle cx="50" cy="20" r="2.1" class="fill-rose-400" />
+            <circle cx="42" cy="-15" r="2.1" class="fill-rose-400" />
+            <circle cx="58" cy="-20" r="2.1" class="fill-rose-400" />
+            <circle cx="50" cy="-5" r="2.1" class="fill-rose-400" />
           </template>
 
-          <!-- Lv.9 거목: Lv.8 + 더 굵은 트렁크 + 가지 4쌍 + 풍성한 잎 + 열매 5개 -->
+          <!-- Lv.9 거목: Lv.8 보다 더 길고 굵게 + 가지 4쌍 + 풍성한 잎 + 열매 5개 -->
+          <!-- scale ≈ 2.30 -->
           <template v-if="stage === 9">
             <!-- 흙더미 (더 크게) -->
             <ellipse cx="50" cy="100" rx="17" ry="5" class="fill-amber-900" />
             <ellipse cx="50" cy="99" rx="13" ry="3" class="fill-amber-800" />
 
-            <!-- 트렁크 (가장 굵고 길어 viewBox 위쪽 활용) -->
+            <!-- 트렁크 (상단 y=-88) -->
             <path
-              d="M 42 99.5 Q 42 65 43 38 Q 44 18 46 -2 L 54 -2 Q 56 18 57 38 Q 58 65 58 99.5 Z"
+              d="M 42 99.5 Q 42 32 43 -24 Q 44 -60 46 -88 L 54 -88 Q 56 -60 57 -24 Q 58 32 58 99.5 Z"
               class="fill-amber-800"
             />
             <!-- 트렁크 결무늬 (3개로 풍성) -->
-            <path d="M 45.5 82 Q 46 58 45.5 32" stroke-width="0.6" fill="none" class="stroke-amber-950" opacity="0.6" />
-            <path d="M 50.5 80 Q 50 50 50.5 25" stroke-width="0.5" fill="none" class="stroke-amber-950" opacity="0.4" />
-            <path d="M 54 82 Q 53.5 56 54.5 28" stroke-width="0.6" fill="none" class="stroke-amber-950" opacity="0.6" />
+            <path d="M 45.5 65 Q 46 18 45.5 -28" stroke-width="0.6" fill="none" class="stroke-amber-950" opacity="0.6" />
+            <path d="M 50.5 60 Q 50 4 50.5 -42" stroke-width="0.5" fill="none" class="stroke-amber-950" opacity="0.4" />
+            <path d="M 54 65 Q 53.5 14 54.5 -38" stroke-width="0.6" fill="none" class="stroke-amber-950" opacity="0.6" />
 
             <!-- 가지 4쌍 — 하단/중하단/중상단/상단 -->
-            <path d="M 45 70 Q 33 65 18 54" stroke-width="3" stroke-linecap="round" fill="none" class="stroke-amber-800" />
-            <path d="M 55 70 Q 67 65 82 54" stroke-width="3" stroke-linecap="round" fill="none" class="stroke-amber-800" />
-            <path d="M 45 50 Q 36 43 22 34" stroke-width="2.4" stroke-linecap="round" fill="none" class="stroke-amber-800" />
-            <path d="M 55 50 Q 64 43 78 34" stroke-width="2.4" stroke-linecap="round" fill="none" class="stroke-amber-800" />
-            <path d="M 46 30 Q 40 22 32 13" stroke-width="2" stroke-linecap="round" fill="none" class="stroke-amber-800" />
-            <path d="M 54 30 Q 60 22 68 13" stroke-width="2" stroke-linecap="round" fill="none" class="stroke-amber-800" />
-            <path d="M 47 10 Q 44 2 40 -6" stroke-width="1.6" stroke-linecap="round" fill="none" class="stroke-amber-800" />
-            <path d="M 53 10 Q 56 2 60 -6" stroke-width="1.6" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 45 38 Q 33 28 18 8" stroke-width="3" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 55 38 Q 67 28 82 8" stroke-width="3" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 45 0 Q 36 -14 22 -32" stroke-width="2.4" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 55 0 Q 64 -14 78 -32" stroke-width="2.4" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 46 -40 Q 40 -56 32 -74" stroke-width="2" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 54 -40 Q 60 -56 68 -74" stroke-width="2" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 47 -80 Q 44 -96 40 -112" stroke-width="1.6" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 53 -80 Q 56 -96 60 -112" stroke-width="1.6" stroke-linecap="round" fill="none" class="stroke-amber-800" />
 
             <!-- 좌측 잎 클러스터 (6개) -->
-            <ellipse cx="16" cy="52" rx="14" ry="10" transform="rotate(-22 16 52)" class="fill-emerald-700" />
-            <ellipse cx="28" cy="46" rx="9" ry="6.5" transform="rotate(-15 28 46)" class="fill-emerald-500" />
-            <ellipse cx="9" cy="48" rx="7.5" ry="6" transform="rotate(-40 9 48)" class="fill-emerald-600" />
-            <ellipse cx="20" cy="32" rx="9" ry="6.5" transform="rotate(-22 20 32)" class="fill-emerald-500" />
-            <ellipse cx="31" cy="22" rx="7.5" ry="5.5" transform="rotate(-12 31 22)" class="fill-emerald-400" />
-            <ellipse cx="24" cy="10" rx="7" ry="5" transform="rotate(-18 24 10)" class="fill-emerald-500" />
+            <ellipse cx="16" cy="-26" rx="14" ry="10" transform="rotate(-22 16 -26)" class="fill-emerald-700" />
+            <ellipse cx="28" cy="-38" rx="9" ry="6.5" transform="rotate(-15 28 -38)" class="fill-emerald-500" />
+            <ellipse cx="9" cy="-32" rx="7.5" ry="6" transform="rotate(-40 9 -32)" class="fill-emerald-600" />
+            <ellipse cx="20" cy="-56" rx="9" ry="6.5" transform="rotate(-22 20 -56)" class="fill-emerald-500" />
+            <ellipse cx="31" cy="-70" rx="7.5" ry="5.5" transform="rotate(-12 31 -70)" class="fill-emerald-400" />
+            <ellipse cx="24" cy="-90" rx="7" ry="5" transform="rotate(-18 24 -90)" class="fill-emerald-500" />
 
             <!-- 우측 잎 클러스터 (6개) -->
-            <ellipse cx="84" cy="52" rx="14" ry="10" transform="rotate(22 84 52)" class="fill-emerald-600" />
-            <ellipse cx="72" cy="46" rx="9" ry="6.5" transform="rotate(15 72 46)" class="fill-emerald-400" />
-            <ellipse cx="91" cy="48" rx="7.5" ry="6" transform="rotate(40 91 48)" class="fill-emerald-500" />
-            <ellipse cx="80" cy="32" rx="9" ry="6.5" transform="rotate(22 80 32)" class="fill-emerald-400" />
-            <ellipse cx="69" cy="22" rx="7.5" ry="5.5" transform="rotate(12 69 22)" class="fill-emerald-500" />
-            <ellipse cx="76" cy="10" rx="7" ry="5" transform="rotate(18 76 10)" class="fill-emerald-400" />
+            <ellipse cx="84" cy="-26" rx="14" ry="10" transform="rotate(22 84 -26)" class="fill-emerald-600" />
+            <ellipse cx="72" cy="-38" rx="9" ry="6.5" transform="rotate(15 72 -38)" class="fill-emerald-400" />
+            <ellipse cx="91" cy="-32" rx="7.5" ry="6" transform="rotate(40 91 -32)" class="fill-emerald-500" />
+            <ellipse cx="80" cy="-56" rx="9" ry="6.5" transform="rotate(22 80 -56)" class="fill-emerald-400" />
+            <ellipse cx="69" cy="-70" rx="7.5" ry="5.5" transform="rotate(12 69 -70)" class="fill-emerald-500" />
+            <ellipse cx="76" cy="-90" rx="7" ry="5" transform="rotate(18 76 -90)" class="fill-emerald-400" />
 
             <!-- 메인 왕관 (거대) + 상단 풍성 보조 잎 -->
-            <ellipse cx="50" cy="-2" rx="24" ry="18" class="fill-emerald-500" />
-            <ellipse cx="34" cy="-11" rx="9.5" ry="7.5" transform="rotate(-22 34 -11)" class="fill-emerald-600" />
-            <ellipse cx="66" cy="-11" rx="9.5" ry="7.5" transform="rotate(22 66 -11)" class="fill-emerald-400" />
-            <ellipse cx="50" cy="-20" rx="10" ry="8" class="fill-emerald-300" />
-            <ellipse cx="43" cy="-22" rx="6" ry="5" class="fill-emerald-400" />
-            <ellipse cx="57" cy="-22" rx="6" ry="5" class="fill-emerald-500" />
+            <ellipse cx="50" cy="-94" rx="24" ry="18" class="fill-emerald-500" />
+            <ellipse cx="34" cy="-110" rx="9.5" ry="7.5" transform="rotate(-22 34 -110)" class="fill-emerald-600" />
+            <ellipse cx="66" cy="-110" rx="9.5" ry="7.5" transform="rotate(22 66 -110)" class="fill-emerald-400" />
+            <ellipse cx="50" cy="-122" rx="10" ry="8" class="fill-emerald-300" />
 
             <!-- 열매 5개 (rose) -->
-            <circle cx="38" cy="18" r="2.3" class="fill-rose-400" />
-            <circle cx="62" cy="14" r="2.3" class="fill-rose-400" />
-            <circle cx="50" cy="22" r="2.3" class="fill-rose-400" />
-            <circle cx="45" cy="2" r="2.3" class="fill-rose-400" />
-            <circle cx="56" cy="-4" r="2.3" class="fill-rose-400" />
+            <circle cx="38" cy="-20" r="2.3" class="fill-rose-400" />
+            <circle cx="62" cy="-26" r="2.3" class="fill-rose-400" />
+            <circle cx="50" cy="-10" r="2.3" class="fill-rose-400" />
+            <circle cx="45" cy="-60" r="2.3" class="fill-rose-400" />
+            <circle cx="56" cy="-68" r="2.3" class="fill-rose-400" />
           </template>
 
           <!-- Lv.10 결실의 나무: 최대 풍성도 + 황금 열매 섞은 결실 + 트렁크 결무늬 다중 + 빛나는 광휘 -->
+          <!-- scale ≈ 2.45 — viewBox y=-130 까지 거의 다 활용 -->
           <template v-if="stage === 10">
             <!-- 흙더미 (가장 크게) -->
             <ellipse cx="50" cy="100" rx="19" ry="5.5" class="fill-amber-900" />
@@ -414,74 +407,70 @@ const stageLabel = computed(() => stageLabels[stage.value - 1])
             <line x1="33" y1="99.5" x2="32" y2="97" stroke-width="0.6" stroke-linecap="round" class="stroke-emerald-600" />
             <line x1="67" y1="99.5" x2="68" y2="97" stroke-width="0.6" stroke-linecap="round" class="stroke-emerald-600" />
 
-            <!-- 광휘 — 메인 왕관 뒤쪽 부드러운 옅은 빛 (결실의 나무 특별 효과) -->
-            <ellipse cx="50" cy="-8" rx="34" ry="26" class="fill-amber-100" opacity="0.45" />
+            <!-- 광휘 — 메인 왕관 뒤쪽 부드러운 옅은 빛 -->
+            <ellipse cx="50" cy="-108" rx="34" ry="26" class="fill-amber-100" opacity="0.45" />
 
-            <!-- 트렁크 (가장 굵고 viewBox 상단까지) -->
+            <!-- 트렁크 (가장 굵고 viewBox 상단까지 — 상단 y=-105) -->
             <path
-              d="M 40.5 99.5 Q 40.5 63 41.5 35 Q 42.5 15 44.5 -8 L 55.5 -8 Q 57.5 15 58.5 35 Q 59.5 63 59.5 99.5 Z"
+              d="M 40.5 99.5 Q 40.5 25 41.5 -38 Q 42.5 -75 44.5 -105 L 55.5 -105 Q 57.5 -75 58.5 -38 Q 59.5 25 59.5 99.5 Z"
               class="fill-amber-800"
             />
             <!-- 트렁크 결무늬 (다중 디테일 — 나이테 풍성) -->
-            <path d="M 44.5 84 Q 45 56 44.5 28" stroke-width="0.7" fill="none" class="stroke-amber-950" opacity="0.65" />
-            <path d="M 50 82 Q 49.5 48 50 18" stroke-width="0.5" fill="none" class="stroke-amber-950" opacity="0.4" />
-            <path d="M 55 84 Q 54.5 54 55.5 24" stroke-width="0.7" fill="none" class="stroke-amber-950" opacity="0.65" />
-            <!-- 트렁크 옹이 (결실 나무 디테일 — 시간의 흔적) -->
-            <ellipse cx="46" cy="70" rx="1.2" ry="2" class="fill-amber-950" opacity="0.4" />
-            <ellipse cx="54" cy="55" rx="1" ry="1.6" class="fill-amber-950" opacity="0.4" />
+            <path d="M 44.5 60 Q 45 5 44.5 -50" stroke-width="0.7" fill="none" class="stroke-amber-950" opacity="0.65" />
+            <path d="M 50 55 Q 49.5 -10 50 -75" stroke-width="0.5" fill="none" class="stroke-amber-950" opacity="0.4" />
+            <path d="M 55 60 Q 54.5 0 55.5 -60" stroke-width="0.7" fill="none" class="stroke-amber-950" opacity="0.65" />
+            <!-- 트렁크 옹이 -->
+            <ellipse cx="46" cy="40" rx="1.2" ry="2" class="fill-amber-950" opacity="0.4" />
+            <ellipse cx="54" cy="10" rx="1" ry="1.6" class="fill-amber-950" opacity="0.4" />
 
-            <!-- 가지 4쌍 (Lv.9 대비 더 길고 두꺼움) -->
-            <path d="M 43 72 Q 30 67 13 56" stroke-width="3.4" stroke-linecap="round" fill="none" class="stroke-amber-800" />
-            <path d="M 57 72 Q 70 67 87 56" stroke-width="3.4" stroke-linecap="round" fill="none" class="stroke-amber-800" />
-            <path d="M 43 52 Q 34 44 18 34" stroke-width="2.8" stroke-linecap="round" fill="none" class="stroke-amber-800" />
-            <path d="M 57 52 Q 66 44 82 34" stroke-width="2.8" stroke-linecap="round" fill="none" class="stroke-amber-800" />
-            <path d="M 44 32 Q 38 22 28 12" stroke-width="2.2" stroke-linecap="round" fill="none" class="stroke-amber-800" />
-            <path d="M 56 32 Q 62 22 72 12" stroke-width="2.2" stroke-linecap="round" fill="none" class="stroke-amber-800" />
-            <path d="M 45 10 Q 42 0 37 -10" stroke-width="1.8" stroke-linecap="round" fill="none" class="stroke-amber-800" />
-            <path d="M 55 10 Q 58 0 63 -10" stroke-width="1.8" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <!-- 가지 4쌍 (가장 길고 두꺼움) -->
+            <path d="M 43 44 Q 30 32 13 12" stroke-width="3.4" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 57 44 Q 70 32 87 12" stroke-width="3.4" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 43 4 Q 34 -12 18 -32" stroke-width="2.8" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 57 4 Q 66 -12 82 -32" stroke-width="2.8" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 44 -36 Q 38 -56 28 -76" stroke-width="2.2" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 56 -36 Q 62 -56 72 -76" stroke-width="2.2" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 45 -80 Q 42 -100 37 -120" stroke-width="1.8" stroke-linecap="round" fill="none" class="stroke-amber-800" />
+            <path d="M 55 -80 Q 58 -100 63 -120" stroke-width="1.8" stroke-linecap="round" fill="none" class="stroke-amber-800" />
 
             <!-- 좌측 잎 클러스터 (7개 — 그라데이션 톤) -->
-            <ellipse cx="12" cy="54" rx="15" ry="11" transform="rotate(-22 12 54)" class="fill-emerald-700" />
-            <ellipse cx="25" cy="48" rx="10" ry="7" transform="rotate(-15 25 48)" class="fill-emerald-500" />
-            <ellipse cx="5" cy="50" rx="8" ry="6.5" transform="rotate(-42 5 50)" class="fill-emerald-600" />
-            <ellipse cx="17" cy="32" rx="10" ry="7" transform="rotate(-22 17 32)" class="fill-emerald-500" />
-            <ellipse cx="28" cy="22" rx="8" ry="6" transform="rotate(-12 28 22)" class="fill-emerald-400" />
-            <ellipse cx="22" cy="8" rx="8" ry="6" transform="rotate(-18 22 8)" class="fill-emerald-500" />
-            <ellipse cx="32" cy="-2" rx="6.5" ry="5" transform="rotate(-10 32 -2)" class="fill-emerald-400" />
+            <ellipse cx="12" cy="-32" rx="15" ry="11" transform="rotate(-22 12 -32)" class="fill-emerald-700" />
+            <ellipse cx="25" cy="-44" rx="10" ry="7" transform="rotate(-15 25 -44)" class="fill-emerald-500" />
+            <ellipse cx="5" cy="-40" rx="8" ry="6.5" transform="rotate(-42 5 -40)" class="fill-emerald-600" />
+            <ellipse cx="17" cy="-66" rx="10" ry="7" transform="rotate(-22 17 -66)" class="fill-emerald-500" />
+            <ellipse cx="28" cy="-78" rx="8" ry="6" transform="rotate(-12 28 -78)" class="fill-emerald-400" />
+            <ellipse cx="22" cy="-94" rx="8" ry="6" transform="rotate(-18 22 -94)" class="fill-emerald-500" />
+            <ellipse cx="32" cy="-105" rx="6.5" ry="5" transform="rotate(-10 32 -105)" class="fill-emerald-400" />
 
             <!-- 우측 잎 클러스터 (7개 — 그라데이션 톤) -->
-            <ellipse cx="88" cy="54" rx="15" ry="11" transform="rotate(22 88 54)" class="fill-emerald-600" />
-            <ellipse cx="75" cy="48" rx="10" ry="7" transform="rotate(15 75 48)" class="fill-emerald-400" />
-            <ellipse cx="95" cy="50" rx="8" ry="6.5" transform="rotate(42 95 50)" class="fill-emerald-500" />
-            <ellipse cx="83" cy="32" rx="10" ry="7" transform="rotate(22 83 32)" class="fill-emerald-400" />
-            <ellipse cx="72" cy="22" rx="8" ry="6" transform="rotate(12 72 22)" class="fill-emerald-500" />
-            <ellipse cx="78" cy="8" rx="8" ry="6" transform="rotate(18 78 8)" class="fill-emerald-400" />
-            <ellipse cx="68" cy="-2" rx="6.5" ry="5" transform="rotate(10 68 -2)" class="fill-emerald-500" />
+            <ellipse cx="88" cy="-32" rx="15" ry="11" transform="rotate(22 88 -32)" class="fill-emerald-600" />
+            <ellipse cx="75" cy="-44" rx="10" ry="7" transform="rotate(15 75 -44)" class="fill-emerald-400" />
+            <ellipse cx="95" cy="-40" rx="8" ry="6.5" transform="rotate(42 95 -40)" class="fill-emerald-500" />
+            <ellipse cx="83" cy="-66" rx="10" ry="7" transform="rotate(22 83 -66)" class="fill-emerald-400" />
+            <ellipse cx="72" cy="-78" rx="8" ry="6" transform="rotate(12 72 -78)" class="fill-emerald-500" />
+            <ellipse cx="78" cy="-94" rx="8" ry="6" transform="rotate(18 78 -94)" class="fill-emerald-400" />
+            <ellipse cx="68" cy="-105" rx="6.5" ry="5" transform="rotate(10 68 -105)" class="fill-emerald-500" />
 
             <!-- 메인 왕관 (최대) + 상단 풍성 보조 잎 -->
-            <ellipse cx="50" cy="-8" rx="27" ry="20" class="fill-emerald-500" />
-            <ellipse cx="32" cy="-18" rx="10" ry="8" transform="rotate(-22 32 -18)" class="fill-emerald-600" />
-            <ellipse cx="68" cy="-18" rx="10" ry="8" transform="rotate(22 68 -18)" class="fill-emerald-400" />
-            <ellipse cx="50" cy="-28" rx="11" ry="8" class="fill-emerald-300" />
-            <ellipse cx="40" cy="-29" rx="6.5" ry="5" class="fill-emerald-400" />
-            <ellipse cx="60" cy="-29" rx="6.5" ry="5" class="fill-emerald-500" />
-            <!-- 최상단 새순 (결실의 시작점) -->
-            <ellipse cx="50" cy="-31" rx="4.5" ry="3.5" class="fill-emerald-200" />
+            <ellipse cx="50" cy="-110" rx="27" ry="20" class="fill-emerald-500" />
+            <ellipse cx="32" cy="-122" rx="10" ry="8" transform="rotate(-22 32 -122)" class="fill-emerald-600" />
+            <ellipse cx="68" cy="-122" rx="10" ry="8" transform="rotate(22 68 -122)" class="fill-emerald-400" />
+            <ellipse cx="50" cy="-126" rx="11" ry="8" class="fill-emerald-300" />
 
             <!-- 열매 8개 — rose 5개 + amber(황금) 3개 섞어서 "결실" 표현 -->
-            <circle cx="35" cy="20" r="2.5" class="fill-rose-400" />
-            <circle cx="65" cy="16" r="2.5" class="fill-rose-400" />
-            <circle cx="50" cy="24" r="2.5" class="fill-rose-400" />
-            <circle cx="42" cy="0" r="2.5" class="fill-rose-400" />
-            <circle cx="58" cy="-4" r="2.5" class="fill-rose-400" />
-            <circle cx="30" cy="36" r="2.3" class="fill-amber-400" />
-            <circle cx="70" cy="36" r="2.3" class="fill-amber-400" />
-            <circle cx="50" cy="-13" r="2.3" class="fill-amber-400" />
-            <!-- 열매 하이라이트 (광택 점) — 결실의 나무 특유의 윤기 -->
-            <circle cx="34.3" cy="19.3" r="0.7" class="fill-white" opacity="0.7" />
-            <circle cx="64.3" cy="15.3" r="0.7" class="fill-white" opacity="0.7" />
-            <circle cx="29.3" cy="35.3" r="0.6" class="fill-white" opacity="0.7" />
-            <circle cx="69.3" cy="35.3" r="0.6" class="fill-white" opacity="0.7" />
+            <circle cx="35" cy="-12" r="2.5" class="fill-rose-400" />
+            <circle cx="65" cy="-20" r="2.5" class="fill-rose-400" />
+            <circle cx="50" cy="-5" r="2.5" class="fill-rose-400" />
+            <circle cx="42" cy="-60" r="2.5" class="fill-rose-400" />
+            <circle cx="58" cy="-65" r="2.5" class="fill-rose-400" />
+            <circle cx="30" cy="20" r="2.3" class="fill-amber-400" />
+            <circle cx="70" cy="20" r="2.3" class="fill-amber-400" />
+            <circle cx="50" cy="-100" r="2.3" class="fill-amber-400" />
+            <!-- 열매 하이라이트 (광택 점) — 결실의 나무 특유의 윤기 (열매 cx,cy 기준 좌상단 0.7 오프셋) -->
+            <circle cx="34.3" cy="-12.7" r="0.7" class="fill-white" opacity="0.7" />
+            <circle cx="64.3" cy="-20.7" r="0.7" class="fill-white" opacity="0.7" />
+            <circle cx="29.3" cy="19.3" r="0.6" class="fill-white" opacity="0.7" />
+            <circle cx="69.3" cy="19.3" r="0.6" class="fill-white" opacity="0.7" />
           </template>
         </svg>
       </div>
@@ -500,34 +489,14 @@ const stageLabel = computed(() => stageLabels[stage.value - 1])
           ></div>
         </div>
         <p :class="expanded ? 'text-[10px] leading-tight text-gray-600' : 'text-[9px] leading-tight text-gray-500'">
-          <template v-if="stage >= esg.maxStage">최고 단계 달성</template>
+          <!-- Lv.10: 결실 익는 중 → 새 나무 시작까지 남은 점수 / 그 외: 다음 단계까지 -->
+          <template v-if="stage >= esg.maxStage && pointsToNext > 0">
+            🍎 결실 익는 중! 새 나무까지 {{ pointsToNext.toLocaleString() }}P
+          </template>
+          <template v-else-if="stage >= esg.maxStage">최고 단계 달성</template>
           <template v-else>다음 단계까지 {{ pointsToNext.toLocaleString() }}P</template>
         </p>
 
-        <!-- DEV 단계 미리보기 컨트롤 — 디자인 확인용. 빌드 시 자동 제거됨. -->
-        <div v-if="isDev" class="mt-2 flex items-center justify-center gap-2 border-t border-emerald-200/60 pt-2">
-          <button
-            type="button"
-            @click="prevStage"
-            :disabled="stage <= 1"
-            class="rounded border border-gray-300 bg-white/90 px-2 py-0.5 text-[10px] font-bold text-gray-700 hover:bg-emerald-50 disabled:cursor-not-allowed disabled:opacity-40"
-            aria-label="이전 단계 미리보기"
-          >
-            ◀
-          </button>
-          <span class="text-[9px] font-medium uppercase tracking-wider text-gray-500">
-            DEV Lv.{{ stage }}
-          </span>
-          <button
-            type="button"
-            @click="nextStage"
-            :disabled="stage >= esg.maxStage"
-            class="rounded border border-gray-300 bg-white/90 px-2 py-0.5 text-[10px] font-bold text-gray-700 hover:bg-emerald-50 disabled:cursor-not-allowed disabled:opacity-40"
-            aria-label="다음 단계 미리보기"
-          >
-            ▶
-          </button>
-        </div>
       </div>
     </div>
   </div>

--- a/src/stores/esg.js
+++ b/src/stores/esg.js
@@ -23,6 +23,11 @@ const STAGE_THRESHOLDS = [
   1500000,   // Lv.10 — 결실의 나무 (만점)
 ]
 const MAX_STAGE = STAGE_THRESHOLDS.length   // 10
+// Lv.10 만점 임계값 — 1,500,000pt 도달 시 결실의 나무 완성 (Lv.10 표시)
+const MAX_LEVEL_POINTS = STAGE_THRESHOLDS[MAX_STAGE - 1]   // 1,500,000
+// 사이클 한 바퀴 = 1그루 완성 — 만점 1,500,000 + 결실 익는 보너스 500,000 = 2,000,000pt
+// 매 사이클마다 그루 +1 + Lv.1 씨앗으로 리셋
+const FULL_TREE_POINTS = 2_000_000
 
 // BE 응답 실패 시 폴백 가격 (BE 의 esg.carbon-api.fallback-price 와 동기화: 9,200)
 const KAU_FALLBACK_PRICE = 9200
@@ -82,29 +87,46 @@ export const useEsgStore = defineStore('esg', () => {
     return Number((((curr - prev) / prev) * 100).toFixed(1))
   })
 
-  // 현재 단계 — STAGE_THRESHOLDS 배열에서 totalPoints 가 도달한 가장 큰 임계값의 인덱스+1
-  //  - Curved 곡선: 단계별 간격이 다름 (초반 5K→20K, 후반 1M→1.5M)
+  // 키운 나무 그루 수 — 매 사이클 (2,000,000pt) 완료마다 +1
+  // 예: totalPoints=4,500,000 → 2그루 + 사이클 내 500,000pt (Lv.7)
+  const treeCount = computed(() => Math.floor(totalPoints.value / FULL_TREE_POINTS))
+
+  // 사이클 내 점수 — 0 ~ 1,999,999 사이 (2,000,000 도달 시 0 으로 리셋, 그루+1)
+  const cyclePoints = computed(() => totalPoints.value % FULL_TREE_POINTS)
+
+  // 현재 단계 — cyclePoints 기준으로 Lv.1~10 매칭
+  //  - cyclePoints < 1,500,000 : STAGE_THRESHOLDS 기준 Lv.1~Lv.9
+  //  - cyclePoints >= 1,500,000 : Lv.10 만점 (결실 익는 보너스 구간)
   const stage = computed(() => {
-    const pts = totalPoints.value
+    const pts = cyclePoints.value
     for (let i = STAGE_THRESHOLDS.length - 1; i >= 0; i--) {
       if (pts >= STAGE_THRESHOLDS[i]) return i + 1
     }
     return 1
   })
 
-  // 현재 단계 내 진행률 (%) — 현재 임계값 ~ 다음 임계값 사이에서의 비율
+  // 현재 단계 내 진행률 (%)
+  //  - Lv.10 : "결실 익는 진행률" = (cyclePoints - 1,500,000) / 500,000
+  //  - 그 외 : 다음 단계 임계값까지의 비율
   const stageProgress = computed(() => {
-    if (stage.value >= MAX_STAGE) return 100
+    if (stage.value >= MAX_STAGE) {
+      // Lv.10 결실 익는 구간 — cyclePoints 1,500,000~1,999,999 → 0~100%
+      return Math.min(100, ((cyclePoints.value - MAX_LEVEL_POINTS) / (FULL_TREE_POINTS - MAX_LEVEL_POINTS)) * 100)
+    }
     const curr = STAGE_THRESHOLDS[stage.value - 1]
     const next = STAGE_THRESHOLDS[stage.value]
     if (next <= curr) return 100  // 안전 폴백 (배열 오류 대비)
-    return Math.min(100, ((totalPoints.value - curr) / (next - curr)) * 100)
+    return Math.min(100, ((cyclePoints.value - curr) / (next - curr)) * 100)
   })
 
   // 다음 단계까지 남은 점수
+  //  - Lv.10 : 그루+1 (다음 사이클 시작) 까지 남은 점수
+  //  - 그 외 : 다음 단계 임계값까지 남은 점수
   const pointsToNext = computed(() => {
-    if (stage.value >= MAX_STAGE) return 0
-    return Math.max(0, STAGE_THRESHOLDS[stage.value] - totalPoints.value)
+    if (stage.value >= MAX_STAGE) {
+      return Math.max(0, FULL_TREE_POINTS - cyclePoints.value)
+    }
+    return Math.max(0, STAGE_THRESHOLDS[stage.value] - cyclePoints.value)
   })
 
   /**
@@ -247,6 +269,7 @@ export const useEsgStore = defineStore('esg', () => {
     stage,
     stageProgress,
     pointsToNext,
+    treeCount,
     // Curved 단계 정책 노출 — EsgTreeWidget 등에서 진척도 표시용
     stageThresholds: STAGE_THRESHOLDS,
     maxStage: MAX_STAGE,

--- a/src/stores/notification.js
+++ b/src/stores/notification.js
@@ -14,7 +14,11 @@
 
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
-import { notificationApi, subscribeNotificationStream } from '@/api/notification.js'
+import {
+  notificationApi,
+  subscribeNotificationStream,
+  closeNotificationStreamBeacon,
+} from '@/api/notification.js'
 
 export const useNotificationStore = defineStore('notification', () => {
   const notifications = ref([])           // 최신순 (id desc)
@@ -24,6 +28,7 @@ export const useNotificationStore = defineStore('notification', () => {
   const error = ref('')
 
   let eventSource = null
+  let sessionId = null                    // BE connect 이벤트로 받은 SSE 세션 UUID — unload 시 sendBeacon 으로 명시적 종료에 사용
 
   const unreadCount = computed(
     () => notifications.value.filter((n) => !n.read).length,
@@ -63,8 +68,9 @@ export const useNotificationStore = defineStore('notification', () => {
   function connectStream() {
     if (eventSource) return
     eventSource = subscribeNotificationStream({
-      onConnect: () => {
-        // 연결 성공
+      onConnect: (sid) => {
+        // BE 가 connect 이벤트 data 로 sessionId 를 전달 — 페이지 unload 시 sendBeacon 으로 명시적 종료에 사용
+        sessionId = sid
       },
       onNotification: (payload) => {
         // BE SsePayload (id/type/severity/title/message/createdAt) — read=false 기본
@@ -118,12 +124,25 @@ export const useNotificationStore = defineStore('notification', () => {
     }
   }
 
-  /** SSE close + 상태 초기화 — 로그아웃 시 호출 */
+  /**
+   * SSE close + 상태 초기화 — 로그아웃 / 페이지 unload (탭 닫기/F5/창 닫기) 시 호출.
+   *
+   * 두 단계 종료:
+   *  1) sendBeacon — 페이지 unload 중에도 보장되는 BE 명시적 종료 호출 (sessionId 보유 시).
+   *     BE 가 emitters Map 에서 즉시 정리 → heartbeat 30초 대기 불필요.
+   *  2) eventSource.close() — 클라이언트 TCP 끊기. BE onError/onCompletion 콜백 발화로 fallback 정리.
+   *
+   * 순서 중요: sendBeacon 을 먼저 호출해야 sessionId 가 살아있는 동안 BE 까지 도달.
+   */
   function dispose() {
+    if (sessionId) {
+      try { closeNotificationStreamBeacon(sessionId) } catch { /* ignore */ }
+    }
     if (eventSource) {
       try { eventSource.close() } catch { /* ignore */ }
       eventSource = null
     }
+    sessionId = null
     notifications.value = []
     totalElements.value = 0
     initialized.value = false

--- a/src/views/hq/esg/EsgTreeScoreView.vue
+++ b/src/views/hq/esg/EsgTreeScoreView.vue
@@ -405,8 +405,8 @@ onMounted(reload)
             <span class="text-[14px] font-bold text-emerald-600">pt</span>
           </div>
           <p class="mt-2 text-[11px] text-emerald-700/70">
-            🌳 {{ Math.floor(totalScore / 1000) }}그루의 나무를 키우는 효과
-            <span class="ml-1 text-gray-500">(1,000 pt = 1그루 환산 mock)</span>
+            🌳 {{ esgStore.treeCount.toLocaleString() }}그루의 나무를 키웠습니다!
+            <span class="ml-1 text-gray-500">(Lv.10 만점 1,500,000pt + 결실 익는 보너스 500,000pt = 2,000,000pt 마다 1그루 + Lv.1 씨앗 재시작)</span>
           </p>
         </div>
 


### PR DESCRIPTION
## 📌 요약
- 운영의 stale SSE emitter 누적 문제 해결 — 페이지 unload 시 sendBeacon 으로 BE 명시적 종료
- ESG 나무 위젯 Lv.7~10 디자인 신설 + 점수 사이클(2,000,000pt = 1그루) 자동 연동
- DEV 미리보기 버튼 제거로 본사 화면 운영 친화적 정리

<br><br>

## 🎯 작업 내용

### SSE 명시적 종료 (BE PR 과 짝)
- `subscribeNotificationStream`: BE 의 connect 이벤트에서 sessionId 수신 → onConnect 콜백으로 전달
- `closeNotificationStreamBeacon` helper 신설 — `navigator.sendBeacon` 으로 페이지 unload 중에도 도달 보장
- `notificationStore`: sessionId 클로저 보관, `dispose()` 에서 sendBeacon → EventSource.close 순서 호출
- `App.vue`: `pagehide` 이벤트 핸들러로 `notif.dispose()` 자동 호출 (BFCache 예외 처리 포함)

### ESG 나무 위젯 Lv.7~10
- Lv.7~10 SVG 신설 (Lv.6 무드 유지하면서 vertical 2배 확장)
- 동적 svgViewBox — Lv.1~6 는 기존 박스, Lv.7+ 는 길어진 박스로 자동 전환
- 점수 사이클: `MAX_LEVEL_POINTS=1,500,000` + `BONUS=500,000` = `FULL_TREE_POINTS=2,000,000`
- `treeCount = floor(totalPoints / 2,000,000)`, `cyclePoints = totalPoints % 2,000,000` 자동 계산
- Lv.10 도달 후 추가 500,000pt 획득 시 → 그루 카운터 +1 + Lv.1 부터 다시 시작
- "🌳 N그루의 나무를 키웠습니다!" 표시 + Lv.10 진행도 "🍎 결실 익는 중!" 문구
- DEV 미리보기 버튼 (prevStage / nextStage) 제거 — 실제 운영 화면 정리

<br><br>

## ✔️ 참고 사항
- SSE 검증: 로컬에서 탭 닫기/F5/다중 탭 모두 통과 — DevTools EventStream 의 `:ping` 8분 지속 확인
- 다중 탭 시나리오: 탭 2 닫아도 탭 1 SSE 유지 (sessionId 정밀 종료 작동 확인)
- BE PR (`feat/sse-explicit-unsubscribe`) 과 같이 배포되어야 sendBeacon 효과 발휘
- ESG 변경은 SSE 와 독립 — 단 PR 분리 안 하고 한 번에 처리 (브랜치 명은 ESG 작업명 그대로 유지)
- 점수 사이클 진입 시 자동 reset 동작은 `cyclePoints` computed 로 처리 — Pinia store 의 reactive 흐름 그대로

<br><br>

## ✔️ 관련 이슈

- Close #517 
- Related: BE `feat/sse-explicit-unsubscribe` PR

<br><br>
