### PR TITLE
fix(k8s): FE Probe timeoutSeconds 1초 → 5초 명시

### DIFF
--- a/CICD/k8s/front-deployment-blue.yml
+++ b/CICD/k8s/front-deployment-blue.yml
@@ -44,12 +44,16 @@ spec:
               port: 80
             initialDelaySeconds: 15
             periodSeconds: 10
+            timeoutSecond: 5
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /
               port: 80
             initialDelaySeconds: 10
             periodSeconds: 10
+            timeoutSecond: 5
+            failureThreshold: 3
       volumes:
         - name: nginx-config
           configMap:

--- a/CICD/k8s/front-deployment-green.yml
+++ b/CICD/k8s/front-deployment-green.yml
@@ -44,12 +44,16 @@ spec:
               port: 80
             initialDelaySeconds: 15
             periodSeconds: 10
+            timeoutSecond: 5
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /
               port: 80
             initialDelaySeconds: 10
             periodSeconds: 10
+            timeoutSecond: 5
+            failureThreshold: 3
       volumes:
         - name: nginx-config
           configMap:


### PR DESCRIPTION
## 📌 요약
- 부하 테스트 시 Grafana 의 "FE DOWN" 표시 해결
- FE Probe timeoutSeconds 미명시 → k8s 기본 1초 → 부하 시 nginx 응답 지연으로 Probe 실패
- yaml 에 timeoutSeconds: 5 명시하여 영구 반영

<br><br>

## 🎯 작업 내용
- `CICD/k8s/front-deployment-blue.yml`: livenessProbe / readinessProbe 에 `timeoutSeconds: 5` + `failureThreshold: 3` 명시
- `CICD/k8s/front-deployment-green.yml`: 동일

<br><br>

## ✔️ 참고 사항
- 진단: pod RESTARTS = 0 (죽지 않음), 평소 응답 136ms (정상), but 부하 시 Probe failed events 다수
- 원인: 부하 시 nginx 가 1MB+ JS chunk 처리하느라 응답 1초+ 지연 → 기본 timeoutSeconds: 1 초과
- 운영 대시보드에서 임시 적용 후 효과 검증됨 (부하 사이클 2회 다운 0회)
- 이 PR 로 영구 반영 — 다음 Jenkins 배포 시 sustained
- 자원 / replicas / 코드 변경 없음
- BE 의 추가 튜닝 (JVM heap, graceful shutdown) 은 별도 PR 로 검토 예정

<br><br>

## ✔️ 관련 이슈
- Close #521 
