### PR TITLE
release: develop → main 동기화 — FE Probe timeoutSeconds 1초 → 5초 명시

### DIFF
--- a/CICD/k8s/front-deployment-blue.yml
+++ b/CICD/k8s/front-deployment-blue.yml
@@ -44,12 +44,16 @@ spec:
               port: 80
             initialDelaySeconds: 15
             periodSeconds: 10
+            timeoutSecond: 5
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /
               port: 80
             initialDelaySeconds: 10
             periodSeconds: 10
+            timeoutSecond: 5
+            failureThreshold: 3
       volumes:
         - name: nginx-config
           configMap:

--- a/CICD/k8s/front-deployment-green.yml
+++ b/CICD/k8s/front-deployment-green.yml
@@ -44,12 +44,16 @@ spec:
               port: 80
             initialDelaySeconds: 15
             periodSeconds: 10
+            timeoutSecond: 5
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /
               port: 80
             initialDelaySeconds: 10
             periodSeconds: 10
+            timeoutSecond: 5
+            failureThreshold: 3
       volumes:
         - name: nginx-config
           configMap:


### PR DESCRIPTION
## 📌 요약
- develop 의 FE Probe timeoutSeconds 변경 (PR #522) 을 main(운영) 으로 반영
- 부하 테스트 시 Grafana "FE DOWN" 표시 현상 해결

<br><br>

## 🎯 작업 내용
- `CICD/k8s/front-deployment-blue.yml`: livenessProbe / readinessProbe 에 `timeoutSeconds: 5` 명시
- `CICD/k8s/front-deployment-green.yml`: 동일

<br><br>

## ✔️ 참고 사항

### 진단 결과
- pod RESTARTS = 0 (죽지 않음)
- 평소 응답 136ms (정상)
- 부하 시 Probe failed events 다수 발생
- 원인: yaml 에 timeoutSeconds 미명시 → k8s 기본 1초 적용 → 부하 시 nginx 가 1MB+ JS chunk 처리하느라 응답 1초+ 지연 → Probe 실패

### 검증
- 대시보드에서 임시 적용 후 부하 사이클 3회 모두 다운 0회 확인
- develop 머지 (PR #522) 완료
- 이 PR 로 main(운영) 영구 반영

### 안전성
- 자원 / replicas / 코드 변경 없음
- yaml 한 줄 추가 (timeoutSeconds: 5)
- pod RESTARTS = 0 유지 예상

<br><br>

## ✔️ 관련 이슈
