### PR TITLE
fix: k8s 오타 수정

### DIFF
--- a/CICD/k8s/front-deployment-blue.yml
+++ b/CICD/k8s/front-deployment-blue.yml
@@ -44,7 +44,7 @@ spec:
               port: 80
             initialDelaySeconds: 15
             periodSeconds: 10
-            timeoutSecond: 5
+            timeoutSeconds: 5
             failureThreshold: 3
           readinessProbe:
             httpGet:
@@ -52,7 +52,7 @@ spec:
               port: 80
             initialDelaySeconds: 10
             periodSeconds: 10
-            timeoutSecond: 5
+            timeoutSeconds: 5
             failureThreshold: 3
       volumes:
         - name: nginx-config

--- a/CICD/k8s/front-deployment-green.yml
+++ b/CICD/k8s/front-deployment-green.yml
@@ -44,7 +44,7 @@ spec:
               port: 80
             initialDelaySeconds: 15
             periodSeconds: 10
-            timeoutSecond: 5
+            timeoutSeconds: 5
             failureThreshold: 3
           readinessProbe:
             httpGet:
@@ -52,7 +52,7 @@ spec:
               port: 80
             initialDelaySeconds: 10
             periodSeconds: 10
-            timeoutSecond: 5
+            timeoutSeconds: 5
             failureThreshold: 3
       volumes:
         - name: nginx-config


### PR DESCRIPTION
## 📌 요약
- 직전 PR(#522, #523) 의 yaml 에 `timeoutSecond` (단수) 오타 발견
- k8s strict decoding error 로 Jenkins 배포 #74 실패
- 정확한 필드명 `timeoutSeconds` (복수) 로 수정하여 영구 반영

<br><br>

## 🎯 작업 내용
- `CICD/k8s/front-deployment-blue.yml`
  - `livenessProbe.timeoutSecond` → `timeoutSeconds: 5`
  - `readinessProbe.timeoutSecond` → `timeoutSeconds: 5`
- `CICD/k8s/front-deployment-green.yml`
  - `livenessProbe.timeoutSecond` → `timeoutSeconds: 5`
  - `readinessProbe.timeoutSecond` → `timeoutSeconds: 5`

<br><br>
## ✔️ 관련 이슈

- Close #524 

<br><br>