### PR TITLE
release: develop → main 동기화 — FE Probe timeoutSeconds 오타 수정 반영

### DIFF
--- a/CICD/k8s/front-deployment-blue.yml
+++ b/CICD/k8s/front-deployment-blue.yml
@@ -44,7 +44,7 @@ spec:
               port: 80
             initialDelaySeconds: 15
             periodSeconds: 10
-            timeoutSecond: 5
+            timeoutSeconds: 5
             failureThreshold: 3
           readinessProbe:
             httpGet:
@@ -52,7 +52,7 @@ spec:
               port: 80
             initialDelaySeconds: 10
             periodSeconds: 10
-            timeoutSecond: 5
+            timeoutSeconds: 5
             failureThreshold: 3
       volumes:
         - name: nginx-config

--- a/CICD/k8s/front-deployment-green.yml
+++ b/CICD/k8s/front-deployment-green.yml
@@ -44,7 +44,7 @@ spec:
               port: 80
             initialDelaySeconds: 15
             periodSeconds: 10
-            timeoutSecond: 5
+            timeoutSeconds: 5
             failureThreshold: 3
           readinessProbe:
             httpGet:
@@ -52,7 +52,7 @@ spec:
               port: 80
             initialDelaySeconds: 10
             periodSeconds: 10
-            timeoutSecond: 5
+            timeoutSeconds: 5
             failureThreshold: 3
       volumes:
         - name: nginx-config


### PR DESCRIPTION
## 📌 요약
- develop 의 hotfix (Probe 필드명 오타 수정) 을 main(운영) 으로 반영
- 직전 PR(#522, #523) 의 `timeoutSecond` (단수) 오타 → `timeoutSeconds` (복수) 로 수정 완료
- 이 PR 머지 후 Jenkins 자동 재배포 → 운영 영구 반영

<br><br>

## 🎯 작업 내용
- `CICD/k8s/front-deployment-blue.yml`
  - livenessProbe / readinessProbe `timeoutSeconds: 5` 정확히 명시
- `CICD/k8s/front-deployment-green.yml`
  - 동일

<br><br>

## ✔️ 참고 사항

### 원본 변경 의도
- 부하 테스트 시 nginx 가 1MB+ JS chunk 처리하느라 응답 1초+ 지연
- 기본 `timeoutSeconds: 1` 이 부족 → Probe 실패 → Grafana DOWN 마킹
- `timeoutSeconds: 5` 로 완화 (운영 대시보드에서 임시 적용 후 효과 검증됨)
- 부하 사이클 4회 다운 0회 확인


