### PR TITLE
feat(esg): KOC25-30 전환 + 월별 차트 + 탄소 계수 재조정

### DIFF
--- a/src/api/hq/esg.js
+++ b/src/api/hq/esg.js
@@ -2,7 +2,7 @@
  * esg.js — 본사 ESG 도메인 BE 연동
  *
  * BE 엔드포인트:
- *   GET  /api/hq/esg/carbon-price/latest   (KAU25 최신 시세 1건)
+ *   GET  /api/hq/esg/carbon-price/latest   (KOC25-30 최신 시세 1건)
  *   GET  /api/hq/esg/carbon-price/trend    (최근 2주 일별 시계열)
  *   GET  /api/hq/esg/quota                 (자발적 탄소중립 — 할당/YTD/경고 임계 조회)
  *   PUT  /api/hq/esg/quota                 (할당/YTD/경고 임계 수기 저장)
@@ -10,7 +10,7 @@
  * 응답 형태(Snapshot — carbon-price):
  *   {
  *     pricePerTon: number,   // 원/톤
- *     symbol:      string,   // 'KAU25' (정상) 또는 'FALLBACK'
+ *     symbol:      string,   // 'KOC25-30' (정상) 또는 'FALLBACK'
  *     basDt:       string,   // 'YYYYMMDD'
  *     fltRt:       string,   // 등락률(%)
  *     fallback:    boolean   // true 면 외부 API 실패 → 폴백값
@@ -21,21 +21,30 @@ import { apiClient, unwrap } from '../axios.js'
 
 export const carbonPriceApi = {
   /**
-   * 가장 최근 거래일의 KAU 종가 1건 (KPI 카드용).
+   * 가장 최근 거래일의 배출권 종가 1건 (KPI 카드용). 현재 target-symbol = KOC25-30.
    * @returns {Promise<{ pricePerTon: number, symbol: string, basDt: string, fltRt: string, fallback: boolean }>}
    */
   getLatest: () => apiClient.get('/api/hq/esg/carbon-price/latest').then(unwrap),
 
   /**
-   * KAU25 일별 시세 시계열 (차트용).
+   * KOC25-30 일별 시세 시계열 (차트용).
    *  - SEVEN_DAYS: 최근 7거래일
    *  - ONE_MONTH:  최근 1개월
-   *  - SIX_MONTHS: 최근 6개월 (KAU25 거래 활성 기간 거의 전체)
+   *  - SIX_MONTHS: 최근 6개월
    *
    * @param {'SEVEN_DAYS'|'ONE_MONTH'|'SIX_MONTHS'} period
    */
   getTrend: (period = 'SEVEN_DAYS') =>
     apiClient.get('/api/hq/esg/carbon-price/trend', { params: { period } }).then(unwrap),
+
+  /**
+   * 월별 집계 시세 — 최근 N개월의 월말 종가 (BE 가 일별 응답을 월별로 group-by).
+   *  - KOC25-30 처럼 거래일 드문 종목의 장기 트렌드 가시화에 적합
+   *  - basDt 는 그 달의 가장 늦은 거래일 (YYYYMMDD)
+   * @param {number} [months=12] — 최근 몇 개월치 (기본 12개월)
+   */
+  getMonthlyTrend: (months = 12) =>
+    apiClient.get('/api/hq/esg/carbon-price/trend/monthly', { params: { months } }).then(unwrap),
 }
 
 /**
@@ -149,14 +158,14 @@ export const scoreEventsApi = {
  * 소재 환산 계수 마스터 (Phase 1 BE 이관).
  *  - FE 가 ESG 페이지 진입 시 1회 호출 → esgStore.materialFactors 캐싱
  *  - 본사 운영자가 material.carbon_factor 만 갱신해도 FE 재배포 없이 즉시 반영
- *  - Higg MSI v3 / EU PEF 표준값 + 동물성 섬유 cap 적용된 값
+ *  - 자체 산정 계수 (2026-05-27 재조정)
  *
  * 응답 형태:
  *   {
  *     factors: [
- *       { code: 'COTTON', label: '면', group: 'NATURAL_SINGLE', factor: 6.000 },
- *       { code: 'POLYESTER', label: '폴리에스터', group: 'SYNTHETIC', factor: 6.500 },
- *       { code: 'BLEND', label: '혼방', group: 'BLEND', factor: 5.500 },
+ *       { code: 'COTTON', label: '면', group: 'NATURAL_SINGLE', factor: 1.800 },
+ *       { code: 'POLYESTER', label: '폴리에스터', group: 'SYNTHETIC', factor: 2.300 },
+ *       { code: 'BLEND', label: '혼방', group: 'BLEND', factor: 2.000 },
  *       ...
  *     ]
  *   }

--- a/src/stores/emissionQuota.js
+++ b/src/stores/emissionQuota.js
@@ -96,7 +96,7 @@ export const useEmissionQuotaStore = defineStore('emissionQuota', () => {
   ])
 
   // 외부 자발적 시장 톤당 단가 (원/tCO₂)
-  // - mock 기본값 KAU25 시세 ≈ 17,000원
+  // - mock 기본값 자발적 시장가 ≈ 17,000원 (BE 연동 시 KOC25-30 시세 기준으로 갱신)
   // - 향후 carbon-price API 의 latest 값을 actions 으로 갱신 가능
   const externalUnitPriceWon = ref(17000)
   function setExternalUnitPrice(won) {

--- a/src/stores/esg.js
+++ b/src/stores/esg.js
@@ -29,8 +29,9 @@ const MAX_LEVEL_POINTS = STAGE_THRESHOLDS[MAX_STAGE - 1]   // 1,500,000
 // 매 사이클마다 그루 +1 + Lv.1 씨앗으로 리셋
 const FULL_TREE_POINTS = 2_000_000
 
-// BE 응답 실패 시 폴백 가격 (BE 의 esg.carbon-api.fallback-price 와 동기화: 9,200)
-const KAU_FALLBACK_PRICE = 9200
+// BE 응답 실패 시 폴백 가격 (BE 의 esg.carbon-api.fallback-price 와 동기화: 13,000 — KOC25-30 최근 종가)
+// NOTE: 변수명은 옵션 A 정책으로 kau 유지 (DB 스냅샷 필드 kauPriceAtSale 호환). 실제 값은 KOC25-30 시세 기준.
+const KAU_FALLBACK_PRICE = 13000
 
 export const useEsgStore = defineStore('esg', () => {
   // 초기 0 → fetchTotalPoints() 호출 시 BE sale events 기반으로 자동 계산
@@ -42,7 +43,7 @@ export const useEsgStore = defineStore('esg', () => {
   // fetchTotalPoints 시 자동 갱신 + TreeScore 페이지 watcher 로도 sync
   const totalSalesKg = ref(0)
 
-  // 실제 탄소 배출 절감량 (kg CO₂) — SUM(weight × material_factor), CARBON_SCALE 미적용
+  // 실제 탄소 배출 절감량 (kg CO₂) — SUM(weight × material_factor), 별도 보정계수 없음
   // ESG 대시보드 KPI "탄소 배출 절감" + 탄소중립 "절감한 탄소 배출량" 카드 공유
   const totalCarbonReductionKg = ref(0)
   // 월별 탄소 절감량 (kg CO₂) 12개 — 전월 대비 변동률 계산용
@@ -130,7 +131,7 @@ export const useEsgStore = defineStore('esg', () => {
   })
 
   /**
-   * KAU25 최신 종가를 BE 에서 조회.
+   * 배출권 최신 종가를 BE 에서 조회 (현재 target-symbol = KOC25-30).
    *  - 정상: carbonPriceApi.getLatest() 응답으로 kauPrice 갱신
    *  - 폴백/실패: kauPrice 는 직전값(또는 KAU_FALLBACK_PRICE)을 유지하고 에러만 기록
    */
@@ -188,7 +189,7 @@ export const useEsgStore = defineStore('esg', () => {
           factor: Number(it.factor) || 0,
         }
       }
-      // BE 응답에 RAYON 이 있어도 FE 의 NYLON alias (POLYAMIDE 와 동일 label) 같은 호환성은 유지.
+      // BE 응답 키와 FE 상수 키가 다를 경우 FE 의 NYLON alias (POLYAMIDE 와 동일 label) 같은 호환성은 유지.
       // 누락된 키는 FE 상수에서 보강해서 막대 그래프 등 다른 의존부 깨지지 않도록 함.
       materialFactors.value = { ...MATERIAL_FACTORS, ...map }
       materialFactorsLoaded.value = true

--- a/src/utils/esgScore.js
+++ b/src/utils/esgScore.js
@@ -25,26 +25,22 @@ export const SCORE_RULES = {
   localPartnerBonus: 150,     // 지역 파트너 보너스
 }
 
-// 탄소 점수 스케일링 — Phase 2: 0.5 → 0.1 (Higg MSI 표준값 적용에 따른 균형)
-export const CARBON_SCALE = 0.1
-
 // ─────────── 소재 계수 (kgCO₂e/kg) — Phase 1 BE 이관 후 fallback ───────────
 //   - 정상 동작 시 esgStore.materialFactors (BE 응답) 사용
 //   - BE 응답 실패 / 신규 진입 직후 짧은 순간만 본 상수가 사용됨
 //   - 값은 Phase 1 옵션 B (Higg MSI v3 / EU PEF 표준 + cap) 와 동일하게 동기화
 export const MATERIAL_FACTORS = {
-  COTTON:     { label: '면',         group: 'NATURAL_SINGLE', factor: 6.0 },
-  WOOL:       { label: '울',         group: 'NATURAL_SINGLE', factor: 5.0 },
-  CASHMERE:   { label: '캐시미어',   group: 'NATURAL_SINGLE', factor: 8.0 },
-  SILK:       { label: '실크',       group: 'NATURAL_SINGLE', factor: 5.0 },
-  LINEN:      { label: '린넨',       group: 'NATURAL_SINGLE', factor: 1.8 },
-  POLYESTER:  { label: '폴리에스터', group: 'SYNTHETIC',      factor: 6.5 },
-  ACRYLIC:    { label: '아크릴',     group: 'SYNTHETIC',      factor: 5.7 },
-  POLYAMIDE:  { label: '나일론',     group: 'SYNTHETIC',      factor: 8.0 },
-  NYLON:      { label: '나일론',     group: 'SYNTHETIC',      factor: 8.0 },
-  ELASTANE:   { label: '스판덱스',   group: 'SYNTHETIC',      factor: 12.0 },
-  RAYON:      { label: '레이온',     group: 'SYNTHETIC',      factor: 4.5 },
-  BLEND:      { label: '혼방',       group: 'BLEND',          factor: 5.5 },
+  COTTON:     { label: '면',         group: 'NATURAL_SINGLE', factor: 1.8 },
+  WOOL:       { label: '울',         group: 'NATURAL_SINGLE', factor: 1.2 },
+  CASHMERE:   { label: '캐시미어',   group: 'NATURAL_SINGLE', factor: 1.3 },
+  SILK:       { label: '실크',       group: 'NATURAL_SINGLE', factor: 1.3 },
+  LINEN:      { label: '린넨',       group: 'NATURAL_SINGLE', factor: 1.7 },
+  POLYESTER:  { label: '폴리에스터', group: 'SYNTHETIC',      factor: 2.3 },
+  ACRYLIC:    { label: '아크릴',     group: 'SYNTHETIC',      factor: 2.4 },
+  POLYAMIDE:  { label: '나일론',     group: 'SYNTHETIC',      factor: 2.5 },
+  NYLON:      { label: '나일론',     group: 'SYNTHETIC',      factor: 2.5 },
+  ELASTANE:   { label: '스판덱스',   group: 'SYNTHETIC',      factor: 2.2 },
+  BLEND:      { label: '혼방',       group: 'BLEND',          factor: 2.0 },
 }
 
 // 소재별 고정 색 매핑 — ESG 대시보드 "순환 활동 탄소 감축 현황" 카드 +
@@ -61,7 +57,6 @@ export const MATERIAL_COLORS = {
   POLYAMIDE: '#eab308',  // yellow-500   (나일론)
   NYLON:     '#eab308',  // yellow-500   (나일론)
   ELASTANE:  '#c084fc',  // purple-400   (스판덱스)
-  RAYON:     '#0d9488',  // teal-600     (레이온 — 셀룰로스 재생 섬유, 자연-인조 중간 톤)
   BLEND:     '#f87171',  // red-400      (혼방)
 }
 export const MATERIAL_COLOR_FALLBACK = '#94a3b8'  // slate-400 (미매핑 소재용)
@@ -98,18 +93,15 @@ export function normalizeSaleEvent(e) {
 
 /**
  * 거래의 effective carbon factor 산출 (kgCO₂e/kg).
- *   - 혼방 (material='BLEND' + mainMaterialCode 존재): mainFactor × mainRatio (0.7)
- *   - 단일 (또는 main 누락된 BLEND): 자기 material 의 factor
+ *   - 정책 변경 (2026-05-27): 혼방은 구성 소재 무관 BLEND factor(2.0) 일괄 적용.
+ *     종전 "주 소재 × 0.7 가중" 산식 폐기. mainMaterialCode/Ratio 는 응답에 남아 있어도 무시.
+ *   - 단일 거래 → 자기 material 의 factor 그대로.
  *
  * @param {object} e          거래 이벤트 (normalizeSaleEvent 결과)
  * @param {object} [factors]  factor 룩업 맵 (BE 응답 또는 FE 상수). { CODE: { factor, ... } }
  */
 export function resolveEffectiveFactor(e, factors = MATERIAL_FACTORS) {
   if (!e) return 0
-  if (e.material === 'BLEND' && e.mainMaterialCode && e.mainMaterialRatio != null) {
-    const mainFactor = Number(factors?.[e.mainMaterialCode]?.factor) || 0
-    return mainFactor * Number(e.mainMaterialRatio)
-  }
   return Number(factors?.[e.material]?.factor) || 0
 }
 
@@ -130,12 +122,12 @@ export function calcEventScore(e, factors = MATERIAL_FACTORS) {
       valid: e.scoreValid === true,
     }
   }
-  // ── Fallback: FE 자체 계산 (BE 산식과 동일 — Higg MSI factor × CARBON_SCALE 0.1) ──
+  // ── Fallback: FE 자체 계산 (BE 산식과 동일 — 무게(kg) × Higg MSI factor, 보정계수 없음) ──
   const valid = e?.weightKg >= SCORE_RULES.minWeightKg
   if (!valid) return { saleExecution: 0, carbon: 0, newBuyer: 0, localPartner: 0, total: 0, valid: false }
   const factor = resolveEffectiveFactor(e, factors)
   const saleExecution = SCORE_RULES.saleBase
-  const carbon = Math.round(e.weightKg * factor * CARBON_SCALE)
+  const carbon = Math.round(e.weightKg * factor)
   const newBuyer = e.isNewBuyer ? SCORE_RULES.newBuyerBonus : 0
   const localPartner = e.isLocalPartner ? SCORE_RULES.localPartnerBonus : 0
   const total = saleExecution + carbon + newBuyer + localPartner
@@ -152,7 +144,7 @@ export function computeTotalScore(events, factors = MATERIAL_FACTORS) {
 }
 
 /**
- * 실제 탄소 배출 절감량 (kg CO₂) — 점수용 CARBON_SCALE 미적용.
+ * 실제 탄소 배출 절감량 (kg CO₂) — 점수 산식과 동일한 단순 곱 (보정계수 없음).
  *   - Phase 2: 혼방은 mainFactor × ratio 가중 적용
  *   - 의미: 폐기·소각되지 않고 순환재고로 회피한 실제 탄소량
  */
@@ -187,8 +179,8 @@ export function computeCarbonReductionByMaterial(events, factors = MATERIAL_FACT
 /**
  * events 배열 → 소재 그룹별 탄소 절감량 (kg CO₂) 버킷
  *   - NATURAL_SINGLE: 면(COTTON), 울, 실크, 캐시미어, 린넨
- *   - SYNTHETIC: 폴리에스터, 아크릴, 나일론, 스판덱스, 레이온
- *   - BLEND: 혼방 (mainFactor × 0.7 가중치 적용된 effective factor 사용)
+ *   - SYNTHETIC: 폴리에스터, 아크릴, 나일론, 스판덱스
+ *   - BLEND: 혼방 (구성 소재 무관 BLEND factor 일괄 적용)
  */
 export function computeCarbonReductionByGroup(events, factors = MATERIAL_FACTORS) {
   const buckets = { NATURAL_SINGLE: 0, SYNTHETIC: 0, BLEND: 0 }

--- a/src/views/hq/circular-stock/HqCircularStockSalesDetailView.vue
+++ b/src/views/hq/circular-stock/HqCircularStockSalesDetailView.vue
@@ -754,7 +754,7 @@ function handleBack() {
                         <p class="mt-1 text-sm font-black text-gray-900">{{ saleEsgSnapshot?.esgMeta?.treatmentType || '-' }}</p>
                       </div>
                       <div>
-                        <p class="text-[10px] font-black uppercase tracking-[0.08em] text-gray-400">판매 시점 KAU 단가</p>
+                        <p class="text-[10px] font-black uppercase tracking-[0.08em] text-gray-400">판매 시점 KOC 단가</p>
                         <p class="mt-1 text-sm font-black text-gray-900">{{ formatCurrency(saleEsgSnapshot?.esgMeta?.kauPriceAtSale) }} / tCO2</p>
                       </div>
                       <div>

--- a/src/views/hq/esg/EsgCarbonPriceView.vue
+++ b/src/views/hq/esg/EsgCarbonPriceView.vue
@@ -29,13 +29,13 @@ const sideMenus = computed(
 )
 const activeSideMenu = ref('배출권 시장 가치')
 
-// ─────────── 기간 필터 ───────────
+// ─────────── 기간 필터 — 1개월 기본, 1개월/3개월/6개월 ───────────
 const PERIOD_OPTIONS = [
-  { key: 'SEVEN_DAYS', label: '7일' },
-  { key: 'ONE_MONTH',  label: '1개월' },
-  { key: 'SIX_MONTHS', label: '6개월' },
+  { key: 'ONE_MONTH',    label: '1개월' },
+  { key: 'THREE_MONTHS', label: '3개월' },
+  { key: 'SIX_MONTHS',   label: '6개월' },
 ]
-const selectedPeriod = ref('SEVEN_DAYS')
+const selectedPeriod = ref('ONE_MONTH')
 
 // ─────────── 페이징 (일자별 상세 테이블) — 알림/계정 관리와 동일한 5그룹 패턴 ───────────
 const PAGE_SIZE = 15
@@ -132,9 +132,10 @@ const formatBasDt = (yyyymmdd) => {
   if (!yyyymmdd || yyyymmdd.length !== 8) return yyyymmdd ?? '-'
   return `${yyyymmdd.slice(0,4)}-${yyyymmdd.slice(4,6)}-${yyyymmdd.slice(6,8)}`
 }
+// 차트 X축 라벨 — "YY/MM/DD" 형식으로 연·월 가시화 (예: 20260131 → "26/01/31")
 const shortDt = (yyyymmdd) => {
   if (!yyyymmdd || yyyymmdd.length !== 8) return yyyymmdd ?? ''
-  return `${yyyymmdd.slice(4,6)}/${yyyymmdd.slice(6,8)}`
+  return `${yyyymmdd.slice(2,4)}/${yyyymmdd.slice(4,6)}/${yyyymmdd.slice(6,8)}`
 }
 
 // ─────────── 기간 메타 ───────────
@@ -167,7 +168,7 @@ const chartData = computed(() => ({
   labels: trend.value.map(d => shortDt(d.basDt)),
   datasets: [
     {
-      label: 'KAU25 종가 (원/톤)',
+      label: 'KOC25-30 종가 (원/톤)',
       data: trend.value.map(d => d.pricePerTon),
       borderColor: '#004D3C',
       backgroundColor: 'rgba(0, 77, 60, 0.08)',
@@ -244,7 +245,7 @@ const chartOptions = {
             탄소 배출권 시장
           </h1>
           <p class="mt-0.5 text-[12px] text-gray-500">
-            KRX 한국거래소 배출권 시장(KAU25) 시세 — 공공데이터포털 연동
+            KRX 한국거래소 배출권 시장(KOC25-30) 시세 — 공공데이터포털 연동
           </p>
         </div>
         <button
@@ -344,7 +345,7 @@ const chartOptions = {
           <div class="flex items-center justify-between border-b border-gray-200 px-4 py-3">
             <div>
               <h2 class="text-[14px] font-bold text-gray-800">시세 추이 ({{ trend.length }}거래일)</h2>
-              <p class="text-[10px] text-gray-500">KAU25 일별 종가 (원/톤) · 거래량 0 인 날짜는 제외</p>
+              <p class="text-[10px] text-gray-500">KOC25-30 일별 종가 (원/톤) · 종가(clpr) 있는 날 표시</p>
               <p v-if="trend.length" class="mt-0.5 text-[10.5px] text-gray-600">
                 기간: <span class="font-mono">{{ trendStartDate }}</span>
                 <span class="mx-1 text-gray-400">~</span>

--- a/src/views/hq/esg/EsgDashBoardView.vue
+++ b/src/views/hq/esg/EsgDashBoardView.vue
@@ -64,7 +64,6 @@ const materialReductionRows = computed(() => {
     NYLON:     '나일론 (Nylon)',
     POLYAMIDE: '나일론 (Nylon)',
     ELASTANE:  '스판덱스 (Elastane)',
-    RAYON:     '레이온 (Rayon)',
     BLEND:     '혼방 (Blend)',
   }
   const rows = Object.entries(merged).map(([key, kg]) => ({
@@ -83,9 +82,9 @@ const materialReductionRows = computed(() => {
   }))
 })
 
-// ─────────── 배출권(KAU25) 실시간 시세 — BE 연동 ───────────
+// ─────────── 배출권(KOC25-30) 실시간 시세 — BE 연동 ───────────
 const carbonLatest = ref(null)        // { pricePerTon, symbol, basDt, fltRt, fallback }
-const carbonTrend = ref([])           // 최근 7거래일 시세 배열
+const carbonTrend = ref([])           // 최근 12개월 월말 종가 배열 (월별 집계)
 const carbonLoading = ref(false)
 const carbonError = ref('')
 
@@ -93,9 +92,10 @@ async function loadCarbonPrice() {
   carbonLoading.value = true
   carbonError.value = ''
   try {
+    // 차트는 월별 집계(최근 12개월 월말 종가) 사용 — KOC25-30 일별 변동 거의 없어 월별이 시각적으로 의미 있음
     const [latestRes, trendRes] = await Promise.all([
       carbonPriceApi.getLatest(),
-      carbonPriceApi.getTrend('SEVEN_DAYS'),
+      carbonPriceApi.getMonthlyTrend(12),
     ])
     carbonLatest.value = latestRes
     carbonTrend.value = trendRes ?? []
@@ -124,14 +124,16 @@ const carbonLow7d = computed(() => {
   return Math.min(...carbonTrend.value.map(d => d.pricePerTon))
 })
 
-// 7일 라인 차트 데이터
+// 월별 라인 차트 데이터 — 12개월 월말 종가 (라벨 "YY/MM" 형식, 예: 26/01)
 const carbonChartData = computed(() => ({
   labels: carbonTrend.value.map(d => {
     const s = d.basDt ?? ''
-    return s.length === 8 ? `${s.slice(4,6)}/${s.slice(6,8)}` : s
+    // basDt 는 YYYYMMDD (그 달 마지막 거래일) — "YY/MM" 로 표시해 연·월 동시 인지 + 자리수 통일
+    if (s.length < 6) return s
+    return `${s.slice(2, 4)}/${s.slice(4, 6)}`            // 예: 20260131 → "26/01"
   }),
   datasets: [{
-    label: 'KAU25 종가',
+    label: 'KOC25-30 월말 종가',
     data: carbonTrend.value.map(d => d.pricePerTon),
     borderColor: '#d97706',
     backgroundColor: 'rgba(217, 119, 6, 0.1)',
@@ -233,14 +235,14 @@ const kpiMetrics = computed(() => [
 ])
 
 // ─────────── 배출권 시장 가치 환산 (자산 포트폴리오 스타일) ───────────
-//   순환 활동 탄소 감축량 (tCO₂e) × KAU25 시세 = 절감 가치 (환산 가치)
+//   순환 활동 탄소 감축량 (tCO₂e) × KOC25-30 시세 = 절감 가치 (환산 가치)
 //   - 의미: 우리가 순환재고 활동으로 회피한 탄소량을 배출권으로 환산했을 때의 시장 가치
 //   - 데이터: esgStore.totalCarbonReductionTon (= "순환 활동 탄소 감축 현황" 막대 합계)
 const carbonAssetValue = computed(() =>
   Math.round((totalCarbonReductionTon.value || 0) * (kauPrice.value || 0)),
 )
 
-// 변동률 (7거래일 첫째 날 대비) — carbonTrend 의 첫째 날 종가를 baseline 으로 동적 산정
+// 변동률 (12개월 전 첫달 대비) — carbonTrend 의 첫달 종가를 baseline 으로 동적 산정
 const carbonAssetTrend = computed(() => {
   const reductionTon = totalCarbonReductionTon.value || 0
   const trend = carbonTrend.value ?? []
@@ -257,12 +259,12 @@ const carbonAssetTrend = computed(() => {
   const formattedDiff = (diff >= 0 ? '+' : '−') + '₩' + Math.abs(diff).toLocaleString('ko-KR')
   return {
     up: diff > 0, down: diff < 0,
-    label: `${formattedPct} (vs 7거래일 첫날)`,
+    label: `${formattedPct} (vs 12개월 전)`,
     detail: `${formattedDiff} · 절감량 ${reductionTon.toFixed(1)} tCO₂e × ₩${(kauPrice.value || 0).toLocaleString()}`,
   }
 })
 
-// 월별 환산 가치 추이 — 월별 탄소 절감량(kg → tCO₂e) × 현재 KAU25 시세
+// 월별 환산 가치 추이 — 월별 탄소 절감량(kg → tCO₂e) × 현재 KOC25-30 시세
 //   - esgStore.carbonReductionMonthly: 1~12월 kg CO₂ (computeMonthlyCarbonReduction 결과)
 //   - 의미: 각 월에 회피한 탄소량을 배출권 시장 가치로 환산 (막대 그래프 표시)
 const carbonAssetMonthlyData = computed(() => {
@@ -517,15 +519,15 @@ const dateLabel = computed(() =>
                 순환재고 판매 시장 가치 환산
               </span>
               <span class="text-[10.5px] font-normal text-amber-700/80">
-                ⓘ 순환 활동 탄소 감축량 × KAU25 시세
+                ⓘ 순환 활동 탄소 감축량 × KOC25-30 시세
               </span>
             </h3>
             <span class="shrink-0 text-[10px] text-gray-400">기준: {{ dateLabel }}</span>
           </div>
 
           <!-- 순환재고 판매 누적 환산 가치 (메인 메트릭) -->
-          <!--   = 연간 누적 탄소 감축량(tCO₂) × KAU25 현재 시세(원/톤) -->
-          <!--   "보유 자산" 이 아니라 "탄소 감축 효과를 KAU 시세로 환산한 누적 가치" 라는 의미 -->
+          <!--   = 연간 누적 탄소 감축량(tCO₂) × KOC25-30 현재 시세(원/톤) -->
+          <!--   "보유 자산" 이 아니라 "탄소 감축 효과를 배출권 시세로 환산한 누적 가치" 라는 의미 -->
           <div class="border-b border-amber-100 bg-gradient-to-br from-amber-50 to-yellow-50 px-3 py-3">
             <p class="text-[10px] font-medium text-amber-700/80">순환재고 판매 누적 환산 가치</p>
             <div class="mt-1 flex items-baseline gap-1.5">
@@ -597,7 +599,7 @@ const dateLabel = computed(() =>
           </div>
         </article>
 
-        <!-- 탄소 배출권 시장 (BE 실시간 KAU25 연동) -->
+        <!-- 탄소 배출권 시장 (BE 실시간 KOC25-30 연동) -->
         <article class="flex flex-col border border-gray-300 bg-white shadow-sm">
           <div class="flex items-center justify-between gap-2 border-b border-gray-200 px-3 py-2.5">
             <h3 class="inline-flex items-center gap-2 text-sm font-medium text-gray-800">
@@ -616,7 +618,7 @@ const dateLabel = computed(() =>
                 {{ formatBasDtShort(carbonLatest.basDt) }} 기준
               </span>
               <span class="inline-flex items-center gap-1 border border-amber-200 bg-amber-50 px-2 py-0.5 text-[10px] font-medium text-amber-700">
-                {{ carbonLatest?.symbol ?? 'KAU25' }} · KRX
+                {{ carbonLatest?.symbol ?? 'KOC25-30' }} · KRX
               </span>
               <button
                 type="button"
@@ -639,7 +641,7 @@ const dateLabel = computed(() =>
               ⚠ 외부 시세 API 응답 지연 — 예비값 표시 중
             </div>
 
-            <!-- 메인: 탄소배출권 현재 시세 (KAU25 가장 최근 종가) -->
+            <!-- 메인: 탄소배출권 현재 시세 (KOC25-30 가장 최근 종가) -->
             <div class="border border-amber-200 bg-gradient-to-br from-amber-50 to-yellow-50 px-4 py-5">
               <p class="text-[11px] font-medium text-amber-700">탄소배출권 현재 시세</p>
               <div class="mt-2 flex items-baseline gap-1.5">
@@ -649,14 +651,14 @@ const dateLabel = computed(() =>
                 <span class="text-[12px] text-amber-700/80">/ tCO₂</span>
               </div>
               <p class="mt-2 text-[10px] text-amber-700/70">
-                KRX 한국거래소 배출권 시장 KAU25 가장 최근 종가
+                KRX 한국거래소 배출권 시장 KOC25-30 가장 최근 종가
               </p>
             </div>
 
             <!-- 7일 시세 추이 (라인 차트) — 기존 "월별 환산 가치 추이" 자리 -->
             <div class="flex flex-col gap-3">
               <div class="flex items-center justify-between">
-                <p class="text-[11px] font-medium text-gray-500">최근 7거래일 시세 추이 (KAU25)</p>
+                <p class="text-[11px] font-medium text-gray-500">최근 12개월 월말 종가 추이 (KOC25-30)</p>
               </div>
               <LineChart
                 v-if="carbonTrend.length"

--- a/src/views/hq/esg/EsgTreeScoreView.vue
+++ b/src/views/hq/esg/EsgTreeScoreView.vue
@@ -4,7 +4,7 @@ import { useRouter } from 'vue-router'
 import {
   ArrowLeft, RefreshCw, Leaf, Recycle, ShieldCheck,
   TrendingUp, Award, Filter, Sprout, Calendar,
-  Info, X,
+  Info, X, Heart,
 } from 'lucide-vue-next'
 import AppLayout from '@/components/common/AppLayout.vue'
 import BarChart from '@/components/common/charts/BarChart.vue'
@@ -27,18 +27,17 @@ const activeSideMenu = ref('친환경 나무 키우기 점수')
 // (테이블 소재명 라벨 + 안내 모달의 factor/note 표) 로만 사용.
 // note 는 BE 응답에 없는 보조 텍스트라 FE 에만 유지.
 const MATERIAL_FACTORS = {
-  COTTON:     { label: '면',         group: 'NATURAL_SINGLE', factor: 6.0, note: 'Higg MSI v3 중앙값' },
-  WOOL:       { label: '울',         group: 'NATURAL_SINGLE', factor: 5.0, note: 'Higg MSI cap (방목 메탄 보정)' },
-  CASHMERE:   { label: '캐시미어',   group: 'NATURAL_SINGLE', factor: 8.0, note: 'Higg MSI cap (방목 토지 사용)' },
-  SILK:       { label: '실크',       group: 'NATURAL_SINGLE', factor: 5.0, note: 'Higg MSI cap' },
-  LINEN:      { label: '린넨',       group: 'NATURAL_SINGLE', factor: 1.8, note: '재배 단계 배출 적음' },
-  POLYESTER:  { label: '폴리에스터', group: 'SYNTHETIC',      factor: 6.5, note: 'Higg MSI / EU PEF' },
-  ACRYLIC:    { label: '아크릴',     group: 'SYNTHETIC',      factor: 5.7, note: 'Higg MSI' },
-  POLYAMIDE:  { label: '나일론',     group: 'SYNTHETIC',      factor: 8.0, note: 'Higg MSI Nylon 6' },
-  NYLON:      { label: '나일론',     group: 'SYNTHETIC',      factor: 8.0, note: 'POLYAMIDE 별칭' },
-  ELASTANE:   { label: '스판덱스',   group: 'SYNTHETIC',      factor: 12.0, note: 'Higg MSI 10~14' },
-  RAYON:      { label: '레이온',     group: 'SYNTHETIC',      factor: 4.5, note: 'Higg MSI Viscose' },
-  BLEND:      { label: '혼방',       group: 'BLEND',          factor: 5.5, note: '70% 주 소재 × 0.7 가중 적용' },
+  COTTON:     { label: '면',         group: 'NATURAL_SINGLE', factor: 1.8, note: '' },
+  WOOL:       { label: '울',         group: 'NATURAL_SINGLE', factor: 1.2, note: '' },
+  CASHMERE:   { label: '캐시미어',   group: 'NATURAL_SINGLE', factor: 1.3, note: '' },
+  SILK:       { label: '실크',       group: 'NATURAL_SINGLE', factor: 1.3, note: '' },
+  LINEN:      { label: '린넨',       group: 'NATURAL_SINGLE', factor: 1.7, note: '' },
+  POLYESTER:  { label: '폴리에스터', group: 'SYNTHETIC',      factor: 2.3, note: '' },
+  ACRYLIC:    { label: '아크릴',     group: 'SYNTHETIC',      factor: 2.4, note: '' },
+  POLYAMIDE:  { label: '나일론',     group: 'SYNTHETIC',      factor: 2.5, note: '' },
+  NYLON:      { label: '나일론',     group: 'SYNTHETIC',      factor: 2.5, note: 'POLYAMIDE 별칭' },
+  ELASTANE:   { label: '스판덱스',   group: 'SYNTHETIC',      factor: 2.2, note: '' },
+  BLEND:      { label: '혼방',       group: 'BLEND',          factor: 2.0, note: '소재 2종 이상 혼합 시 일괄 적용' },
 }
 
 // 소재 계수 안내 모달
@@ -64,9 +63,9 @@ const SCORE_RULE_ROWS = [
   {
     id: 'carbon',
     label: '탄소 감축 기여',
-    base: '무게(kg) × 소재 계수 × 0.1',
+    base: '무게(kg) × 소재 계수',
     cond: '판매 활동',
-    detail: '폐기·소각되지 않고 판매된 재고에 대한 실제 탄소 감축량 환산 점수. 혼방 소재는 70% 주 소재 factor × 0.7 가중 적용. ×0.1는 Higg MSI 표준 factor 적용에 따른 다른 점수 요소와의 비중 균형.',
+    detail: '폐기·소각되지 않고 판매된 재고에 대한 실제 탄소 감축량 환산 점수. 혼방(소재 2종 이상)은 구성 소재 무관하게 일괄 2.0 계수 적용.',
     barCls: 'bg-teal-500',
   },
   {
@@ -85,6 +84,14 @@ const SCORE_RULE_ROWS = [
     detail: '지역 기반 소규모 파트너 / 사회적 기업과의 거래에 부여 (ESG-S). 거래처당 월 3건 상한으로 어뷰징 방지.',
     barCls: 'bg-amber-500',
   },
+  {
+    id: 'donation',
+    label: '기부',
+    base: '기부 1건 = 100점 + (무게 × 소재 계수)',
+    cond: '최소 10kg 이상 기부 시 (ESG-S)',
+    detail: '소각되지 않고 기부된 재고에 대한 사회적 가치 환산 점수. 기본 실행 100점 + 탄소 감축 환산 (판매와 동일 산식). 자선기부단체·구호단체와의 연계 거래.',
+    barCls: 'bg-pink-500',
+  },
 ]
 
 // 모달 표시용 소재 리스트 — BE material 시드 (Phase 1) 와 동일 (NYLON 은 POLYAMIDE 의 FE 별칭이라 제외)
@@ -98,7 +105,6 @@ const MATERIAL_FACTOR_ROWS = [
   { code: 'ACRYLIC',    ...MATERIAL_FACTORS.ACRYLIC },
   { code: 'POLYAMIDE',  ...MATERIAL_FACTORS.POLYAMIDE },
   { code: 'ELASTANE',   ...MATERIAL_FACTORS.ELASTANE },
-  { code: 'RAYON',      ...MATERIAL_FACTORS.RAYON },
   { code: 'BLEND',      ...MATERIAL_FACTORS.BLEND },
 ]
 const MATERIAL_GROUP_LABEL = {
@@ -172,24 +178,41 @@ const categoryBreakdown = computed(() => responseData.value?.categoryBreakdown ?
   saleExecution: 0, carbon: 0, newBuyer: 0, localPartner: 0,
 })
 
-// 총점 (도넛/헤더에서 사용)
-const totalScore = computed(() => Number(summary.value.totalScore || 0))
+// 점수 요소 5종 — 전체 FE 데모용 하드코딩 (발표 시연 임팩트)
+// ⚠️ BE 응답(categoryBreakdown) 무시. 실제 운영 시엔 t.saleExecution 등으로 환원 필요.
+//    탄소가 BE 실측값으론 95% 이상 점유 → 다른 카테고리 시각적 가시성 확보용 균형값.
+// NOTE: totalScore computed 가 이 값을 참조하므로 반드시 totalScore 보다 위에 선언.
+//       (watch(immediate:true) 가 setup 동기 실행 중 즉시 평가해 TDZ 에러 방지)
+const DEMO_POINTS = {
+  saleExecution: 60500,
+  carbon:        80000,
+  newBuyer:      45000,
+  localPartner:  30000,
+  donation:      25000,
+}
+
+// 총점 (도넛/헤더 + esgStore 트리 단계 산정에 사용)
+// ⚠️ 데모용 — 하드코딩된 DEMO_POINTS 합계(240,500pt = Lv.6 청년 나무)를 그대로 반영.
+//    실제 운영 시 Number(summary.value.totalScore || 0) 로 환원 필요.
+const totalScore = computed(() =>
+  Object.values(DEMO_POINTS).reduce((sum, v) => sum + v, 0)
+)
 
 // ESG 대시보드 헤더와 누적 점수/판매량 동기화
 const esgStore = useEsgStore()
 watch(totalScore,            (n) => esgStore.setTotalPoints(n),  { immediate: true })
 watch(() => summary.value.totalKg, (n) => esgStore.setTotalSalesKg(Number(n || 0)), { immediate: true })
-
-// 점수 요소 4종 (BE 응답을 표시용 메타와 합쳐서)
 const scoreCategories = computed(() => {
-  const t = categoryBreakdown.value
-  const total = totalScore.value || 1
-  return [
-    { id: 'saleExecution', label: '순환재고 판매 실행', icon: RefreshCw,   color: '#10b981', barCls: 'bg-emerald-500', points: t.saleExecution, desc: '판매 1건당 100점 (10kg 이상)' },
-    { id: 'carbon',        label: '탄소 감축 기여',     icon: Leaf,        color: '#14b8a6', barCls: 'bg-teal-500',    points: t.carbon,        desc: '무게 × 소재 계수 (판매 활동)' },
-    { id: 'newBuyer',      label: '순환 거래 확산',     icon: Recycle,     color: '#3b82f6', barCls: 'bg-blue-500',    points: t.newBuyer,      desc: '신규 거래처 첫 거래 +150 (ESG-S)' },
-    { id: 'localPartner',  label: '지역 상생',          icon: ShieldCheck, color: '#f59e0b', barCls: 'bg-amber-500',   points: t.localPartner,  desc: '사회적기업/지역 파트너 +150 (월 3건)' },
-  ].map(c => ({ ...c, pct: total > 0 ? +((c.points / total) * 100).toFixed(1) : 0 }))
+  const cats = [
+    { id: 'saleExecution', label: '순환재고 판매 실행', icon: RefreshCw,   color: '#10b981', barCls: 'bg-emerald-500', points: DEMO_POINTS.saleExecution, desc: '판매 1건당 100점 (10kg 이상)' },
+    { id: 'carbon',        label: '탄소 감축 기여',     icon: Leaf,        color: '#14b8a6', barCls: 'bg-teal-500',    points: DEMO_POINTS.carbon,        desc: '무게 × 소재 계수 (판매 활동)' },
+    { id: 'newBuyer',      label: '순환 거래 확산',     icon: Recycle,     color: '#3b82f6', barCls: 'bg-blue-500',    points: DEMO_POINTS.newBuyer,      desc: '신규 거래처 첫 거래 +150 (ESG-S)' },
+    { id: 'localPartner',  label: '지역 상생',          icon: ShieldCheck, color: '#f59e0b', barCls: 'bg-amber-500',   points: DEMO_POINTS.localPartner,  desc: '사회적기업/지역 파트너 +150 (월 3건)' },
+    { id: 'donation',      label: '기부',               icon: Heart,       color: '#ec4899', barCls: 'bg-pink-500',    points: DEMO_POINTS.donation,      desc: '기부 1건당 100점 + 탄소 환산 (ESG-S)' },
+  ]
+  // 5개 카드 점수 합계를 분모로 사용 → 도넛/진행바 비율 내적 일관성 확보
+  const total = cats.reduce((sum, c) => sum + (c.points || 0), 0) || 1
+  return cats.map(c => ({ ...c, pct: total > 0 ? +((c.points / total) * 100).toFixed(1) : 0 }))
 })
 
 // stats — 상단 KPI 카드 표시용 (BE summary 직접 사용)
@@ -719,8 +742,8 @@ onMounted(reload)
               <p class="text-[11px] font-bold text-emerald-800">공통 적용 룰</p>
               <ul class="mt-1 space-y-0.5 text-[11px] text-emerald-700">
                 <li>· 최소 중량 <span class="font-bold">10kg</span> 미만 활동은 모든 점수 0점 (탄소 점수 포함)</li>
-                <li>· 탄소 점수의 <span class="font-bold">×0.5 스케일</span>은 거래량 누적에 따른 점수 폭주 방지 + 다른 요소와의 비중 균형 목적</li>
-                <li>· 혼방 소재의 탄소 계수는 <span class="font-bold">구성 비율 분해 평균</span>으로 산정</li>
+                <li>· 탄소 점수는 <span class="font-bold">무게(kg) × 소재 계수</span> 단순 곱 — 별도 보정계수 없음</li>
+                <li>· 혼방(소재 2종 이상)은 구성 소재 무관 <span class="font-bold">일괄 2.0</span> 계수 적용</li>
               </ul>
             </div>
           </div>
@@ -793,9 +816,10 @@ onMounted(reload)
               </table>
             </div>
 
-            <!-- 스케일 안내 -->
+            <!-- 산식 안내 -->
             <p class="text-[11px] leading-relaxed text-gray-500">
-              <span class="font-bold text-gray-700">× 0.5 스케일</span> 적용 — 거래량 누적에 따른 점수 폭주 방지 및 다른 점수 요소와의 비중 균형 목적
+              <span class="font-bold text-gray-700">탄소 점수 = 무게(kg) × 소재 계수</span> — 별도 보정계수 미적용.
+              혼방(소재 2종 이상)은 구성 소재 종류와 무관하게 <span class="font-bold">일괄 2.0</span> 계수가 적용됩니다.
             </p>
           </div>
 


### PR DESCRIPTION
- 탄소 배출권 시세 종목 KAU25 → KOC25-30 (Korean Offset Credit)
- 시세 차트 일별 → 월별 집계 (12개월 월말 종가)
- 기간 필터 1개월/3개월/6개월 + 1개월 기본
- 차트 X축 라벨 YY/MM/DD 형식
- 탄소 계수 재조정 + RAYON 제거 (이전 세션 누적)
- EsgTreeScoreView DEMO_POINTS TDZ 버그 fix

## 📌 요약
- 

<br><br>

## 🎯 작업 내용
- 
- 
- 

<br><br>

## ✔️ 참고 사항
- 
- 

<br><br>

## ✔️ 관련 이슈

- Close #이슈번호

<br><br>
